### PR TITLE
Subproperties for defined by

### DIFF
--- a/ontohgis.ttl
+++ b/ontohgis.ttl
@@ -19522,8 +19522,6 @@ ontohgis:settlement_type_76 rdfs:comment "In BDTO10k a tourist shelter is distin
 
 ontohgis:settlement_type_8 rdfs:comment "A demesne (manor) may be considered as an independent locality as long as it is distinguished by an individual name. Usually, a demesne was located away from the main group of houses in a village, on the outskirts, or in its vicinity."@en ,
                                         "Folwark może być traktowany jako odrębna miejscowość, o ile posiadał własną nazwę. Zazwyczaj folwark położony był poza główną zabudową wsi, na jej obrzeżach lub w nieznacznym oddaleniu."@pl ;
-                           rdfs:isDefinedBy "A demesne (en: manor, pl: folwark, de: Volwerk) is a locality with an industrial function, often located near the manor (a building) or separate."@en ,
-                                            "Folwark (niem: Volwerk) to miejscowość o charakterze gospodarczym, często funkcjonująca obok dworu lub osobno."@pl ;
                            rdfs:label "demesne"@en ,
                                       "folwark"@pl ;
                            rdfs:seeAlso <http://dbpedia.org/page/Demesne> ,
@@ -19553,42 +19551,42 @@ ontohgis:settlement_type_8 rdfs:comment "A demesne (manor) may be considered as 
                            ontohgis:hasExternalIdentifier "8" ;
                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                           ontohgis:hasTranslator ontohgis:person_9 .
+                           ontohgis:hasTranslator ontohgis:person_9 ;
+                           ontohgis:isDefinedByLiteral "A demesne (en: manor, pl: folwark, de: Volwerk) is a locality with an industrial function, often located near the manor (a building) or separate."^^rdfs:Literal ,
+                                                       "Folwark (niem: Volwerk) to miejscowość o charakterze gospodarczym, często funkcjonująca obok dworu lub osobno."^^rdfs:Literal .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_8 ;
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "duże gospodarstwo rolne wraz z zabudowaniami."@pl ;
-   rdfs:isDefinedBy ontohgis:document_4 ,
-                    <https://sjp.pwn.pl/doroszewski/folwark;5428273.html>
+   ontohgis:isDefinedByIRI ontohgis:document_4 ,
+                           <https://sjp.pwn.pl/doroszewski/folwark;5428273.html>
  ] .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_8 ;
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "t. 1, s. 173: duże gospodarstwo rolne lub rolno-hodowlane, produkujące głównie na zbyt, posługujące się pracą chłopów pańszczyźnianych albo siłą najemną. Organizowane przez feudalnych właścicieli ziemskich już w XIV w., stanowiły kontynuację tzw. rezerwy pańskiej, czyli gruntów wyłączonych spod uprawy chłopskiej i przeznaczonych do zaspokajania bezpośrednich potrzeb dworu--’"@pl ;
-   rdfs:isDefinedBy ontohgis:document_17
+   ontohgis:isDefinedByIRI ontohgis:document_17
  ] .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_8 ;
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "t. 1, s. 759: 1. mała wioska, leżąca obok dużej, oddzielona część wsi; przysiółek; 2. majętność, grunt z zabudowaniem, ferma; 3. dwór we wsi, mieszkanie dziedzica albo dzierżawcy razem z zabudowaniami dworskimi."@pl ;
-   rdfs:isDefinedBy ontohgis:document_5
+   ontohgis:isDefinedByIRI ontohgis:document_5
  ] .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_8 ;
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "t. 7, s. 90–91: 1. ziemskie gospodarstwo, w przeciwieństwie do gospodarstwa chłopskiego, grunt z zabudowaniami gospodarskimi i mieszkalnymi, często będący częścią większej majętności; zazwyczaj wydzielona część wsi; 2. zabudowania gospodarcze; 3. ziemia orna, rola należąca do folwarku; 4. posiadłość ziemska, dworek z zabudowaniami gospodarskimi położony pod miastem; 5. wieś"@pl ;
-   rdfs:isDefinedBy ontohgis:document_2
+   ontohgis:isDefinedByIRI ontohgis:document_2
  ] .
 
 
 ontohgis:settlement_type_80 rdfs:comment "Characteristic for the Commonwealth of Poland and Lithuania from 16th to 18th century."@en ,
                                          "Charakterystycznego dla Rzeczypospolitej XVII–XVIII wieku"@pl ;
-                            rdfs:isDefinedBy "\"Holendry\" (a Dutch type locality) is a colony established on an empty territory, in areas not very useful for agriculture. It was a type of locality characteristic for a \"Dutch colonisation\", which was a specific form of a settlement movement - widespread in the Commonwealth of Poland and Lithuania from 16th to 18th century. Granting uncongenial land difficult to cultivate or for animal husbandry to local people or (more often) immigrants inflowing from Flanders, German countries and Silesia was the core element of this process."@en ,
-                                             "Holendry to kolonia zakładana na obszarach nieobjętych osadnictwem z powodu nikłej przydatności rolniczej, właściwa dla tzw. kolonizacji olęderskiej, czyli specyficznej formy ruchu osadniczego – charakterystycznego dla Rzeczypospolitej XVII–XVIII wieku – polegającego na nadaniu ludności rodzimej – lub częściej – imigrantom pochodzącym z Flandrii, państw niemieckich lub Śląska, trudnej (w uprawie lub hodowli) ziemi."@pl ;
                             rdfs:label "\"holendry\""@en ,
                                        "holendry"@pl ;
                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Hauland"@de ,
@@ -19602,7 +19600,9 @@ ontohgis:settlement_type_80 rdfs:comment "Characteristic for the Commonwealth of
                                                                             "holendry"@pl ;
                             ontohgis:hasExternalIdentifier "80" ;
                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 .
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:isDefinedByLiteral "\"Holendry\" (a Dutch type locality) is a colony established on an empty territory, in areas not very useful for agriculture. It was a type of locality characteristic for a \"Dutch colonisation\", which was a specific form of a settlement movement - widespread in the Commonwealth of Poland and Lithuania from 16th to 18th century. Granting uncongenial land difficult to cultivate or for animal husbandry to local people or (more often) immigrants inflowing from Flanders, German countries and Silesia was the core element of this process."^^rdfs:Literal ,
+                                                        "Holendry to kolonia zakładana na obszarach nieobjętych osadnictwem z powodu nikłej przydatności rolniczej, właściwa dla tzw. kolonizacji olęderskiej, czyli specyficznej formy ruchu osadniczego – charakterystycznego dla Rzeczypospolitej XVII–XVIII wieku – polegającego na nadaniu ludności rodzimej – lub częściej – imigrantom pochodzącym z Flandrii, państw niemieckich lub Śląska, trudnej (w uprawie lub hodowli) ziemi."^^rdfs:Literal .
 
 
 ontohgis:settlement_type_82 rdfs:comment "Port morski na austriackiej mapie 1:75 000 wyróżniony explicite i opisany krojem pisma takim jak miasta większe niż 100 000 mieszkańców i twierdze.W BDOT10k „port wodny lub przystań” w klasie kompleks komunikacyjny.Jest u Bystrzyckiego (nie w skrótach) – port, miasto portowe."@pl ,

--- a/ontohgis.ttl
+++ b/ontohgis.ttl
@@ -1,7 +1,7 @@
 @prefix : <https://onto.kul.pl/ontohgis/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix dct: <http://purl.org/dc/terms/> .
 @prefix oc: <http://ontologies.makolab.com/oc/> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -30,10 +30,10 @@
 
 ###  http://purl.org/dc/elements/1.1/contributor
 dc:contributor rdf:type owl:AnnotationProperty ;
-               <http://purl.org/dc/terms/description> "Examples of a Contributor include a person, an organization, or a service. Typically, the name of a Contributor should be used to indicate the entity."@en ;
-               <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#contributor-006> ;
-               <http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-               <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
+               dct:description "Examples of a Contributor include a person, an organization, or a service. Typically, the name of a Contributor should be used to indicate the entity."@en ;
+               dct:hasVersion <http://dublincore.org/usage/terms/history/#contributor-006> ;
+               dct:issued "1999-07-02"^^xsd:date ;
+               dct:modified "2008-01-14"^^xsd:date ;
                rdfs:comment "An entity responsible for making contributions to the resource."@en ;
                rdfs:isDefinedBy dc: ;
                rdfs:label "Contributor"@en ;
@@ -42,10 +42,10 @@ dc:contributor rdf:type owl:AnnotationProperty ;
 
 ###  http://purl.org/dc/elements/1.1/creator
 dc:creator rdf:type owl:AnnotationProperty ;
-           <http://purl.org/dc/terms/description> "Examples of a Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity."@en ;
-           <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#creator-006> ;
-           <http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-           <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
+           dct:description "Examples of a Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity."@en ;
+           dct:hasVersion <http://dublincore.org/usage/terms/history/#creator-006> ;
+           dct:issued "1999-07-02"^^xsd:date ;
+           dct:modified "2008-01-14"^^xsd:date ;
            rdfs:comment "An entity primarily responsible for making the resource."@en ;
            rdfs:isDefinedBy dc: ;
            rdfs:label "Creator"@en ;
@@ -54,10 +54,10 @@ dc:creator rdf:type owl:AnnotationProperty ;
 
 ###  http://purl.org/dc/elements/1.1/date
 dc:date rdf:type owl:AnnotationProperty ;
-        <http://purl.org/dc/terms/description> "Date may be used to express temporal information at any level of granularity.  Recommended best practice is to use an encoding scheme, such as the W3CDTF profile of ISO 8601 [W3CDTF]."@en ;
-        <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#date-006> ;
-        <http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-        <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
+        dct:description "Date may be used to express temporal information at any level of granularity.  Recommended best practice is to use an encoding scheme, such as the W3CDTF profile of ISO 8601 [W3CDTF]."@en ;
+        dct:hasVersion <http://dublincore.org/usage/terms/history/#date-006> ;
+        dct:issued "1999-07-02"^^xsd:date ;
+        dct:modified "2008-01-14"^^xsd:date ;
         rdfs:comment "A point or period of time associated with an event in the lifecycle of the resource."@en ;
         rdfs:isDefinedBy dc: ;
         rdfs:label "Date"@en ;
@@ -66,10 +66,10 @@ dc:date rdf:type owl:AnnotationProperty ;
 
 ###  http://purl.org/dc/elements/1.1/description
 dc:description rdf:type owl:AnnotationProperty ;
-               <http://purl.org/dc/terms/description> "Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource."@en ;
-               <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#description-006> ;
-               <http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-               <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
+               dct:description "Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource."@en ;
+               dct:hasVersion <http://dublincore.org/usage/terms/history/#description-006> ;
+               dct:issued "1999-07-02"^^xsd:date ;
+               dct:modified "2008-01-14"^^xsd:date ;
                rdfs:comment "An account of the resource."@en ;
                rdfs:isDefinedBy dc: ;
                rdfs:label "Description"@en ;
@@ -78,10 +78,10 @@ dc:description rdf:type owl:AnnotationProperty ;
 
 ###  http://purl.org/dc/elements/1.1/identifier
 dc:identifier rdf:type owl:AnnotationProperty ;
-              <http://purl.org/dc/terms/description> "Recommended best practice is to identify the resource by means of a string conforming to a formal identification system. "@en ;
-              <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#identifier-006> ;
-              <http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-              <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
+              dct:description "Recommended best practice is to identify the resource by means of a string conforming to a formal identification system. "@en ;
+              dct:hasVersion <http://dublincore.org/usage/terms/history/#identifier-006> ;
+              dct:issued "1999-07-02"^^xsd:date ;
+              dct:modified "2008-01-14"^^xsd:date ;
               rdfs:comment "An unambiguous reference to the resource within a given context."@en ;
               rdfs:isDefinedBy dc: ;
               rdfs:label "Identifier"@en ;
@@ -90,10 +90,10 @@ dc:identifier rdf:type owl:AnnotationProperty ;
 
 ###  http://purl.org/dc/elements/1.1/publisher
 dc:publisher rdf:type owl:AnnotationProperty ;
-             <http://purl.org/dc/terms/description> "Examples of a Publisher include a person, an organization, or a service. Typically, the name of a Publisher should be used to indicate the entity."@en ;
-             <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#publisher-006> ;
-             <http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-             <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
+             dct:description "Examples of a Publisher include a person, an organization, or a service. Typically, the name of a Publisher should be used to indicate the entity."@en ;
+             dct:hasVersion <http://dublincore.org/usage/terms/history/#publisher-006> ;
+             dct:issued "1999-07-02"^^xsd:date ;
+             dct:modified "2008-01-14"^^xsd:date ;
              rdfs:comment "An entity responsible for making the resource available."@en ;
              rdfs:isDefinedBy dc: ;
              rdfs:label "Publisher"@en ;
@@ -102,10 +102,10 @@ dc:publisher rdf:type owl:AnnotationProperty ;
 
 ###  http://purl.org/dc/elements/1.1/relation
 dc:relation rdf:type owl:AnnotationProperty ;
-            <http://purl.org/dc/terms/description> "Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system. "@en ;
-            <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#relation-006> ;
-            <http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-            <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
+            dct:description "Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system. "@en ;
+            dct:hasVersion <http://dublincore.org/usage/terms/history/#relation-006> ;
+            dct:issued "1999-07-02"^^xsd:date ;
+            dct:modified "2008-01-14"^^xsd:date ;
             rdfs:comment "A related resource."@en ;
             rdfs:isDefinedBy dc: ;
             rdfs:label "Relation"@en ;
@@ -114,10 +114,10 @@ dc:relation rdf:type owl:AnnotationProperty ;
 
 ###  http://purl.org/dc/elements/1.1/source
 dc:source rdf:type owl:AnnotationProperty ;
-          <http://purl.org/dc/terms/description> "The described resource may be derived from the related resource in whole or in part. Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system."@en ;
-          <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#source-006> ;
-          <http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-          <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
+          dct:description "The described resource may be derived from the related resource in whole or in part. Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system."@en ;
+          dct:hasVersion <http://dublincore.org/usage/terms/history/#source-006> ;
+          dct:issued "1999-07-02"^^xsd:date ;
+          dct:modified "2008-01-14"^^xsd:date ;
           rdfs:comment "A related resource from which the described resource is derived."@en ;
           rdfs:isDefinedBy dc: ;
           rdfs:label "Source"@en ;
@@ -126,9 +126,9 @@ dc:source rdf:type owl:AnnotationProperty ;
 
 ###  http://purl.org/dc/elements/1.1/title
 dc:title rdf:type owl:AnnotationProperty ;
-         <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#title-006> ;
-         <http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-         <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
+         dct:hasVersion <http://dublincore.org/usage/terms/history/#title-006> ;
+         dct:issued "1999-07-02"^^xsd:date ;
+         dct:modified "2008-01-14"^^xsd:date ;
          rdfs:comment "A name given to the resource."@en ;
          rdfs:isDefinedBy dc: ;
          rdfs:label "Title"@en ;
@@ -136,207 +136,206 @@ dc:title rdf:type owl:AnnotationProperty ;
 
 
 ###  http://purl.org/dc/terms/abstract
-<http://purl.org/dc/terms/abstract> rdf:type owl:AnnotationProperty ;
-                                    rdfs:subPropertyOf dc:description ,
-                                                       <http://purl.org/dc/terms/description> .
+dct:abstract rdf:type owl:AnnotationProperty ;
+             rdfs:subPropertyOf dc:description ,
+                                dct:description .
 
 
 ###  http://purl.org/dc/terms/alternative
-<http://purl.org/dc/terms/alternative> rdf:type owl:AnnotationProperty ;
-                                       rdfs:subPropertyOf dc:title ;
-                                       rdfs:range rdfs:Literal .
+dct:alternative rdf:type owl:AnnotationProperty ;
+                rdfs:subPropertyOf dc:title ;
+                rdfs:range rdfs:Literal .
 
 
 ###  http://purl.org/dc/terms/available
-<http://purl.org/dc/terms/available> rdf:type owl:AnnotationProperty ;
-                                     rdfs:subPropertyOf dc:date ;
-                                     rdfs:range rdfs:Literal .
+dct:available rdf:type owl:AnnotationProperty ;
+              rdfs:subPropertyOf dc:date ;
+              rdfs:range rdfs:Literal .
 
 
 ###  http://purl.org/dc/terms/bibliographicCitation
-<http://purl.org/dc/terms/bibliographicCitation> rdf:type owl:AnnotationProperty ;
-                                                 rdfs:subPropertyOf dc:identifier ;
-                                                 rdfs:range rdfs:Literal ;
-                                                 rdfs:domain <http://purl.org/dc/terms/BibliographicResource> .
+dct:bibliographicCitation rdf:type owl:AnnotationProperty ;
+                          rdfs:subPropertyOf dc:identifier ;
+                          rdfs:range rdfs:Literal .
 
 
 ###  http://purl.org/dc/terms/conformsTo
-<http://purl.org/dc/terms/conformsTo> rdf:type owl:AnnotationProperty ;
-                                      rdfs:subPropertyOf dc:relation ,
-                                                         <http://purl.org/dc/terms/relation> ;
-                                      rdfs:range <http://purl.org/dc/terms/Standard> .
+dct:conformsTo rdf:type owl:AnnotationProperty ;
+               rdfs:subPropertyOf dc:relation ,
+                                  dct:relation ;
+               rdfs:range dct:Standard .
 
 
 ###  http://purl.org/dc/terms/contributor
-<http://purl.org/dc/terms/contributor> rdf:type owl:AnnotationProperty ;
-                                       rdfs:subPropertyOf dc:contributor ;
-                                       rdfs:range <http://purl.org/dc/terms/Agent> .
+dct:contributor rdf:type owl:AnnotationProperty ;
+                rdfs:subPropertyOf dc:contributor ;
+                rdfs:range dct:Agent .
 
 
 ###  http://purl.org/dc/terms/created
-<http://purl.org/dc/terms/created> rdf:type owl:AnnotationProperty ;
-                                   rdfs:subPropertyOf dc:date ;
-                                   rdfs:range rdfs:Literal .
+dct:created rdf:type owl:AnnotationProperty ;
+            rdfs:subPropertyOf dc:date ;
+            rdfs:range rdfs:Literal .
 
 
 ###  http://purl.org/dc/terms/creator
-<http://purl.org/dc/terms/creator> rdf:type owl:AnnotationProperty ;
-                                   rdfs:subPropertyOf dc:creator ;
-                                   rdfs:range <http://purl.org/dc/terms/Agent> .
-             
+dct:creator rdf:type owl:AnnotationProperty ;
+            rdfs:subPropertyOf dc:creator ;
+            rdfs:range dct:Agent .
+
 
 ###  http://purl.org/dc/terms/date
-<http://purl.org/dc/terms/date> rdf:type owl:AnnotationProperty ;
-                                rdfs:subPropertyOf dc:date ;
-                                rdfs:range rdfs:Literal .
+dct:date rdf:type owl:AnnotationProperty ;
+         rdfs:subPropertyOf dc:date ;
+         rdfs:range rdfs:Literal .
 
 
 ###  http://purl.org/dc/terms/dateAccepted
-<http://purl.org/dc/terms/dateAccepted> rdf:type owl:AnnotationProperty ;
-                                        rdfs:subPropertyOf dc:date ;
-                                        rdfs:range rdfs:Literal .
+dct:dateAccepted rdf:type owl:AnnotationProperty ;
+                 rdfs:subPropertyOf dc:date ;
+                 rdfs:range rdfs:Literal .
 
 
 ###  http://purl.org/dc/terms/dateCopyrighted
-<http://purl.org/dc/terms/dateCopyrighted> rdf:type owl:AnnotationProperty ;
-                                           rdfs:subPropertyOf dc:date ;
-                                           rdfs:range rdfs:Literal .
+dct:dateCopyrighted rdf:type owl:AnnotationProperty ;
+                    rdfs:subPropertyOf dc:date ;
+                    rdfs:range rdfs:Literal .
 
 
 ###  http://purl.org/dc/terms/dateSubmitted
-<http://purl.org/dc/terms/dateSubmitted> rdf:type owl:AnnotationProperty ;
-                                         rdfs:subPropertyOf dc:date ;
-                                         rdfs:range rdfs:Literal .
+dct:dateSubmitted rdf:type owl:AnnotationProperty ;
+                  rdfs:subPropertyOf dc:date ;
+                  rdfs:range rdfs:Literal .
 
 
 ###  http://purl.org/dc/terms/description
-<http://purl.org/dc/terms/description> rdf:type owl:AnnotationProperty ;
-                                       rdfs:subPropertyOf dc:description .
+dct:description rdf:type owl:AnnotationProperty ;
+                rdfs:subPropertyOf dc:description .
 
 
 ###  http://purl.org/dc/terms/hasFormat
-<http://purl.org/dc/terms/hasFormat> rdf:type owl:AnnotationProperty ;
-                                     rdfs:subPropertyOf dc:relation ,
-                                                        <http://purl.org/dc/terms/relation> .
+dct:hasFormat rdf:type owl:AnnotationProperty ;
+              rdfs:subPropertyOf dc:relation ,
+                                 dct:relation .
 
 
 ###  http://purl.org/dc/terms/hasPart
-<http://purl.org/dc/terms/hasPart> rdf:type owl:AnnotationProperty ;
-                                   rdfs:subPropertyOf dc:relation ,
-                                                      <http://purl.org/dc/terms/relation> .
+dct:hasPart rdf:type owl:AnnotationProperty ;
+            rdfs:subPropertyOf dc:relation ,
+                               dct:relation .
 
 
 ###  http://purl.org/dc/terms/hasVersion
-<http://purl.org/dc/terms/hasVersion> rdf:type owl:AnnotationProperty ;
-                                      rdfs:subPropertyOf dc:relation ,
-                                                         <http://purl.org/dc/terms/relation> .
+dct:hasVersion rdf:type owl:AnnotationProperty ;
+               rdfs:subPropertyOf dc:relation ,
+                                  dct:relation .
 
 
 ###  http://purl.org/dc/terms/identifier
-<http://purl.org/dc/terms/identifier> rdf:type owl:AnnotationProperty ;
-                                      rdfs:subPropertyOf dc:identifier ;
-                                      rdfs:range rdfs:Literal .
+dct:identifier rdf:type owl:AnnotationProperty ;
+               rdfs:subPropertyOf dc:identifier ;
+               rdfs:range rdfs:Literal .
 
 
 ###  http://purl.org/dc/terms/isFormatOf
-<http://purl.org/dc/terms/isFormatOf> rdf:type owl:AnnotationProperty ;
-                                      rdfs:subPropertyOf dc:relation ,
-                                                         <http://purl.org/dc/terms/relation> .
+dct:isFormatOf rdf:type owl:AnnotationProperty ;
+               rdfs:subPropertyOf dc:relation ,
+                                  dct:relation .
 
 
 ###  http://purl.org/dc/terms/isPartOf
-<http://purl.org/dc/terms/isPartOf> rdf:type owl:AnnotationProperty ;
-                                    rdfs:subPropertyOf dc:relation ,
-                                                       <http://purl.org/dc/terms/relation> .
+dct:isPartOf rdf:type owl:AnnotationProperty ;
+             rdfs:subPropertyOf dc:relation ,
+                                dct:relation .
 
 
 ###  http://purl.org/dc/terms/isReferencedBy
-<http://purl.org/dc/terms/isReferencedBy> rdf:type owl:AnnotationProperty ;
-                                          rdfs:subPropertyOf dc:relation ,
-                                                             <http://purl.org/dc/terms/relation> .
+dct:isReferencedBy rdf:type owl:AnnotationProperty ;
+                   rdfs:subPropertyOf dc:relation ,
+                                      dct:relation .
 
 
 ###  http://purl.org/dc/terms/isReplacedBy
-<http://purl.org/dc/terms/isReplacedBy> rdf:type owl:AnnotationProperty ;
-                                        rdfs:subPropertyOf dc:relation ,
-                                                           <http://purl.org/dc/terms/relation> .
+dct:isReplacedBy rdf:type owl:AnnotationProperty ;
+                 rdfs:subPropertyOf dc:relation ,
+                                    dct:relation .
 
 
 ###  http://purl.org/dc/terms/isRequiredBy
-<http://purl.org/dc/terms/isRequiredBy> rdf:type owl:AnnotationProperty ;
-                                        rdfs:subPropertyOf dc:relation ,
-                                                           <http://purl.org/dc/terms/relation> .
+dct:isRequiredBy rdf:type owl:AnnotationProperty ;
+                 rdfs:subPropertyOf dc:relation ,
+                                    dct:relation .
 
 
 ###  http://purl.org/dc/terms/isVersionOf
-<http://purl.org/dc/terms/isVersionOf> rdf:type owl:AnnotationProperty ;
-                                       rdfs:subPropertyOf dc:relation ,
-                                                          <http://purl.org/dc/terms/relation> .
+dct:isVersionOf rdf:type owl:AnnotationProperty ;
+                rdfs:subPropertyOf dc:relation ,
+                                   dct:relation .
 
 
 ###  http://purl.org/dc/terms/issued
-<http://purl.org/dc/terms/issued> rdf:type owl:AnnotationProperty ;
-                                  rdfs:subPropertyOf dc:date ;
-                                  rdfs:range rdfs:Literal .
+dct:issued rdf:type owl:AnnotationProperty ;
+           rdfs:subPropertyOf dc:date ;
+           rdfs:range rdfs:Literal .
 
 
 ###  http://purl.org/dc/terms/modified
-<http://purl.org/dc/terms/modified> rdf:type owl:AnnotationProperty ;
-                                    rdfs:subPropertyOf dc:date ;
-                                    rdfs:range rdfs:Literal .
+dct:modified rdf:type owl:AnnotationProperty ;
+             rdfs:subPropertyOf dc:date ;
+             rdfs:range rdfs:Literal .
 
 
 ###  http://purl.org/dc/terms/publisher
-<http://purl.org/dc/terms/publisher> rdf:type owl:AnnotationProperty ;
-                                     rdfs:subPropertyOf dc:publisher ;
-                                     rdfs:range <http://purl.org/dc/terms/Agent> .
+dct:publisher rdf:type owl:AnnotationProperty ;
+              rdfs:subPropertyOf dc:publisher ;
+              rdfs:range dct:Agent .
 
 
 ###  http://purl.org/dc/terms/references
-<http://purl.org/dc/terms/references> rdf:type owl:AnnotationProperty ;
-                                      rdfs:subPropertyOf dc:relation ,
-                                                         <http://purl.org/dc/terms/relation> .
+dct:references rdf:type owl:AnnotationProperty ;
+               rdfs:subPropertyOf dc:relation ,
+                                  dct:relation .
 
 
 ###  http://purl.org/dc/terms/relation
-<http://purl.org/dc/terms/relation> rdf:type owl:AnnotationProperty ;
-                                    rdfs:subPropertyOf dc:relation .
+dct:relation rdf:type owl:AnnotationProperty ;
+             rdfs:subPropertyOf dc:relation .
 
 
 ###  http://purl.org/dc/terms/replaces
-<http://purl.org/dc/terms/replaces> rdf:type owl:AnnotationProperty ;
-                                    rdfs:subPropertyOf dc:relation ,
-                                                       <http://purl.org/dc/terms/relation> .
+dct:replaces rdf:type owl:AnnotationProperty ;
+             rdfs:subPropertyOf dc:relation ,
+                                dct:relation .
 
 
 ###  http://purl.org/dc/terms/requires
-<http://purl.org/dc/terms/requires> rdf:type owl:AnnotationProperty ;
-                                    rdfs:subPropertyOf dc:relation ,
-                                                       <http://purl.org/dc/terms/relation> .
+dct:requires rdf:type owl:AnnotationProperty ;
+             rdfs:subPropertyOf dc:relation ,
+                                dct:relation .
 
 
 ###  http://purl.org/dc/terms/source
-<http://purl.org/dc/terms/source> rdf:type owl:AnnotationProperty ;
-                                  rdfs:subPropertyOf dc:source ,
-                                                     <http://purl.org/dc/terms/relation> .
+dct:source rdf:type owl:AnnotationProperty ;
+           rdfs:subPropertyOf dc:source ,
+                              dct:relation .
 
 
 ###  http://purl.org/dc/terms/tableOfContents
-<http://purl.org/dc/terms/tableOfContents> rdf:type owl:AnnotationProperty ;
-                                           rdfs:subPropertyOf dc:description ,
-                                                              <http://purl.org/dc/terms/description> .
+dct:tableOfContents rdf:type owl:AnnotationProperty ;
+                    rdfs:subPropertyOf dc:description ,
+                                       dct:description .
 
 
 ###  http://purl.org/dc/terms/title
-<http://purl.org/dc/terms/title> rdf:type owl:AnnotationProperty ;
-                                 rdfs:subPropertyOf dc:title ;
-                                 rdfs:range rdfs:Literal .
+dct:title rdf:type owl:AnnotationProperty ;
+          rdfs:subPropertyOf dc:title ;
+          rdfs:range rdfs:Literal .
 
 
 ###  http://purl.org/dc/terms/valid
-<http://purl.org/dc/terms/valid> rdf:type owl:AnnotationProperty ;
-                                 rdfs:subPropertyOf dc:date ;
-                                 rdfs:range rdfs:Literal .
+dct:valid rdf:type owl:AnnotationProperty ;
+          rdfs:subPropertyOf dc:date ;
+          rdfs:range rdfs:Literal .
 
 
 ###  http://www.w3.org/2004/02/skos/core#altLabel
@@ -367,17 +366,11 @@ ontohgis:hasExternalIdentifier rdf:type owl:AnnotationProperty ;
 
 
 ###  https://onto.kul.pl/ontohgis/hasLanguageVerificator
-ontohgis:hasLanguageVerificator rdf:type owl:AnnotationProperty ;
-                                rdfs:label "translation was verified by"@en ,
-                                           "weryfikacja tłumaczenia deskrypcji przez"@pl ;
-                                rdfs:subPropertyOf dct:contributor .
+ontohgis:hasLanguageVerificator rdf:type owl:AnnotationProperty .
 
 
 ###  https://onto.kul.pl/ontohgis/hasOntologicalVerificator
-ontohgis:hasOntologicalVerificator rdf:type owl:AnnotationProperty ;
-                                   rdfs:label "deskrypcja została ontologicznie zweryfikowana przez"@pl ,
-                                              "was ontologically verified by"@en ;
-                                   rdfs:subPropertyOf dct:contributor .
+ontohgis:hasOntologicalVerificator rdf:type owl:AnnotationProperty .
 
 
 ###  https://onto.kul.pl/ontohgis/hasOntologyDevelopmentComment
@@ -388,10 +381,23 @@ ontohgis:hasOntologyDevelopmentComment rdf:type owl:AnnotationProperty ;
 
 
 ###  https://onto.kul.pl/ontohgis/hasTranslator
-ontohgis:hasTranslator rdf:type owl:AnnotationProperty ;
-                       rdfs:label "deskrypcja została przetłumaczona przez"@pl ,
-                                  "was translated by"@en ;
-                       rdfs:subPropertyOf dct:contributor .
+ontohgis:hasTranslator rdf:type owl:AnnotationProperty .
+
+
+###  https://onto.kul.pl/ontohgis/isDefinedByIRI
+ontohgis:isDefinedByIRI rdf:type owl:AnnotationProperty ;
+                        rdfs:label "is defined by IRI"@en ,
+                                   "jest zdefiniowany przez IRI"@pl ;
+                        rdfs:subPropertyOf rdfs:isDefinedBy ;
+                        rdfs:range xsd:anyURI .
+
+
+###  https://onto.kul.pl/ontohgis/isDefinedByLiteral
+ontohgis:isDefinedByLiteral rdf:type owl:AnnotationProperty ;
+                            rdfs:label "is defined by literal"@en ,
+                                       "jest zdefiniowany przez literał"@pl ;
+                            rdfs:subPropertyOf rdfs:isDefinedBy ;
+                            rdfs:range rdfs:Literal .
 
 
 ###  https://onto.kul.pl/ontohgis/isMentionedInSource
@@ -457,51 +463,51 @@ ontohgis:isValidThroughout rdf:type owl:AnnotationProperty ;
 #################################################################
 
 ###  http://purl.org/dc/terms/Box
-<http://purl.org/dc/terms/Box> rdf:type rdfs:Datatype .
+dct:Box rdf:type rdfs:Datatype .
 
 
 ###  http://purl.org/dc/terms/ISO3166
-<http://purl.org/dc/terms/ISO3166> rdf:type rdfs:Datatype .
+dct:ISO3166 rdf:type rdfs:Datatype .
 
 
 ###  http://purl.org/dc/terms/ISO639-2
-<http://purl.org/dc/terms/ISO639-2> rdf:type rdfs:Datatype .
+dct:ISO639-2 rdf:type rdfs:Datatype .
 
 
 ###  http://purl.org/dc/terms/ISO639-3
-<http://purl.org/dc/terms/ISO639-3> rdf:type rdfs:Datatype .
+dct:ISO639-3 rdf:type rdfs:Datatype .
 
 
 ###  http://purl.org/dc/terms/Period
-<http://purl.org/dc/terms/Period> rdf:type rdfs:Datatype .
+dct:Period rdf:type rdfs:Datatype .
 
 
 ###  http://purl.org/dc/terms/Point
-<http://purl.org/dc/terms/Point> rdf:type rdfs:Datatype .
+dct:Point rdf:type rdfs:Datatype .
 
 
 ###  http://purl.org/dc/terms/RFC1766
-<http://purl.org/dc/terms/RFC1766> rdf:type rdfs:Datatype .
+dct:RFC1766 rdf:type rdfs:Datatype .
 
 
 ###  http://purl.org/dc/terms/RFC3066
-<http://purl.org/dc/terms/RFC3066> rdf:type rdfs:Datatype .
+dct:RFC3066 rdf:type rdfs:Datatype .
 
 
 ###  http://purl.org/dc/terms/RFC4646
-<http://purl.org/dc/terms/RFC4646> rdf:type rdfs:Datatype .
+dct:RFC4646 rdf:type rdfs:Datatype .
 
 
 ###  http://purl.org/dc/terms/RFC5646
-<http://purl.org/dc/terms/RFC5646> rdf:type rdfs:Datatype .
+dct:RFC5646 rdf:type rdfs:Datatype .
 
 
 ###  http://purl.org/dc/terms/URI
-<http://purl.org/dc/terms/URI> rdf:type rdfs:Datatype .
+dct:URI rdf:type rdfs:Datatype .
 
 
 ###  http://purl.org/dc/terms/W3CDTF
-<http://purl.org/dc/terms/W3CDTF> rdf:type rdfs:Datatype .
+dct:W3CDTF rdf:type rdfs:Datatype .
 
 
 ###  http://www.w3.org/2001/XMLSchema#date
@@ -530,13 +536,13 @@ oc:isPredecessorEntityManifestationOf rdf:type owl:ObjectProperty ,
 
 
 ###  http://purl.org/dc/terms/contributor
-<http://purl.org/dc/terms/contributor> rdf:type owl:ObjectProperty .
+dct:contributor rdf:type owl:ObjectProperty .
 
 
 ###  http://purl.org/dc/terms/creator
-<http://purl.org/dc/terms/creator> rdf:type owl:ObjectProperty ;
-                                   rdfs:subPropertyOf <http://purl.org/dc/terms/contributor> ;
-                                   owl:inverseOf ontohgis:isCreatedBy .
+dct:creator rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf dct:contributor ;
+            owl:inverseOf ontohgis:isCreatedBy .
 
 
 ###  http://www.cidoc-crm.org/cidoc-crm/P100_was_death_of
@@ -4622,6 +4628,16 @@ ontohgis:hasImproperFunction rdf:type owl:ObjectProperty ;
                              rdfs:seeAlso "http://dx.doi.org/10.1080/13869790410001694462"^^xsd:anyURI .
 
 
+###  https://onto.kul.pl/ontohgis/hasLanguageVerificator
+ontohgis:hasLanguageVerificator rdf:type owl:ObjectProperty ;
+                                rdfs:subPropertyOf dct:contributor .
+
+
+###  https://onto.kul.pl/ontohgis/hasOntologicalVerificator
+ontohgis:hasOntologicalVerificator rdf:type owl:ObjectProperty ;
+                                   rdfs:subPropertyOf dct:contributor .
+
+
 ###  https://onto.kul.pl/ontohgis/hasProperFunction
 ontohgis:hasProperFunction rdf:type owl:ObjectProperty ;
                            rdfs:subPropertyOf ontohgis:hasFunction ;
@@ -4629,6 +4645,11 @@ ontohgis:hasProperFunction rdf:type owl:ObjectProperty ;
                            rdfs:label "has proper function"@en ,
                                       "ma funkcję właściwą"@pl ;
                            rdfs:seeAlso "http://dx.doi.org/10.1080/13869790410001694462"^^xsd:anyURI .
+
+
+###  https://onto.kul.pl/ontohgis/hasTranslator
+ontohgis:hasTranslator rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf dct:contributor .
 
 
 ###  https://onto.kul.pl/ontohgis/isAdditionalyDenotedBy
@@ -4717,65 +4738,66 @@ ontohgis:settlementIsPartOfSettlement rdf:type owl:ObjectProperty ;
 #################################################################
 
 ###  http://purl.org/dc/terms/alternative
-<http://purl.org/dc/terms/alternative> rdf:type owl:DatatypeProperty ;
-                                       rdfs:subPropertyOf <http://purl.org/dc/terms/title> .
+dct:alternative rdf:type owl:DatatypeProperty ;
+                rdfs:subPropertyOf dct:title .
 
 
 ###  http://purl.org/dc/terms/available
-<http://purl.org/dc/terms/available> rdf:type owl:DatatypeProperty ;
-                                     rdfs:subPropertyOf <http://purl.org/dc/terms/date> .
+dct:available rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf dct:date .
 
 
 ###  http://purl.org/dc/terms/bibliographicCitation
-<http://purl.org/dc/terms/bibliographicCitation> rdf:type owl:DatatypeProperty ;
-                                                 rdfs:subPropertyOf <http://purl.org/dc/terms/identifier> .
+dct:bibliographicCitation rdf:type owl:DatatypeProperty ;
+                          rdfs:subPropertyOf dct:identifier ;
+                          rdfs:domain dct:BibliographicResource .
 
 
 ###  http://purl.org/dc/terms/created
-<http://purl.org/dc/terms/created> rdf:type owl:DatatypeProperty ;
-                                   rdfs:subPropertyOf <http://purl.org/dc/terms/date> .
+dct:created rdf:type owl:DatatypeProperty ;
+            rdfs:subPropertyOf dct:date .
 
 
 ###  http://purl.org/dc/terms/date
-<http://purl.org/dc/terms/date> rdf:type owl:DatatypeProperty .
+dct:date rdf:type owl:DatatypeProperty .
 
 
 ###  http://purl.org/dc/terms/dateAccepted
-<http://purl.org/dc/terms/dateAccepted> rdf:type owl:DatatypeProperty ;
-                                        rdfs:subPropertyOf <http://purl.org/dc/terms/date> .
+dct:dateAccepted rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf dct:date .
 
 
 ###  http://purl.org/dc/terms/dateCopyrighted
-<http://purl.org/dc/terms/dateCopyrighted> rdf:type owl:DatatypeProperty ;
-                                           rdfs:subPropertyOf <http://purl.org/dc/terms/date> .
+dct:dateCopyrighted rdf:type owl:DatatypeProperty ;
+                    rdfs:subPropertyOf dct:date .
 
 
 ###  http://purl.org/dc/terms/dateSubmitted
-<http://purl.org/dc/terms/dateSubmitted> rdf:type owl:DatatypeProperty ;
-                                         rdfs:subPropertyOf <http://purl.org/dc/terms/date> .
+dct:dateSubmitted rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf dct:date .
 
 
 ###  http://purl.org/dc/terms/identifier
-<http://purl.org/dc/terms/identifier> rdf:type owl:DatatypeProperty .
+dct:identifier rdf:type owl:DatatypeProperty .
 
 
 ###  http://purl.org/dc/terms/issued
-<http://purl.org/dc/terms/issued> rdf:type owl:DatatypeProperty ;
-                                  rdfs:subPropertyOf <http://purl.org/dc/terms/date> .
+dct:issued rdf:type owl:DatatypeProperty ;
+           rdfs:subPropertyOf dct:date .
 
 
 ###  http://purl.org/dc/terms/modified
-<http://purl.org/dc/terms/modified> rdf:type owl:DatatypeProperty ;
-                                    rdfs:subPropertyOf <http://purl.org/dc/terms/date> .
+dct:modified rdf:type owl:DatatypeProperty ;
+             rdfs:subPropertyOf dct:date .
 
 
 ###  http://purl.org/dc/terms/title
-<http://purl.org/dc/terms/title> rdf:type owl:DatatypeProperty .
+dct:title rdf:type owl:DatatypeProperty .
 
 
 ###  http://purl.org/dc/terms/valid
-<http://purl.org/dc/terms/valid> rdf:type owl:DatatypeProperty ;
-                                 rdfs:subPropertyOf <http://purl.org/dc/terms/date> .
+dct:valid rdf:type owl:DatatypeProperty ;
+          rdfs:subPropertyOf dct:date .
 
 
 ###  http://www.cidoc-crm.org/cidoc-crm/P168_place_is_defined_by
@@ -5063,8 +5085,12 @@ obo:BFO_0000140 rdf:type owl:Class ;
 
 
 ###  http://purl.org/dc/terms/AgentClass
-<http://purl.org/dc/terms/AgentClass> rdf:type owl:Class ;
-                                      rdfs:subClassOf rdfs:Class .
+dct:AgentClass rdf:type owl:Class ;
+               rdfs:subClassOf rdfs:Class .
+
+
+###  http://purl.org/dc/terms/BibliographicResource
+dct:BibliographicResource rdf:type owl:Class .
 
 
 ###  http://www.cidoc-crm.org/cidoc-crm/E10_Transfer_of_Custody
@@ -10500,31 +10526,7 @@ ontohgis:settlement_type_1 rdf:type owl:Class ;
                                            [ rdf:type owl:Restriction ;
                                              owl:onProperty ontohgis:hasProperFunction ;
                                              owl:hasValue ontohgis:function5
-                                           ] ;
-                           dct:creator ontohgis:person_2 ;
-                           rdfs:comment "A castle could be an independent settlement unit or an object within some other unit."@en ,
-                                        "Zamek mógł być jednostką osadniczą lub obiektem w obrębie innej jednostki."@pl ;
-                           rdfs:isDefinedBy "A castle (a locality) is a locality comprising a castle (building) unless it is a part of another locality."@en ,
-                                            "Zamek (miejscowość) jest to miejscowość obejmująca zamek (obiekt), gdy nie jest on częścią innej miejscowości."@pl ;
-                           rdfs:label "castle"@en ,
-                                      "zamek"@pl ;
-                           rdfs:seeAlso <http://gov.genealogy.net/types.owl#111> ,
-                                        <http://linkedgeodata.org/page/ontology/Castle> ;
-                           <http://www.w3.org/2004/02/skos/core#altLabel> "Burg"@de ,
-                                                                          "Schloß"@de ,
-                                                                          "castellum"@la ,
-                                                                          "castrum"@la ;
-                           <http://www.w3.org/2004/02/skos/core#hiddenLabel> "arx"@la ,
-                                                                             "forteca"@pl ,
-                                                                             "gród"@pl ,
-                                                                             "pałac"@pl ,
-                                                                             "twierdza"@pl ;
-                           <http://www.w3.org/2004/02/skos/core#prefLabel> "castle"@en ,
-                                                                           "zamek"@pl ;
-                           ontohgis:hasExternalIdentifier "1"^^xsd:string ;
-                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                           ontohgis:hasTranslator ontohgis:person_9 .
+                                           ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_10
@@ -10542,28 +10544,7 @@ ontohgis:settlement_type_10 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function8
-                                            ] ;
-                            dct:creator ontohgis:person_4 ;
-                            rdfs:comment "A brewery might be a separate locality (rarely, before the WW II), both individual and a part of a cluster of localities sharing the same name, however most often it has been an integral part of a city or a town and has not been distinguished."@en ,
-                                         "Browar może być odrębną miejscowością (rzadko, przed II wojną światową), zarówno samodzielną jak i częścią grupy miejscowości o tej samej nazwie, ale najczęściej znajduje się w obrębie miast i nie jest wyróżniony."@pl ;
-                            rdfs:isDefinedBy "Brewery (locality) is a settlement, where a brewery (a factory) plays the most important role."@en ,
-                                             "Browar (miejscowość) jest to osada, w której główna rolę pełni browar (obiekt)."@pl ;
-                            rdfs:label "brewery"@en ,
-                                       "browar"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Bierbrauerei"@de ,
-                                                                              "Brauerei"@de ,
-                                                                              "Brauhaus"@de ,
-                                                                              "braxatorium"@la ,
-                                                                              "mielcuch"@pl ,
-                                                                              "piwowarnia"@pl ,
-                                                                              "warzelnia"@pl ,
-                                                                              "пивоварня"@ru ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "brewery"@en ,
-                                                                            "browar"@pl ;
-                            ontohgis:hasExternalIdentifier "10"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_100
@@ -10580,35 +10561,7 @@ ontohgis:settlement_type_100 rdf:type owl:Class ;
                                              [ rdf:type owl:Restriction ;
                                                owl:onProperty ontohgis:hasProperFunction ;
                                                owl:hasValue ontohgis:function12
-                                             ] ;
-                             dct:creator ontohgis:person_6 ;
-                             rdfs:comment "As a separate building, chapel could be a separate settlement unit in the past (rarely in the early modern era), but most often it is part of the village as a building."@en ,
-                                          "Kaplica jako odrębny budynek mogła być w przeszłości odrębną jednostką osadniczą (rzadko, spotyka się w okresie staropolskim), najczęściej jednak wchodzi w skład miejscowości jako budowla."@pl ;
-                             rdfs:isDefinedBy "Chapel is a locality, where the main role is played by a chapel (sacral building)."@en ,
-                                              "Kaplica jest to miejscowość, w której główną rolę pełni kaplica jako obiekt sakralny."@pl ;
-                             rdfs:label "chapel"@en ,
-                                        "kaplica"@pl ;
-                             rdfs:seeAlso <http://gov.genealogy.net/types.owl#245> ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "capella"@la ,
-                                                                            "die Kapelle"@de ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "aedes"@la ,
-                                                                               "aedicula sacrarium"@la ,
-                                                                               "augurale"@la ,
-                                                                               "auguratorium"@la ,
-                                                                               "delubrum"@la ,
-                                                                               "fanulum"@la ,
-                                                                               "fanum"@la ,
-                                                                               "kościół"@pl ,
-                                                                               "lararium"@la ,
-                                                                               "oratorium"@la ,
-                                                                               "sacellum"@la ,
-                                                                               "świątynia"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "chapel"@en ,
-                                                                             "kaplica"@pl ;
-                             ontohgis:hasExternalIdentifier "100"^^xsd:string ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
+                                             ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_1000
@@ -10638,7 +10591,7 @@ ontohgis:settlement_type_102 rdf:type owl:Class ;
                              rdfs:label "group of buildings"@en ,
                                         "grupa zabudowań"@pl ;
                              rdfs:seeAlso <http://gov.genealogy.net/types.owl#229> ;
-                             ontohgis:hasExternalIdentifier "102"^^xsd:string .
+                             ontohgis:hasExternalIdentifier "102" .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_103
@@ -10655,30 +10608,7 @@ ontohgis:settlement_type_103 rdf:type owl:Class ;
                                              [ rdf:type owl:Restriction ;
                                                owl:onProperty ontohgis:hasProperFunction ;
                                                owl:hasValue ontohgis:function12
-                                             ] ;
-                             dct:creator ontohgis:person_6 ;
-                             rdfs:comment "A church could be a separate settlement in the past (rarely, one can note its existence during and early modern era), however usually it, understood as a building, constituted a part of a locality."@en ,
-                                          "Kościół mógł być w przeszłości odrębną jednostką osadniczą (rzadko, spotyka się w okresie staropolskim), najczęściej jednak wchodzi w skład miejscowości jako budowla."@pl ;
-                             rdfs:isDefinedBy "Church is a locality, where the main role is played by the church (sacral building)."@en ,
-                                              "Kościół jest to miejscowość, w której główną rolę pełni kościół jako obiekt sakralny."@pl ;
-                             rdfs:label "church"@en ,
-                                        "kościół"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "ecclesia"@la ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "aedes"@la ,
-                                                                               "cerkiew"@pl ,
-                                                                               "die Kirche"@de ,
-                                                                               "domus Dei"@la ,
-                                                                               "fanum"@la ,
-                                                                               "kaplica"@pl ,
-                                                                               "templum"@la ,
-                                                                               "świątynia"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "church"@en ,
-                                                                             "kościół"@pl ;
-                             ontohgis:hasExternalIdentifier "103"^^xsd:string ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 ,
-                                                    ontohgis:person_9 .
+                                             ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_104
@@ -10688,10 +10618,10 @@ ontohgis:settlement_type_104 rdf:type owl:Class ;
                                                owl:onProperty <http://www.geonames.org/ontology#featureCode> ;
                                                owl:hasValue <http://www.geonames.org/ontology#S.MFG>
                                              ] ;
-                             rdfs:label "fabryka"^^xsd:string ;
+                             rdfs:label "fabryka" ;
                              rdfs:seeAlso <http://dbpedia.org/ontology/Factory> ,
                                           <http://linkedgeodata.org/ontology/Factory> ;
-                             ontohgis:hasExternalIdentifier "104"^^xsd:string .
+                             ontohgis:hasExternalIdentifier "104" .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_106
@@ -10702,23 +10632,7 @@ ontohgis:settlement_type_106 rdf:type owl:Class ;
                                              [ rdf:type owl:Restriction ;
                                                owl:onProperty ontohgis:hasProperFunction ;
                                                owl:hasValue ontohgis:function1
-                                             ] ;
-                             dct:creator ontohgis:person_3 ;
-                             rdfs:comment "Although the category exists on maps - e.g. the Topographical Map of the Kingdom of Poland from 1843 - it is very rare. On the Map, one can notice the peculiar spelling of this category: \"romunek\"."@en ,
-                                          "Kategoria występuje na mapach – np. Kwatermistrzostwie, to jednak jest to kategoria bardzo rzadka."@pl ;
-                             rdfs:isDefinedBy "\"Rumunek\" is an outlying settlement, situated in a cleared forest area (usually) or near the forest."@en ,
-                                              "Rumunek to odosobniona osada, położona w miejscu po wykarczowanym lesie (najczęściej) lub pod lasem."@pl ;
-                             rdfs:label "\"rumunek\""@en ,
-                                        "rumunek"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "pustkowie (pl)" ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "kolonia"@pl ,
-                                                                               "przysiółek"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "\"rumunek\""@en ,
-                                                                             "rumunek"@pl ;
-                             ontohgis:hasExternalIdentifier "106"^^xsd:string ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
+                                             ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_11
@@ -10732,24 +10646,7 @@ ontohgis:settlement_type_11 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function8
-                                            ] ;
-                            dct:creator ontohgis:person_4 ;
-                            rdfs:comment "A brickyard might be a separate locality, both individual and a part of a cluster of localities sharing the same name. It may also be an integral part of a bigger locality."@en ,
-                                         "Cegielnia może być odrębną miejscowością, zarówno samodzielną jak i częścią grupy miejscowości o tej samej nazwie, może też znajdować się w obrębie większej miejscowości."@pl ;
-                            rdfs:isDefinedBy "Brickyard (locality) is a settlement, where a brickyard (a building and a factory) plays the most important role."@en ,
-                                             "Cegielnia (miejscowość) jest to osada, w której główną rolę odrywa cegielnia (obiekt)."@pl ;
-                            rdfs:label "brickyard"@en ,
-                                       "cegielnia"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Ziegelei"@de ,
-                                                                              "Ziegelscheune"@de ,
-                                                                              "cegielnica"@pl ,
-                                                                              "кирпичный завод"@ru ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "brickyard"@en ,
-                                                                            "cegielnia"@pl ;
-                            ontohgis:hasExternalIdentifier "11"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_110
@@ -10759,27 +10656,7 @@ ontohgis:settlement_type_110 rdf:type owl:Class ;
                                              [ rdf:type owl:Restriction ;
                                                owl:onProperty ontohgis:hasProperFunction ;
                                                owl:hasValue ontohgis:function1
-                                             ] ;
-                             dct:creator ontohgis:person_3 ;
-                             rdfs:comment "O odrębności wójtostwa decyduje kryterium nazewnicze, które jest efektem jego statusu prawnego."@pl ,
-                                          "Vogt-owned-settlement is distinguished on the basis of its name, which results from its legal status."@en ;
-                             rdfs:isDefinedBy "Vogt-owned-settlement is the area of land owned by the vogt (ger Schultheiß) which is either a separate locality or a separate part of another locality."@en ,
-                                              "Wójtostwo to obszar zajmowany przez ziemię należącą do sołtysa (wójta), będący osobną miejscowością lub wydzieloną częścią miejscowości."@pl ;
-                             rdfs:label "vogt-owned-settlement"@en ,
-                                        "wójtostwo"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "die Vogtei"@de ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "grunt"@pl ,
-                                                                               "majątek"@pl ,
-                                                                               "posiadłość"@pl ,
-                                                                               "sołectwo"@pl ,
-                                                                               "zagroda"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "vogt-owned-settlement"@en ,
-                                                                             "wójtostwo"@pl ;
-                             ontohgis:hasExternalIdentifier "110"^^xsd:string ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 ,
-                                                    ontohgis:person_9 .
+                                             ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_112
@@ -10794,20 +10671,7 @@ ontohgis:settlement_type_112 rdf:type owl:Class ;
                                                  ] ;
                              rdfs:subClassOf ontohgis:object_1000 ,
                                              ontohgis:settlement_type_1000 ,
-                                             ontohgis:settlement_type_3008 ;
-                             dct:creator ontohgis:person_8 ;
-                             rdfs:comment "Część przysiółka jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Części przysiółków to 6 obiektów: 3 w woj. małopolskim, po 1 w woj. mazowieckim, kujawsko-pomorskim i wielkopolskim."@pl ,
-                                          "Part of a hamlet is a separate settlement unit, a kind of locality, it always has a particular name. There are 6 parts of the hamlets according to National Register of Geographic Names (pl \"Państwowy Rejestr Nazwy Geograficznych\"): 3 in Małopolskie voivodship, 1 in Mazowieckie , Kuyawsko-Pomorskie, and Wielkopolskie voivodships."@en ;
-                             rdfs:isDefinedBy "Część przysiółka jest to miejscowość stanowiąca integralną część miejscowości podstawowej przysiółka, jest wydzielona administracyjnie, ale należy do jednostki nadrzędnej."@pl ,
-                                              "Part of a hamlet is an integral part of the main locality a hamlet; it is administratively separated, but belongs to the superior locality."@en ;
-                             rdfs:label "część przysiółka"@pl ,
-                                        "part of a hamlet"@en ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "część przysiółka"@pl ,
-                                                                             "part of a hamlet"@en ;
-                             ontohgis:hasExternalIdentifier 112 ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
+                                             ontohgis:settlement_type_3008 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_113
@@ -10816,248 +10680,32 @@ ontohgis:settlement_type_113 rdf:type owl:Class ;
                                              [ rdf:type owl:Restriction ;
                                                owl:onProperty ontohgis:hasProperFunction ;
                                                owl:hasValue ontohgis:function3
-                                             ] ;
-                             dct:creator ontohgis:person_2 ;
-                             rdfs:comment "At least untill the 13th century, a gord was a central and usually the only element of a city or town indicated in written historical sources, which is why these may be considered as identical for this period; after location, the gord became one of many facilities in a city or a town, usually situated on peripheries, sometimes converted into a castle."@en ,
-                                          "Gords are characteristic mostly for the High Middle Ages, when documents were written in Latin, despite the fact that Latin does not know a proper notion for this kind of settlement unit. Expressions with a different, relatively similar, meaning had been used to describe the gord, i.e. a city (lat civitas), or a castle (lat arx, castrum). In younger historical German sources “gród” was called Burg, the expression meaning both a gord and a castle. Researchers consider “gord” as an endemic and specifically Slavic phenomenon."@en ,
-                                          "Grody są charakterystyczne przede wszystkim dla pełnego średniowiecza, gdy językiem źródeł była łacina - a w niej nie wykształcił się w ogóle termin odpowiadający tej jednostce osadniczej. Określano ją więc za pomocą pojęć o odmiennym, względnie podobnym znaczeniu, jak miasto (civitas), zamek (arx, castrum). Z kolei w późniejszych źródłach niemieckich odpowiadał mu termin Burg, oznaczający zarówno gród, jak również zamek. W literaturze przedmiotu gród jest traktowany jako zjawisko specyficznie słowiańskie."@pl ,
-                                          "Przynamniej do XIII w. gród stanowił centralną i zwykle jedyną uchwytną źródłowo część miasta, więc dla tego okresu może być z nim utożsamiany; po lokacji stawał się jednym z obiektów w mieście, zwykle peryferyjnym, niejednokrotnie zamienianym w zamek."@pl ;
-                             rdfs:isDefinedBy "Gord is a medieval or – in eastern territories – early modern settlement with revetments and stockades."@en ,
-                                              "Średniowieczna lub, na terenach wschodnich, wczesnonowożytna osada z obwarowaniami drewniano-ziemnymi."@pl ;
-                             rdfs:label "gord"@en ,
-                                        "gród"@pl ;
-                             rdfs:seeAlso <http://dbpedia.org/page/Gord_(archaeology)> ,
-                                          <https://www.wikidata.org/wiki/Q88598> ,
-                                          "t. 2, s. 168 (hasło \"Grodzisko\"): \"Grody to obiekty sztucznie ogrodzone w celach obronnych. Pojęcie to obejmuje wszelkiego rodzaju miejsca obronne, jak wsie, miasta, ośrodki administracyjne, wojskowe i inne schronienia przygotowane do obrony. W średniowieczu grodami nazywano też miasta\"."@pl ,
-                                          "t. 2, s. 637: \"pierwotnie osada obronna, ogrodzona palisadą lub obwałowana\""@pl ,
-                                          "t. 6, s. 22: \"miejsce obronne w znaczeniu późniejszym tyle co \"zamek\", \"miasto\"\""@pl ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Burg"@de ,
-                                                                               "arx"@la ,
-                                                                               "castrum"@la ,
-                                                                               "civitas"@la ,
-                                                                               "gorod"@ru ,
-                                                                               "grodzisko"@pl ,
-                                                                               "grodzisko (pol, zamek (pl), Burg (de), gorod (ru), civitas (lat), arx (lat), castrum (lat)" ,
-                                                                               "zamek"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "gord"@en ,
-                                                                             "gród"@pl ;
-                             ontohgis:hasExternalIdentifier "113"^^xsd:string ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_113 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 2, s. 168 (hasło \"Grodzisko\"): \"Grody to obiekty sztucznie ogrodzone w celach obronnych. Pojęcie to obejmuje wszelkiego rodzaju miejsca obronne, jak wsie, miasta, ośrodki administracyjne, wojskowe i inne schronienia przygotowane do obrony. W średniowieczu grodami nazywano też miasta\"."@pl ;
-   rdfs:isDefinedBy ontohgis:document_139
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_113 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 2, s. 637: \"pierwotnie osada obronna, ogrodzona palisadą lub obwałowana\""@pl ;
-   rdfs:isDefinedBy ontohgis:document_138
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_113 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 6, s. 22: \"miejsce obronne w znaczeniu późniejszym tyle co \"zamek\", \"miasto\"\""@pl ;
-   rdfs:isDefinedBy ontohgis:document_140
- ] .
+                                             ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_114
 ontohgis:settlement_type_114 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_50 ;
-                             dct:creator ontohgis:person_2 ;
-                             rdfs:comment "Chronologically, a castle with its functions was preceded by a gord (non-brick, without buildings having both defensive and residential functions), while its successor was a palace (with defensive functions reduced), and a fortress (is was not necessarily a densely built-up structure, and there was no buildings with both defensive and residential functions). During the Early Modern era, military functions of castles were diminishing, but they continued to be residences. Newly established ones in their form imitated defensive buildings and due to this feature were called castles."@en ,
-                                          "Chronologicznie funkcjonalnym poprzednikiem zamku był gród (niemurowany i bez budynków łączących funkcje obronne i rezydencjonalne), a następcą pałac (bez funkcji obronnych) i twierdza (nie musiała być założeniem zwartym i bez budynków łączących funkcje obronne i rezydencjonalne). W epoce nowożytnej i później zamki w coraz mniejszym stopniu pełniły funkcje militarne, ale zachowywały ciągłość funkcji rezydencjonalnych lub, nowopowstałe, w architekturze naśladowały budowle obronne i z tego względu były nazywane zamkami."@pl ;
-                             rdfs:isDefinedBy "Castle is a brick, densely built-up, closed, usually complex structure, within which at least some buildings have both defensive and residential functions; built in the Middle Ages or later but then in a form referring to that period."@en ,
-                                              "Murowane, zwarte, zamknięte, zwykle wieloczłonowe założenie, w którym przynajmniej część budynków pełni funkcje zarazem obronne i rezydencjonalne; powstałe w średniowieczu lub nawiązujące formą do tej epoki."@pl ;
-                             rdfs:label "castle"@en ,
-                                        "zamek - obiekt"@pl ;
-                             rdfs:seeAlso <http://dbpedia.org/ontology/Castle> ,
-                                          <http://linkedgeodata.org/page/ontology/Castle> ,
-                                          <http://vocab.getty.edu/aat/300006891> ,
-                                          <https://www.wikidata.org/wiki/Q23413> ,
-                                          "miejsce obronne, twierdza"@pl ,
-                                          "od średniowiecza do w. XVII obronna siedziba pana feudalnego, ośrodek władzy; w XVII w. i później królewska, książęca lub magnacka rezydencja miejska lub pozamiejska"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "Burg"@de ,
-                                                                            "Schloss"@de ,
-                                                                            "castellum"@la ,
-                                                                            "castrum"@la ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "arx"@la ,
-                                                                               "forteca"@pl ,
-                                                                               "gród"@pl ,
-                                                                               "pałac"@pl ,
-                                                                               "twierdza"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "castle"@en ,
-                                                                             "zamek"@pl ;
-                             ontohgis:hasExternalIdentifier "114"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_114 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "miejsce obronne, twierdza"@pl ;
-   rdfs:isDefinedBy ontohgis:document_2
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_114 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "od średniowiecza do w. XVII obronna siedziba pana feudalnego, ośrodek władzy; w XVII w. i później królewska, książęca lub magnacka rezydencja miejska lub pozamiejska"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
+                             rdfs:subClassOf ontohgis:object_50 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_115
 ontohgis:settlement_type_115 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_23 ;
-                             dct:creator ontohgis:person_5 ;
-                             rdfs:comment "Port morski określa funkcję, jako pełni miejscowość, np. Gdynia jest miastem portowym (określenie z Bystrzyckiego), ale „port” (niekoniecznie morski) również może być miejscowością (patrz: Koeniglicher Hafen k. Torunia). Niektóre portowe miasta niemieckie zawierają „port” (niem. „-hafen”) w nazwie własnej (np. Osternothafen dziś: Chorzelin, id prng: 178058)."@pl ,
-                                          "Sea harbour defines the function of the locality, e.g. Gdynia is a \"harbour city\" (in Bystrzycki's register), but the \"harbour\" (not necessarily at sea) may also be a locality (see: Koeniglicher Hafen near Toruń). Some harbours in Germany contain a \"harbour\" (German \"-hafen\") suffix in their own name (e.g. Osternothafen today: Chorzelin, id :: prng 178058)."@en ;
-                             rdfs:isDefinedBy "Port morski to przybrzeżny obszar wodny wraz z infrastrukturą przeznaczony dla obsługi statków."@pl ,
-                                              "Sea harbour is an area consisting of coastal waters together with artificial structures designed for the ship service."@en ;
-                             rdfs:label "port morski - obiekt"@pl ,
-                                        "sea harbour"@en ;
-                             rdfs:seeAlso <http://dbpedia.org/ontology/Port> ,
-                                          <https://www.wikidata.org/wiki/Q15310171> ,
-                                          "przybrzeżny obszar wodny, odpowiednio pogłębiony, osłonięty przed wiatrem i falą, przeznaczony dla postoju statków, wyposażony w specjalne urządzenia służące do ich załadowywania, wyładowywania, zaopatrzenia i naprawy; miasto  nabrzeżne, w którym jest także miejsce postoju statków."@pl ,
-                                          "t. 2, cz. 2. s. 929: część można między ziemią zamknięta, do którey okręty wchodzą o od burzy morskiey bezpieczeństwo znayduią"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "port morski"@pl ,
-                                                                             "sea harbour"@en ;
-                             ontohgis:hasExternalIdentifier "115"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 ,
-                                                    ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_115 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "przybrzeżny obszar wodny, odpowiednio pogłębiony, osłonięty przed wiatrem i falą, przeznaczony dla postoju statków, wyposażony w specjalne urządzenia służące do ich załadowywania, wyładowywania, zaopatrzenia i naprawy; miasto  nabrzeżne, w którym jest także miejsce postoju statków."@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_115 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 2, cz. 2. s. 929: część można między ziemią zamknięta, do którey okręty wchodzą o od burzy morskiey bezpieczeństwo znayduią"@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
+                             rdfs:subClassOf ontohgis:object_23 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_117
 ontohgis:settlement_type_117 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_50 ;
-                             dct:creator ontohgis:person_5 ;
-                             rdfs:comment "Although tourist shelter is nowadays classified as a kind of village (PRNG, DBTO10k), it seems that the tourist shelters were not considered localites in the period of our interest. This is due to the lack of this category in Bystrzycki's register, as well as the way of presentation on the maps: without the particular name, only symbol and explanatory abbreviation. Conceptually, this category is similar to shepherd's huts and inns (see: example)."@en ,
-                                          "Mimo że dziś figuruje jako rodzaj miejscowości (PRNG, BDOT10k), wydaje się, że schronisko turystyczne nie było w interesującym nas okresie uznawane za miejscowość. Świadczy o tym brak wyróżnienia tej kategorii w spisie Bystrzyckiego, jak również sposób prezentacji na mapach: bez nazwy własnej, jedynie sygnatura i skrótem objaśniającym. Pojęciowo kategoria zbliżona do szałasów pasterskich i karczem (patrz przykład)."@pl ;
-                             rdfs:isDefinedBy "Schronisko turystyczne to budynek na szlaku turystycznym służący jako miejsce odpoczynku i noclegu dla turystów."@pl ,
-                                              "Tourist shelter is a building on the tourist trail that serves as a place of rest and accommodation for tourists."@en ;
-                             rdfs:label "schronisko turystyczne - obiekt"@pl ,
-                                        "tourist shelter"@en ;
-                             rdfs:seeAlso <http://dbpedia.org/page/Mountain_hut> ,
-                                          <https://pzgik.geoportal.gov.pl/ontologies/prng/schroniskoTurystyczne> ,
-                                          <https://www.wikidata.org/wiki/Q182676> ,
-                                          "1] miejsce, gdzie można się schronić, czuć bezpiecznie, schronienie; [2] budynek położony na szlaku turystycznym z dala od osiedli ludzkich, służący jako miejsce odpoczynku i noclegu dla turystów (podróżnych); [3] przytułek, zakład dla bezdomnych, starców"@pl ,
-                                          "budynek na szlaku turystycznym służący jako miejsce odpoczynku i noclegu dla turystów (kategorie: budynki, budowle i urządzenia; kompleksu użytkowania terenu, miejscowości)"@pl ,
-                                          "t. 5, s. 201 – mieysce do schronienia"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "karczma"@pl ,
-                                                                               "schronisko"@pl ,
-                                                                               "schronisko górskie"@pl ,
-                                                                               "stacja turystyczna"@pl ,
-                                                                               "szałas"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "schronisko turystyczne"@pl ,
-                                                                             "tourist shelter"@en ;
-                             ontohgis:hasExternalIdentifier "117"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_117 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "1] miejsce, gdzie można się schronić, czuć bezpiecznie, schronienie; [2] budynek położony na szlaku turystycznym z dala od osiedli ludzkich, służący jako miejsce odpoczynku i noclegu dla turystów (podróżnych); [3] przytułek, zakład dla bezdomnych, starców"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_117 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "budynek na szlaku turystycznym służący jako miejsce odpoczynku i noclegu dla turystów (kategorie: budynki, budowle i urządzenia; kompleksu użytkowania terenu, miejscowości)"@pl ;
-   rdfs:comment ontohgis:document_9
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_117 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 5, s. 201 – mieysce do schronienia"@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
+                             rdfs:subClassOf ontohgis:object_50 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_118
 ontohgis:settlement_type_118 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_23 ;
-                             dct:creator ontohgis:person_5 ;
-                             rdfs:comment "Functional distinctivness - clearly defined (passenger services).Morphological distinctiveness - on the maps, mostly as a non-scale symbols and an explanatory annotation.Spatial distinctivness - depending on the location of the railway line with the respect of locality, stations are either at a distance (often they have a given name, such as a town and the number of houses) or in the area of the locality (without a proper name, only a symbol and an explanatory annotation).Railway station can be part of a locality (Czekanów) or a separate locality (Chrośnica), then spatially distinct. If the station is located far away from the locality, then on the MGI maps it can be supplemeted by information about number of houses, not just the explanatory annotation (pol \"st.\"). The name of the station is never a proper name name but only the name of the main locality."@en ,
-                                          "Odrębność funkcjonalna – jasno określona (obsługa podróżnych).Odrębność morfologiczna – najczęściej na mapach jako znak nieskalowy i podpis objaśniający.Odrębność przestrzenna – w zależności od położenia linii kolejowej względem miejscowości stacje znajdują się albo w oddaleniu (wtedy często mają podaną nazwę, taką jak miejscowość oraz liczbę domów) lub na obszarze miejscowości (bez nazwy; tylko sygnatura i skrót objaśniający).Stacja kolejowa może być częścią miejscowości (Czekanów) albo osobną miejscowością (Chrośnica) wyodrębnioną przestrzennie. Jeżeli stacja leży w oddaleniu od głównej miejscowości (wówczas na mapie WIG ma podaną liczbę domów, a nie tylko skrót objaśniający „st.”). Nazwa stacji nigdy nie jest nazwą własną, a jedynie nazwą głównej miejscowości."@pl ;
-                             rdfs:isDefinedBy "Stacja kolejowa to obszar, gdzie rozmieszczone są budowle związane z obsługą pasażerów kolei naziemnych."@pl ,
-                                              "The railway station is an area where facilities related to the service of ground railway passengers are located."@en ;
-                             rdfs:label "railway station"@en ,
-                                        "stacja kolejowa - obiekt"@pl ;
-                             rdfs:seeAlso "#BDOT10k, s. 154 – Obszar, na którym rozmieszczone są budowle (budynek stacyjny, magazyny, przechowalnia bagażu, perony, parkingi itp.), związane z obsługą pasażerów kolei naziemnych i przeładunkiem towarów (klasa obiektów: kompleks komunikacyjny)"@pl ,
-                                          "miejsce, gdzie zatrzymują się pociągi"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "Haltestation (de)" ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "przystanek kolejowy (pl), dworzec kolejowy (pl)" ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "railway station"@en ,
-                                                                             "stacja kolejowa"@pl ;
-                             ontohgis:hasExternalIdentifier "118"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_118 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "miejsce, gdzie zatrzymują się pociągi"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
+                             rdfs:subClassOf ontohgis:object_23 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_119
 ontohgis:settlement_type_119 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_23 ;
-                             dct:creator ontohgis:person_5 ;
-                             rdfs:comment "Functional distinctivness - clearly defined (passenger services).Morphological distinctiveness - most often on topographic maps as a non-scale symbol or an explanatory annotation, usually without a proper name (only an abbreviation).Spatial distinctivness - depending on the location of the railway line with respect to the locality, the stops are either located at a distance (then they often have a proper name, the same as a locality) or within the area of the locality (no particular name, only symbol or an explanatory annotation). A railway station should rather not be treated as a locality, unless in exceptional cases, when all the constitutive conditions of localities are met."@en ,
-                                          "Odrębność funkcjonalna – jasno określona (obsługa podróżnych).Odrębność morfologiczna – najczęściej na mapach jako znak nieskalowy obszaru przystanku i podpis objaśniający, przeważnie bez nazwy własnej (jedynie skrót).Odrębność przestrzenna – w zależności od położenia linii kolejowej względem miejscowości przystanki znajdują się albo w oddaleniu (wtedy często mają podaną nazwę, taką jak miejscowość) lub na obszarze miejscowości (bez nazwy; tylko sygnatura i skrót objaśniający). Przystanek kolejowy raczej nie powinien być traktowany jako miejscowość, chyba że w wyjątkowych przypadkach, gdy spełnione są wszystkie warunki konstytutywne miejscowości."@pl ;
-                             rdfs:isDefinedBy "A train stop is a stopping place for trains enabling travelers to enter or leave the train."@en ,
-                                              "Przystanek kolejowy to miejsce zatrzymywania się pociągów umożliwiające podróżnym wejście lub opuszczenie pociągu."@pl ;
-                             rdfs:label "przystanek kolejowy - obiekt"@pl ,
-                                        "train stop"@en ;
-                             rdfs:seeAlso "#BDOT10k, s. 166 – miejsce zatrzymywania się pociągów, umożliwiające podróżnym wejście lub opuszczenie pociągu (klasa obiektów: obiekt związany z komunikacją)"@pl ,
-                                          "mała stacja kolejowa przeznaczona tylko dla ruchu pasażerskiego"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "Haltepunkt (de)" ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Stacja kolejowa (pl), dworzec kolejowy (pl)" ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "przystanek kolejowy"@pl ,
-                                                                             "train stop"@en ;
-                             ontohgis:hasExternalIdentifier "119"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_119 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "mała stacja kolejowa przeznaczona tylko dla ruchu pasażerskiego"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
+                             rdfs:subClassOf ontohgis:object_23 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_12
@@ -11076,323 +10724,32 @@ ontohgis:settlement_type_12 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function8
-                                            ] ;
-                            dct:creator ontohgis:person_4 ;
-                            rdfs:comment "It is very unusual to classify a sugar factory or refinery as a separate locality, most often it is a part of a locality."@en ,
-                                         "W niezwykle rzadkich przypadkach cukrownia może być odrębną miejscowością, zazwyczaj jest częścią miejscowości."@pl ;
-                            rdfs:isDefinedBy "Cukrownia (miejscowość) jest to osada, w której główną rolę odgrywa cukrownia (obiekt)."@pl ,
-                                             "Sugar rafinery (a locality) is a settlement with a sugar factory or refinery (a factory) as the most important element."@en ;
-                            rdfs:label "cukrownia"@pl ,
-                                       "sugar factory"@en ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "die Zuckerfabrik"@de ,
-                                                                              "die Zuckersiederei"@de ,
-                                                                              "Сахарный завод"@ru ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "cukrownia"@pl ,
-                                                                            "sugar factory"@en ;
-                            ontohgis:hasExternalIdentifier "12"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_120
 ontohgis:settlement_type_120 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_23 ;
-                             dct:creator ontohgis:person_6 ;
-                             rdfs:comment "A church could be a separate unit (from adjacent settlements) distinguished by a particular name and morphology."@en ,
-                                          "W analizowanych przypadkach kościół mógł stanowić odrębną (od sąsiadujących) nazewniczo i morfologicznie jednostkę osadniczą."@pl ;
-                             rdfs:isDefinedBy "A church (in architecture) is a building used by a religious community to meet and listen to the Word of God, for preaching, private prayers or to celebrate rituals."@en ,
-                                              "Kościół (w kontekście architektonicznym) jest to budynek, gdzie wspólnota religijna gromadzi się na słuchanie słowa Bożego, wspólną lub prywatną modlitwę oraz celebrację sakramentów."@pl ;
-                             rdfs:label "church"@en ,
-                                        "kościół - obiekt"@pl ;
-                             rdfs:seeAlso <http://linkedgeodata.org/ontology/BuildingChurch> ,
-                                          <http://plwordnet.pwr.wroc.pl/wordnet/3210a0be-28e9-11eb-8b1d-fb60577b06bc> ,
-                                          <https://dbpedia.org/ontology/Church> ,
-                                          <https://www.wikidata.org/wiki/Q16970> ,
-                                          "2. «budynek, miejsce modlitwy chrześcijan»"@pl ,
-                                          "t. 11, s. 57-68: II. Budowla sakralna; 1. Świątynia chrześcijańska, zwłaszcza katolicka; templum--; aedes, fanum--; ecclesia--; aedes sacra--; sacrum--; domus, sedes sacra--; delubrum, dominicum, domus Dei, martyrium, sacrarium ritus Christiani--. 3. Świątynia mahometańska; meczet--. 4. Świątynia pogańska, delubrum--; aedes, oraculum, templum--; templum idolorum--; idolium--; domus--; aedes sacra, fanum, penetralia, sessimonium deorum--. 6. n-loc [nazwa miejsca] : -- »Czerwony Kościoł«"@pl ,
-                                          "t. 3, s. 360-362: 1. Świątynia (nie tylko chrześcijańska), dom boży, templum, aedes sacra--. 2. swoista jednostka prawna związana z określonym kościołem (parafia, diecezja itd.), corpus paroeciae vel dioecesis (ad certam quandam ecclesiam pertinens)."@pl ,
-                                          "t. 9, kol. 1025: budynek poświęcony (dedykacja lub benedykcja) w obrzędzie liturg. przez biskupa, gdzie wspólnota ochrzczonych (—> Kościół) gromadzi się na słuchanie słowa Bożego, wspólną i prywatną modlitwę oraz celebrację sakramentów, zwł. Eucharystii; miejsce przechowywania Najśw. Sakramentu, a także pochówku(—> krypta, —> konfesja); k. był określany także jako domus ecclesiae, domus orationis, Kyriakon, domus Dei, Dominicum; w kat. obrządkach wsch. nazywany jest —> cerkwią."@pl ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "ecclesia (lat), templum (lat), fanum (lat), aedes (lat), domus Dei (lat), kaplica (pl), cerkiew (pl), świątynia (pl), die Kirche (de)" ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "church"@en ,
-                                                                             "kościół"@pl ;
-                             ontohgis:hasExternalIdentifier "120"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_120 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "2. «budynek, miejsce modlitwy chrześcijan»"@pl ;
-   rdfs:isDefinedBy ontohgis:document_3 ,
-                    <https://sjp.pwn.pl/sjp/kosciol;2474550.html>
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_120 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 11, s. 57-68: II. Budowla sakralna; 1. Świątynia chrześcijańska, zwłaszcza katolicka; templum--; aedes, fanum--; ecclesia--; aedes sacra--; sacrum--; domus, sedes sacra--; delubrum, dominicum, domus Dei, martyrium, sacrarium ritus Christiani--. 3. Świątynia mahometańska; meczet--. 4. Świątynia pogańska, delubrum--; aedes, oraculum, templum--; templum idolorum--; idolium--; domus--; aedes sacra, fanum, penetralia, sessimonium deorum--. 6. n-loc [nazwa miejsca] : -- »Czerwony Kościoł«"@pl ;
-   rdfs:isDefinedBy ontohgis:document_2
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_120 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 3, s. 360-362: 1. Świątynia (nie tylko chrześcijańska), dom boży, templum, aedes sacra--. 2. swoista jednostka prawna związana z określonym kościołem (parafia, diecezja itd.), corpus paroeciae vel dioecesis (ad certam quandam ecclesiam pertinens)."@pl ;
-   rdfs:isDefinedBy ontohgis:document_6
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_120 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 9, kol. 1025: budynek poświęcony (dedykacja lub benedykcja) w obrzędzie liturg. przez biskupa, gdzie wspólnota ochrzczonych (—> Kościół) gromadzi się na słuchanie słowa Bożego, wspólną i prywatną modlitwę oraz celebrację sakramentów, zwł. Eucharystii; miejsce przechowywania Najśw. Sakramentu, a także pochówku(—> krypta, —> konfesja); k. był określany także jako domus ecclesiae, domus orationis, Kyriakon, domus Dei, Dominicum; w kat. obrządkach wsch. nazywany jest —> cerkwią."@pl ;
-   rdfs:isDefinedBy ontohgis:document_7
- ] .
+                             rdfs:subClassOf ontohgis:object_23 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_121
 ontohgis:settlement_type_121 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_50 ;
-                             dct:creator ontohgis:person_6 ;
-                             rdfs:comment "In each analysed case, a rectory being a separate settlement, lays in a vicinity of a village, or a town/city with the same name. In cartographical sources, one can find it presented separately, with its proper name, an abbreviation of a category (i.e. pol “pleb.”, which is “rect.”), and distinguished by its morphology. A rectory differs slightly from the house of a provost, but we leave this difference aside."@en ,
-                                          "We wszystkich analizowanych przypadkach jeżeli plebania jest odrębną miejscowością, to znajduje się w pobliżu wsi, miasta lub osady o tej samej nazwie. W ujęciu kartograficznym wyodrębniona przez nazwę własną, skrót kategorii (np. pleb.) oraz morfologicznie. Plebania różni się nieco od probostwa, gdyż pleban nie jest tożsamy z proboszczem, ale różnicę tę pomijamy."@pl ;
-                             rdfs:isDefinedBy "A rectory is a house or a group of buildings organised for a home for a provost supervising other priests living with him together with other people responsible for its maintenance."@en ,
-                                              "Plebania jest to dom lub zespół zabudowań przeznaczony do mieszkania dla plebana, podległych mu księży i innych osób zajmujących się jego obsługą."@pl ;
-                             rdfs:label "plebania - obiekt"@pl ,
-                                        "rectory"@en ;
-                             rdfs:seeAlso <http://dbpedia.org/page/Clergy_house> ,
-                                          <http://vocab.getty.edu/aat/300005639> ,
-                                          <https://www.wikidata.org/wiki/Q607241> ,
-                                          "dom należący do parafii, przeznaczony na mieszkanie dla proboszcza"@pl ,
-                                          "t. 2, cz. 2, s. 732: Pleban -- Plebania, -ii, ż., urząd plebański abo beneficjum --; Dochód plebański, ut dobra --; plebaniia, dom plebański, die Pfarrwohnung, die Pfarre. J ksiądz widzimy, plebaniią rzadki Buduie, że kto inszy weźmie po nim spadki. Pot. Pocz. 475 (Slo. fara; Hg. plebania; Cro. plebania; Vd. faroush; Ross. приходъ (cf. przychód)."@pl ,
-                                          "t. 24, s. 326: 1. Domostwo plebana -- ; flaminia -- ; parochia, plebanatus -- ; curionis domus, curionium --; 2. Terytorium będące pod opieką plebana; także urząd i dochody z niego; parochia --; plebanatus --; curionatus, curionium -- ; 2a. Wierni należący do parafii --. Synonimy: probostwo, parafija."@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "Pfarrwohnung"@de ,
-                                                                            "curionis domus"@la ,
-                                                                            "dom plebański"@pl ,
-                                                                            "pastorówka"@pl ,
-                                                                            "plebanatus"@la ,
-                                                                            "popówka"@pl ,
-                                                                            "probostwo"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Pfarre"@de ,
-                                                                               "curionatus"@la ,
-                                                                               "curionium"@la ,
-                                                                               "parafia"@pl ,
-                                                                               "parochia"@la ,
-                                                                               "wikariatka"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "plebania"@pl ,
-                                                                             "rectory"@en ;
-                             ontohgis:hasExternalIdentifier "121"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_121 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "dom należący do parafii, przeznaczony na mieszkanie dla proboszcza"@pl ;
-   rdfs:isDefinedBy ontohgis:document_3
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_121 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 2, cz. 2, s. 732: Pleban -- Plebania, -ii, ż., urząd plebański abo beneficjum --; Dochód plebański, ut dobra --; plebaniia, dom plebański, die Pfarrwohnung, die Pfarre. J ksiądz widzimy, plebaniią rzadki Buduie, że kto inszy weźmie po nim spadki. Pot. Pocz. 475 (Slo. fara; Hg. plebania; Cro. plebania; Vd. faroush; Ross. приходъ (cf. przychód)."@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_121 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 24, s. 326: 1. Domostwo plebana -- ; flaminia -- ; parochia, plebanatus -- ; curionis domus, curionium --; 2. Terytorium będące pod opieką plebana; także urząd i dochody z niego; parochia --; plebanatus --; curionatus, curionium -- ; 2a. Wierni należący do parafii --. Synonimy: probostwo, parafija."@pl ;
-   rdfs:isDefinedBy ontohgis:document_2
- ] .
+                             rdfs:subClassOf ontohgis:object_50 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_122
 ontohgis:settlement_type_122 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_23 ;
-                             dct:creator ontohgis:person_6 ;
-                             rdfs:comment "Kryterium wyróżniającym kościół od kaplicy jest wielkość oraz znaczenie instytucjonalne. Kościół ma charakter świątyni głównej dla wspólnoty wiernych, natomiast kaplica ma znaczenie pomocnicze. Niewielkie wspólnoty wiernych mogły funkcjonować przy kaplicy, kiedy z różnych powodów (brak środków, ograniczenia prawne) nie mogły wybudować lub utrzymać kościoła."@pl ,
-                                          "The criterion that distinguishes the church from the chapel is its size and institutional significance. The church serves as a main temple for the community, while the chapel's role is rather auxiliary. Small communities could use a chapel, when for various reasons (lack of resources, legal restrictions) they could not build or afford a church."@en ;
-                             rdfs:isDefinedBy "Chapel is a separate building (small church) or a separate room with an altar in a church or another building, devoted to religious worship (prayer, worship)."@en ,
-                                              "Kaplica jest to odrębny budynek (mały kościół) lub oddzielne pomieszczenie z ołtarzem w kościele lub innym budynku, przeznaczone do sprawowania kultu religijnego (modlitwy, nabożeństwa)."@pl ;
-                             rdfs:label "chapel"@en ,
-                                        "kaplica - obiekt"@pl ;
-                             rdfs:seeAlso <http://linkedgeodata.org/ontology/BuildingChapel> ,
-                                          <http://plwordnet.pwr.wroc.pl/wordnet/31c75b34-28e9-11eb-89c7-03aa60bf5f82> ,
-                                          <https://www.wikidata.org/wiki/Q108325> ,
-                                          "1. «niewielka budowla sakralna», 2. «oddzielne pomieszczenie z ołtarzem do odprawiania nabożeństw»"@pl ,
-                                          "t. 1, cz 2, s. 955: miejsce bogu poświęcone, w którym obowiązki kościelne za zezwoleniem zwierzchności odprawować się mogą."@pl ,
-                                          "t. 10, s. 81: Mały kościół lub nieduże pomieszczenie z ołtarzem, przeznaczone do uprawiania kultu religijnego; też wydzielona część kościoła (wyraz przeniesiony również na świątynie i pomieszczenia służące innym kultom); sacellum --; aedicula --; sacrarium--; oratorium--; aedes, fanum--; aedis sacrae appendix, augurale, auguratorium, fanulum (s. hanulum), lararium, parvum delubrum"@pl ,
-                                          "t. 8, kol. 676: niewielka budowla kultowa (najczęściej z ołtarzem), wolno stojąca lub związana z większym kompleksem archit., także pomieszczenie, czyli oratorium, miejsce modlitwy liturg. i prywatnej, przeznaczone przez ordynariusza do sprawowanie wszystkich lub niektórych funkcji liturg. dla niewielkiej grupy wiernych, do którego za zgodą kompetentnego przełożonego mogą przychodzić także in. wierni."@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "capella (lat)" ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "kościół (pl), oratorium (pl), świątynia (pl), sacellum (łac), oratorium (lat), aedicula (lat), sacrarium (lat), aedes (lat), fanum (lat), augurale (lat), augurale (lat), auguratorium (lat), fanulum (lat), lararium (lat), delubrum (lat), die Kapelle (de)" ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "chapel"@en ,
-                                                                             "kaplica"@pl ;
-                             ontohgis:hasExternalIdentifier "122"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_122 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "1. «niewielka budowla sakralna», 2. «oddzielne pomieszczenie z ołtarzem do odprawiania nabożeństw»"@pl ;
-   rdfs:isDefinedBy ontohgis:document_3 ,
-                    <https://sjp.pwn.pl/szukaj/kaplica.html>
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_122 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 1, cz 2, s. 955: miejsce bogu poświęcone, w którym obowiązki kościelne za zezwoleniem zwierzchności odprawować się mogą."@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_122 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 10, s. 81: Mały kościół lub nieduże pomieszczenie z ołtarzem, przeznaczone do uprawiania kultu religijnego; też wydzielona część kościoła (wyraz przeniesiony również na świątynie i pomieszczenia służące innym kultom); sacellum --; aedicula --; sacrarium--; oratorium--; aedes, fanum--; aedis sacrae appendix, augurale, auguratorium, fanulum (s. hanulum), lararium, parvum delubrum"@pl ;
-   rdfs:isDefinedBy ontohgis:document_2
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_122 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 8, kol. 676: niewielka budowla kultowa (najczęściej z ołtarzem), wolno stojąca lub związana z większym kompleksem archit., także pomieszczenie, czyli oratorium, miejsce modlitwy liturg. i prywatnej, przeznaczone przez ordynariusza do sprawowanie wszystkich lub niektórych funkcji liturg. dla niewielkiej grupy wiernych, do którego za zgodą kompetentnego przełożonego mogą przychodzić także in. wierni."@pl ;
-   rdfs:isDefinedBy ontohgis:document_7
- ] .
+                             rdfs:subClassOf ontohgis:object_23 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_123
 ontohgis:settlement_type_123 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_23 ;
-                             dct:creator ontohgis:person_6 ;
-                             rdfs:comment "In most analysed cases, if the tar pitch was morphologically distinct, it had the same name as the neighbouring village or another locality. Occasionally it had its proper name."@en ,
-                                          "W większości analizowanych przypadków, jeżeli smolarnia była odrębna morfologicznie, to miała tę samą nazwę, co sąsiadująca wieś lub inna miejscowość. Sporadycznie cechowała ją odrębność nazewnicza."@pl ;
-                             rdfs:isDefinedBy "Obiekt lub zespół obiektów gospodarczych zlokalizowanych w lesie lub jego pobliżu, gdzie w procesie prażenia drewna pozyskiwano smołę i inne produkty np. terpentynę, węgiel drzewny."@pl ,
-                                              "Tar pitch is a facility or a complex of industrial facilities located in or near the forest, where tar was sourced in the process of wood roasting, along with other products, e.g. turpentine, charcoal."@en ;
-                             rdfs:label "smolarnia - obiekt"@pl ,
-                                        "tar pitch"@en ;
-                             rdfs:seeAlso "huta smolana, t. 3, s. 519:"@pl ,
-                                          "prymitywny zakład przemysłowy, gdzie wypraża się z drewna (tzw. karpowin) smołę i otrzymuje terpentynę, spirytus drzewny i inne chemikalia"@pl ,
-                                          "«dawny zakład, w którym się wyprażało z drewna smołę»"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "der Teerofen (de), smolanoi zawod (ru)" ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "terpentyniarnia (pl), osada leśna (pl), dziegciarnia (pl), huta (pl)" ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "smolarnia"@pl ,
-                                                                             "tar pitch"@en ;
-                             ontohgis:hasExternalIdentifier "123"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_123 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "huta smolana, t. 3, s. 519:"@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_123 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "prymitywny zakład przemysłowy, gdzie wypraża się z drewna (tzw. karpowin) smołę i otrzymuje terpentynę, spirytus drzewny i inne chemikalia"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4 ,
-                    <https://sjp.pwn.pl/doroszewski/smolarnia;5498496.html>
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_123 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "«dawny zakład, w którym się wyprażało z drewna smołę»"@pl ;
-   rdfs:isDefinedBy ontohgis:document_3 ,
-                    <https://sjp.pwn.pl/sjp/smolarnia;2522097.html>
- ] .
+                             rdfs:subClassOf ontohgis:object_23 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_124
 ontohgis:settlement_type_124 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_23 ;
-                             dct:creator ontohgis:person_3 ;
-                             rdfs:comment "Inns (localities) are distinguished on the old maps, which is mainly the result of their function. In the historiography, inns are distinguished from \"zajazd\" and \"gościniec\".The former usually served local customers - residents of the village or city, whereas the latter was supposed to serve supra-regional traffic. On the maps, inns are also distinguished by their proper names - e.g. Wygoda or Ostatni Grosz."@en ,
-                                          "Karczmy wyróżniane są na dawnej kartografii, co wynika głównie z pełnionej przez nie funkcji. Warto jednak pamiętać o tym, że w historiografii rozróżnia się pojęcie karczmy oraz zajazdu lub gościńca. Pierwszy obiekt zazwyczaj miał na celu obsługę lokalnych klientów – mieszkańców wsi lub miasta, drugi zaś miał obsługiwać ruch ponadregionalny. Na mapach karczmy wyróżniają także specyficzne nazwy – np. Wygoda lub Ostatni Grosz."@pl ;
-                             rdfs:isDefinedBy "Budynek służący celom gastronomiczno-hotelarskim, zlokalizowany na przedmieściach miast, obrzeżach wsi lub ważnych szlakach komunikacyjnych."@pl ,
-                                              "Inn is a building serving catering and accomodation purposes, located in the suburbs, outskirts of villages, or on important communication routes."@en ;
-                             rdfs:label "inn"@en ,
-                                        "karczma - obiekt"@pl ;
-                             rdfs:seeAlso <http://dbpedia.org/page/Inn> ,
-                                          <https://www.wikidata.org/wiki/Q32860419> ,
-                                          "t. 1, s. 296–298: ‘budynek, w którym warzono, sprzedawano, później głównie szynkowano piwo, miód pitny, od XVI w. gorzałkę; niektóre karczmy, zwłaszcza przy ważniejszych drogach i w miastach, dawały posiłki i obrok dla koni oraz zapewniały nocleg podróżnym (zwano je gościńcami); sprzedawano w nich różne wyroby, głównie spożywcze, rzadziej odzieżowe. Dostarczały też karczmy różnego rodzaju rozrywek, często z muzyką, były miejscem tańców i zabaw. Niekiedy w karczmach odbywał sesje sąd (zwłaszcza wiejski), załatwiano tu sprawy urzędowe podczas popasu dostojników czy pobytu miejscowych oficjalistów [...]’."@pl ,
-                                          "t. 10, s. 136: miejsce wyszynku alkoholu i spotkań okolicznej ludności, przede wszystkim chłopów, także gospoda, dom zajezdny; taberna"@pl ,
-                                          "t. 15, s. 403: ‘budynek służący jako dom zajezdny dla podróżnych, a także miejsce wyszynku oraz spotkań i zabaw miejscowej ludności, wznoszony na przedmieściach większych miast, na rynkach miasteczek, przy uczęszczanych traktach, we wsiach w pobliżu kościoła lub dworu’"@de ,
-                                          """t. 2, s. 264: 1. dom szynkowy (Star.), szynk, szynkownia, gospoda; do na wsi albo przy drodze dla popasu podróżnych, austerja, oberża, dom zajezdny, zajazd’, 
-[por. t. 3, s. 453 hasło: oberża ‘dom gościnny, gospoda, zajazd, karczma, austerja’ i 
-t. 8, s. 106 hasło zajazd, gdzie ‘dom zajezdny, gospoda, austerja, karczma, dom gościnny’]"""@pl ,
-                                          "t. 2, s. 318: dom szynkowy"@pl ,
-                                          "t. 3, s. 564: szynk na wsi, gospoda; dawniej również dom zajezdny, austeria, oberża"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "Gasthof"@de ,
-                                                                            "Krug"@de ,
-                                                                            "Wirthaus"@de ,
-                                                                            "gospoda"@pl ,
-                                                                            "taberna"@la ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "budynek"@pl ,
-                                                                               "gościniec"@pl ,
-                                                                               "gościnny dom"@pl ,
-                                                                               "oberża"@pl ,
-                                                                               "restauracja"@pl ,
-                                                                               "szynkowny dom"@pl ,
-                                                                               "zajazd"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "inn"@en ,
-                                                                             "karczma"@pl ;
-                             ontohgis:hasExternalIdentifier "124"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_124 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 1, s. 296–298: ‘budynek, w którym warzono, sprzedawano, później głównie szynkowano piwo, miód pitny, od XVI w. gorzałkę; niektóre karczmy, zwłaszcza przy ważniejszych drogach i w miastach, dawały posiłki i obrok dla koni oraz zapewniały nocleg podróżnym (zwano je gościńcami); sprzedawano w nich różne wyroby, głównie spożywcze, rzadziej odzieżowe. Dostarczały też karczmy różnego rodzaju rozrywek, często z muzyką, były miejscem tańców i zabaw. Niekiedy w karczmach odbywał sesje sąd (zwłaszcza wiejski), załatwiano tu sprawy urzędowe podczas popasu dostojników czy pobytu miejscowych oficjalistów [...]’."@pl ;
-   rdfs:isDefinedBy ontohgis:document_17
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_124 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 10, s. 136: miejsce wyszynku alkoholu i spotkań okolicznej ludności, przede wszystkim chłopów, także gospoda, dom zajezdny; taberna"@pl ;
-   rdfs:isDefinedBy ontohgis:document_2
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_124 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 15, s. 403: ‘budynek służący jako dom zajezdny dla podróżnych, a także miejsce wyszynku oraz spotkań i zabaw miejscowej ludności, wznoszony na przedmieściach większych miast, na rynkach miasteczek, przy uczęszczanych traktach, we wsiach w pobliżu kościoła lub dworu’"@de ;
-   rdfs:isDefinedBy ontohgis:document_137
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_124 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget """t. 2, s. 264: 1. dom szynkowy (Star.), szynk, szynkownia, gospoda; do na wsi albo przy drodze dla popasu podróżnych, austerja, oberża, dom zajezdny, zajazd’, 
-[por. t. 3, s. 453 hasło: oberża ‘dom gościnny, gospoda, zajazd, karczma, austerja’ i 
-t. 8, s. 106 hasło zajazd, gdzie ‘dom zajezdny, gospoda, austerja, karczma, dom gościnny’]"""@pl ;
-   rdfs:isDefinedBy ontohgis:document_5
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_124 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 2, s. 318: dom szynkowy"@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_124 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 3, s. 564: szynk na wsi, gospoda; dawniej również dom zajezdny, austeria, oberża"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
+                             rdfs:subClassOf ontohgis:object_23 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_125
@@ -11406,80 +10763,12 @@ ontohgis:settlement_type_125 rdf:type owl:Class ;
                                              [ rdf:type owl:Restriction ;
                                                owl:onProperty ontohgis:hasProperFunction ;
                                                owl:hasValue ontohgis:function2
-                                             ] ;
-                             dct:creator ontohgis:person_3 ;
-                             rdfs:isDefinedBy "Ironworks (locality) is a settlement, where the main role is played by an ironworks, an industrial facility."@en ,
-                                              "Osada kuźnicza jest to osada, w której główną rolę pełni kuźnica jako obiekt gospodarczy."@pl ;
-                             rdfs:label "ironworks"@en ,
-                                        "osada kuźnicza"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "Hammer (de), minera (lat), ruda (pl), Hütte (de), Ofen (de), Schmelze (de)" ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "kuźnica"@pl ,
-                                                                               "ruda"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "ironworks"@en ,
-                                                                             "osada kuźnicza"@pl ;
-                             ontohgis:hasExternalIdentifier "125"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
+                                             ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_126
 ontohgis:settlement_type_126 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_23 ;
-                             dct:creator ontohgis:person_3 ;
-                             rdfs:isDefinedBy "Ironworks is a cluster of manufacturing workshops, the main puprpose of which is to melt and manufacture iron."@en ,
-                                              "Zespół warsztatów przemysłowych, których głównym zadaniem jest przetop i obróbka żelaza."@pl ;
-                             rdfs:label "ironworks"@en ,
-                                        "kuźnica - obiekt"@pl ;
-                             rdfs:seeAlso "#Zientara B., Dzieje małopolskiego hutnictwa żelaznego, Warszaw 1954, s. 64‘zespół połączonych warsztatów – dymarki, młotów, kowalichy (piec kowalski i urządzenia służące do produkcji różnych przedmiotów z żelaza)’#Praktyczny słownik współczesnej polszczyzny, red. H. Zgłówkowa, t. 18, s. 369‘dawny typ zakładu hutniczego, w którym żelazo z rud wytapiano za pomocą dymarki i młota napędzanego kołem wodnym’ – dodatkowo inf., że „kuźnice zostały wyparte przez zakłady stosujące procesy wielkopiecowe”#Encyklopedia historii gospodarczej Polski do 1945 r., t. 1, red. A. Mączak:‘w XIII–XVIII w. zespół warsztatów zakładu hutniczego, składający się w zasadzie z dymarki, młota mechanicznego i pieca kowalskiego (kowalichy), niekiedy także ze stęp do drobienia rudy; wszystkie te warsztaty (czasem podwójne) poruszane były energią wodną, uzyskiwaną dzięki budowie zapór na niewielkich rzeczkach. Hamrem (hamernią) zwano wchodzący w skład każdej kuźnicy warsztat obróbki metali, którego głównym urządzeniem był młot mechaniczny z kowadłem; niekiedy jednak przez hamer rozumiano całą kuźnicę. Upowszechnione w Polsce od przełomu XIII/XIV w., stanowiły kuźnice do XVIII w. dominujący typ zakładu hutniczego, tworzącego jednocześnie odrębne przedsiębiorstwo prowadzone przez kuźnika [...]”. Autor hasła B. Zientara"@pl ,
-                                          "t. 11, s. 598: ‘zakład przetapiający i obrabiający żelazo’, ‘warsztat kowalski; miejsce, gdzie się kuje’"@pl ,
-                                          "t. 2, s. 561: utożsamia pojęcia kuźnia i kuźnica, podaje też termin bliskoznaczny kowalnia"@pl ,
-                                          "t. 2, s. 653: ‘zabudowanie mieszczące w sobie jedno albo kilka ognisk, miechy i młoty poruszane przez wodę, gdzie z surowizny przetopionej i oczyszczonej wykuwa się żelazo gotowe; fabryka topienia żelaza i urabiana go w sztaby"@pl ,
-                                          "t. 3, s. 1328: zakład przemysłowy, fabryka wyrobów z żelaza itp. metali; dawniej kuźnia"@pl ,
-                                          "t. 3, s.473–474: ‘warsztat wytopu i obróbki żelaza’"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "Hütte (de), huta (pl), hamer (pl), Hammer (de), minera (lat), hamernia (pl), amernia (pl), oficina ferraria (lat), ferrifonda (lat), ruda (pl)" ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "kuźnia (pl), fryszerka (pl), huta żelaza (pl), zakład przemysłowy (pl), mennica (pl)" ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "ironworks"@en ,
-                                                                             "kuźnica"@pl ;
-                             ontohgis:hasExternalIdentifier "126"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_126 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 11, s. 598: ‘zakład przetapiający i obrabiający żelazo’, ‘warsztat kowalski; miejsce, gdzie się kuje’"@pl ;
-   rdfs:isDefinedBy ontohgis:document_2
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_126 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 2, s. 561: utożsamia pojęcia kuźnia i kuźnica, podaje też termin bliskoznaczny kowalnia"@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_126 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 2, s. 653: ‘zabudowanie mieszczące w sobie jedno albo kilka ognisk, miechy i młoty poruszane przez wodę, gdzie z surowizny przetopionej i oczyszczonej wykuwa się żelazo gotowe; fabryka topienia żelaza i urabiana go w sztaby"@pl ;
-   rdfs:isDefinedBy ontohgis:document_5
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_126 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 3, s. 1328: zakład przemysłowy, fabryka wyrobów z żelaza itp. metali; dawniej kuźnia"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_126 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 3, s.473–474: ‘warsztat wytopu i obróbki żelaza’"@pl ;
-   rdfs:isDefinedBy ontohgis:document_6
- ] .
+                             rdfs:subClassOf ontohgis:object_23 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_127
@@ -11493,652 +10782,67 @@ ontohgis:settlement_type_127 rdf:type owl:Class ;
                                              [ rdf:type owl:Restriction ;
                                                owl:onProperty ontohgis:hasProperFunction ;
                                                owl:hasValue ontohgis:function2
-                                             ] ;
-                             dct:creator ontohgis:person_3 ;
-                             rdfs:comment "Glasswork settlement (ger Hütte) was considered a separate locality, which emerged as consequence of a process in which common names (i.e. huta) gained new meaning, associated with a particular locality. Glasswork settlements were temporary settlements, very often, these were very unstable. When all local resources became exhausted (i.e. woods, sand, limestone), these settlements were moved into a new place. The result was frequent disappearing of glasswork settlements."@en ,
-                                          "Odrębność osadnicza osady hutniczej (od ger Hütte) wynika przede wszystkim z procesu onimizacji, czyli przekształcania nazwy pospolitej (huta) w nazwę własną. Osady hutnicze były często osadami czasowymi, tzn. cechowały się dużą mobilnością. Po wyczerpaniu się pobliskich surowców (drewno, piasek, wapień) przenoszone były w inne miejsca. W związku z tym były to osady zanikające z krajobrazu osadniczego."@pl ;
-                             rdfs:isDefinedBy "Glassworks is a settlement in which the most importan role is played by a glassworks (considered as an factory building)."@en ,
-                                              "Osada hutnicza jest to osada, w której główną rolę pełni huta jako obiekt gospodarczy."@pl ;
-                             rdfs:label "glassworks"@en ,
-                                        "osada hutnicza"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "Hütte (de), Ofen (de), Schmelze (de), Hammer (de)" ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "kuźnica"@pl ,
-                                                                               "ruda"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "glassworks"@en ,
-                                                                             "osada hutnicza"@pl ;
-                             ontohgis:hasExternalIdentifier "127"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
+                                             ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_128
 ontohgis:settlement_type_128 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_23 ;
-                             dct:creator ontohgis:person_3 ;
-                             rdfs:comment "Legal status - ownership diveded between a land lord and a hereditary tenant or an annual tenant."@en ,
-                                          "Status prawny - własność podzielona między pana gruntowego a dzierżawcę dziedzicznego lub dzierżawcę rocznego."@pl ;
-                             rdfs:isDefinedBy "Glassworks is an industrial facility, where major production was glasswork, and later mainly casting and manufacturing metals, e.g. lead, zinc, iron."@en ,
-                                              "Zakład przemysłowy, którego głównym celem była produkcja szkła, a w późniejszym okresie wytop i przetwórstwo rud metali np. ołowiu, cynku, żelaza."@pl ;
-                             rdfs:label "glassworks"@en ,
-                                        "huta - obiekt"@pl ;
-                             rdfs:seeAlso "#J. Olczak, Późnośrednowieczne i nowożytne hutnictwo szkła w Polsce w perspektywie źródeł archeologicznych, „Archeologia Historia Polona”, t.1, 1995, s. 79-86#Wyrobisz A., Szkło w Polsce od XIV do XVII w., Warszawa 1968"@pl ,
-                                          "rozróżnia hutę i hutę szkła. Huta – ‘zakład metalurgiczny, w którym wytapia się metale z rud’, zaś Huta szkła – ‘zakład wytapiający szkło i wytwarzający produkty szklane’"@pl ,
-                                          "t. 2, s. 67: ‘zakład, gdzie robią szkło albo topią metale’"@pl ,
-                                          "zakład lub zespół zakładów przemysłowych produkujących metale z rud, szkło, siarkę i in.’, huty przerabiają nie tylko rudy na surówkę, lecz także surówkę na stal"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "Hütte (de), Ofen (de), Schmelze (de), Hammer (de)" ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "kuźnica (pl), ruda (pl)" ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "glassworks"@en ,
-                                                                             "huta"@pl ;
-                             ontohgis:hasExternalIdentifier "128"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_128 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "rozróżnia hutę i hutę szkła. Huta – ‘zakład metalurgiczny, w którym wytapia się metale z rud’, zaś Huta szkła – ‘zakład wytapiający szkło i wytwarzający produkty szklane’"@pl ;
-   rdfs:isDefinedBy ontohgis:document_3
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_128 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 2, s. 67: ‘zakład, gdzie robią szkło albo topią metale’"@pl ;
-   rdfs:isDefinedBy ontohgis:document_5
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_128 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "zakład lub zespół zakładów przemysłowych produkujących metale z rud, szkło, siarkę i in.’, huty przerabiają nie tylko rudy na surówkę, lecz także surówkę na stal"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
+                             rdfs:subClassOf ontohgis:object_23 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_129
 ontohgis:settlement_type_129 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_50 ;
-                             dct:creator ontohgis:person_5 ;
-                             rdfs:comment "Morphological distinctiveness - usually clear (location in the forest), but there are lodges located in the immediate vicinity of some other localities. Naming distinctiveness - clear from the second half of the 19th c. (previously forester's lodges had no proper names, later not always). Functional distinctiveness - the forester's lodge plays a role in the economy and forest administration."@en ,
-                                          "Odrębność morfologiczna – przeważnie wyraźna (położenie w lesie), ale zdarzają się leśniczówki położone w bezpośrednim sąsiedztwie innych miejscowości. Odrębność nazewnicza – od drugiej połowy XIX wieku (wcześniej bez nazw; później nie zawsze). Odrębność funkcjonalna – leśniczówka pełni rolę związaną z gospodarką i administracją leśną."@pl ;
-                             rdfs:isDefinedBy "Forester's lodge is an area where there is a complex of buildings including a house in which a forester lives, which is the seat of the Forest District's authorities, located in a forest area. Apart from forest management, forester's lodge performs residential functions. Forester's lodge is a locality as long as it has a proper name and is not in the vicinity of another locality."@en ,
-                                              "Leśniczówka (obiekt) to obszar, na którym znajduje się zespół zabudowań obejmujący dom, w którym mieszka leśniczy, stanowiący siedzibę leśnictwa, znajdujący się na terenie leśnym, pełniący oprócz mieszkalnych funkcje związane z gospodarką leśną. Leśniczówka jest miejscowością o ile posiada nazwę własną i nie znajduje się w bezpośrednim sąsiedztwie innej miejscowości."@pl ;
-                             rdfs:label "forester's lodge"@en ,
-                                        "leśniczówka - obiekt"@pl ;
-                             rdfs:seeAlso <http://gov.genealogy.net/types.owl#102> ,
-                                          <http://vocab.getty.edu/aat/300250342> ,
-                                          <https://www.wikidata.org/wiki/Q1425352> ,
-                                          "Dom, zagroda w lesie stanowiąca mieszkanie; mieszkanie leśniczego (zarządca obszaru leśnego stanowiącego leśnictwo) wraz z zabudowaniami gospodarskimi"@pl ,
-                                          "Pojedyncza zagroda służąca leśniczemu i będąca jednocześnie siedzibą leśnictwa"@pl ,
-                                          "t. 2, s. 721: domek w lesie, mieszkanie, zagroda leśniczego a. leśnika"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "Jägerhaus"@de ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Forestrey"@de ,
-                                                                               "Forst Amt"@de ,
-                                                                               "Hegerhaus"@de ,
-                                                                               "gajówka"@pl ,
-                                                                               "nadleśnictwo"@pl ,
-                                                                               "osada leśna"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "forester's lodge"@en ,
-                                                                             "leśniczówka"@pl ;
-                             ontohgis:hasExternalIdentifier "129"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_129 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "Dom, zagroda w lesie stanowiąca mieszkanie; mieszkanie leśniczego (zarządca obszaru leśnego stanowiącego leśnictwo) wraz z zabudowaniami gospodarskimi"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_129 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "Pojedyncza zagroda służąca leśniczemu i będąca jednocześnie siedzibą leśnictwa"@pl ;
-   rdfs:isDefinedBy ontohgis:document_9
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_129 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 2, s. 721: domek w lesie, mieszkanie, zagroda leśniczego a. leśnika"@pl ;
-   rdfs:isDefinedBy ontohgis:document_5
- ] .
+                             rdfs:subClassOf ontohgis:object_50 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_130
 ontohgis:settlement_type_130 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_50 ;
-                             dct:creator ontohgis:person_5 ;
-                             rdfs:comment "Morphological distinctiveness - usually clear (location in the forest), but there are lodges located in the immediate vicinity of some other localities.Naming distinctiveness - clear from the second half of the 19th century (previously forester's lodges had no proper names, later not always).Functional distinctiveness - the forester's lodge plays a role in the economy and forest administration."@en ,
-                                          "Odrębność morfologiczna – przeważnie wyraźna (położenie w lesie), ale zdarzają się gajówki położone w bezpośrednim sąsiedztwie innych miejscowości.Odrębność nazewnicza – od drugiej połowy XIX wieku (wcześniej bez nazw; później nie zawsze). Odrębność funkcjonalna – gajówka pełni rolę związaną z gospodarką leśną."@pl ;
-                             rdfs:isDefinedBy "Forest-guard's lodge is an area comprising a set of buildings including a house in which a forest-guard lives, located in a forest area, performing residential as well as forest management functions. Forest-guard's lodge is a locality as long as it has its own name and is not located in the immediate vicinity of another locality."@en ,
-                                              "Gajówka to obszar na którym znajduje się zespół zabudowań obejmujący dom, w którym mieszka gajowy, znajdujący się na terenie leśnym, pełniący oprócz mieszkalnych funkcje związane z gospodarką leśną. Gajówka jest miejscowością o ile posiada nazwę własną i nie znajduje się w bezpośrednim sąsiedztwie innej miejscowości."@pl ;
-                             rdfs:label "forest-guard's lodge"@en ,
-                                        "gajówka - obiekt"@pl ;
-                             rdfs:seeAlso <http://vocab.getty.edu/aat/300250342> ,
-                                          <https://www.wikidata.org/wiki/Q17087359> ,
-                                          "Budynek, w którym mieszka gajowy (pracownik nadleśnictwa chroniący przydzieloną mu część lasu przed szkodami)"@pl ,
-                                          "Pojedyncza zagroda, zazwyczaj położona w lesie, pełniąca funkcję mieszkania służbowego dla funkcjonariuszy pomocniczej służy leśnej podleśniczych lub gajowych"@pl ,
-                                          "t. 1, s. 793: chatka gajowego"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "Hegerhaus"@de ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Forestrey"@de ,
-                                                                               "Forst Amt"@de ,
-                                                                               "Jägerhaus"@de ,
-                                                                               "leśnictwo"@pl ,
-                                                                               "leśniczówka"@pl ,
-                                                                               "nadleśnictwo"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "forest-guard's lodge"@en ,
-                                                                             "gajówka"@pl ;
-                             ontohgis:hasExternalIdentifier "130"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_130 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "Budynek, w którym mieszka gajowy (pracownik nadleśnictwa chroniący przydzieloną mu część lasu przed szkodami)"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_130 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "Pojedyncza zagroda, zazwyczaj położona w lesie, pełniąca funkcję mieszkania służbowego dla funkcjonariuszy pomocniczej służy leśnej podleśniczych lub gajowych"@pl ;
-   rdfs:isDefinedBy ontohgis:document_9
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_130 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 1, s. 793: chatka gajowego"@pl ;
-   rdfs:isDefinedBy ontohgis:document_5
- ] .
+                             rdfs:subClassOf ontohgis:object_50 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_131
 ontohgis:settlement_type_131 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_50 ;
-                             dct:creator ontohgis:person_5 ;
-                             rdfs:comment """Functional distinctivness - distinguished as a kind of locality in Bystrzycki's register, and on topographic maps as distinct symbol, sometimes with the proper name.
-Morphological and spatial distinctivness - usually a lightouse is a building (structure) within the area of the locality or in its vicinity. 
-If it has its a particular (proper) name, it can be treated as a separate locality (interpretation of maps is necessary, see: Rozewie). Otherwise it is either part of another locality or an object (building/structure) in it (see: Hel, Jastarnia)."""@en ,
-                                          "Odrębność funkcjonalna – wyróżniana jako rodzaj miejscowości u Bystrzyckiego, a na mapach topograficznych odrębnym znakiem, niekiedy z nazwą własną. Odrębność morfologiczna/przestrzenna – przeważnie jest obiektem na obszarze miejscowości lub w niewielkim od niej oddaleniu. Jeżeli posiada nazwę własną może być traktowana jako osobna miejscowość (konieczna interpretacja map; patrz: Rozewie). W przeciwnym razie jest albo częścią innej, większej miejscowości lub obiektem terenowym (budowlą) w niej (patrz: Hel, Jastarnia)."@pl ;
-                             rdfs:isDefinedBy "A lighthouse (a facility) is a building, usually a high tower with a beacon light to guide ships."@en ,
-                                              "Latarnia morska (obiekt) to budowla, najczęściej wysoka wieża służąca jako punkt orientacyjny dla statków."@pl ;
-                             rdfs:label "latarnia morska - obiekt"@pl ,
-                                        "lighthouse"@en ;
-                             rdfs:seeAlso <http://dbpedia.org/ontology/Lighthouse> ,
-                                          <http://linkedgeodata.org/ontology/Lighthouse> ,
-                                          <http://vocab.getty.edu/aat/300007741> ,
-                                          <https://www.wikidata.org/wiki/Q39715> ,
-                                          "wysoka, widoczna z morza wieża, służąca jako punkt orientacyjny dla statków"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "Leuchtturm"@de ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "latarnia morska"@pl ,
-                                                                             "lighthouse"@en ;
-                             ontohgis:hasExternalIdentifier "131"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 ,
-                                                    ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_131 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "wysoka, widoczna z morza wieża, służąca jako punkt orientacyjny dla statków"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
+                             rdfs:subClassOf ontohgis:object_50 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_132
 ontohgis:settlement_type_132 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_50 ;
-                             dct:creator ontohgis:person_6 ;
-                             rdfs:comment "In the analysed cases, the monastery could have been a locality which was separate in terms of name and mophology from the neighbouring ones. The monastery could have been a beginning (a stem) of a larger locality, which would develop around it and transform into a monastery settlement, village, city etc."@en ,
-                                          "W analizowanych przypadkach klasztor mógł stanowić całkowicie odrębną (od sąsiadujących) nazewniczo i morfologicznie miejscowość. Klasztor mógł stanowić zalążek większej miejscowości, która rozwinęła się wokół niego i przekształciła się w osadę klasztorną, wieś, miasto etc."@pl ;
-                             rdfs:isDefinedBy "Klasztor jest to budynek lub zespół budynków przeznaczony do mieszkania dla zakonników lub zakonnic."@pl ,
-                                              "Monastery is a building or a group of buildings where monks and nuns live"@en ;
-                             rdfs:label "klasztor - obiekt"@pl ,
-                                        "monastery"@en ;
-                             rdfs:seeAlso <http://dbpedia.org/ontology/Monastery> ,
-                                          <http://gov.genealogy.net/types.owl#30> ,
-                                          <http://vocab.getty.edu/aat/300000641> ,
-                                          <https://www.wikidata.org/wiki/Q44613> ,
-                                          "1. budynek lub kompleks budynków stanowiących wspólne miejsce zamieszkiwania zakonnic lub zakonników; 2. wspólnota zakonna o określonej regule"@pl ,
-                                          "1. zgromadzenie zakonne; zakon--; 2. budynek lub kompleks budynków zamieszkiwanych przez zakonników (zakonnice) danej reguły"@pl ,
-                                          "t. 1, cz. 2, s. 1010: pomieszkanie zakonnicze"@pl ,
-                                          "t. 10, s. 337: 1. Odosobnione i wyodrębnione spośród innych osiedli ludzkich miejsce zamieszkania zakonników i zakonnic (pojmowane jako budynek lub jego mieszkańcy); odosobnienie; tryb życia klasztornego; w wypadku niektórych zakonów także: szkoła, kolegium; coenobium, monasterium."@pl ,
-                                          "t. 3, s. 282: zabudowanie dla zgromadzenia zakonnego zwykle połączone z kościołem, coenobium, religiosorum domus."@pl ,
-                                          "t. 9, kol. 66-76: zespół budynków lub pomieszczeń mieszkalnych i gospodarczych o różnej strukturze, przeznaczonych do prowadzenia życia pustelniczego (zob. ławra) lub wspólnotowego życia ascetycznego (zob. asceza), występujący w religiach pozachrześcijańskich i chrześcijaństwie. -- Czasem rozbudowane założenia klasztorne tworzyły wręcz miasto, a nawet państwo mnichów (civitas monachorum)"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "Kloster"@de ,
-                                                                            "claustrum"@la ,
-                                                                            "monaster"@pl ,
-                                                                            "monasterium"@la ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "opactwo"@pl ,
-                                                                               "ławra"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "klasztor"@pl ,
-                                                                             "monastery"@en ;
-                             ontohgis:hasExternalIdentifier "132"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_132 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "1. budynek lub kompleks budynków stanowiących wspólne miejsce zamieszkiwania zakonnic lub zakonników; 2. wspólnota zakonna o określonej regule"@pl ;
-   rdfs:isDefinedBy ontohgis:document_3 ,
-                    <https://sjp.pwn.pl/slowniki/klasztor.html>
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_132 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "1. zgromadzenie zakonne; zakon--; 2. budynek lub kompleks budynków zamieszkiwanych przez zakonników (zakonnice) danej reguły"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_132 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 1, cz. 2, s. 1010: pomieszkanie zakonnicze"@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_132 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 10, s. 337: 1. Odosobnione i wyodrębnione spośród innych osiedli ludzkich miejsce zamieszkania zakonników i zakonnic (pojmowane jako budynek lub jego mieszkańcy); odosobnienie; tryb życia klasztornego; w wypadku niektórych zakonów także: szkoła, kolegium; coenobium, monasterium."@pl ;
-   rdfs:isDefinedBy ontohgis:document_2
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_132 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 3, s. 282: zabudowanie dla zgromadzenia zakonnego zwykle połączone z kościołem, coenobium, religiosorum domus."@pl ;
-   rdfs:isDefinedBy ontohgis:document_6
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_132 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 9, kol. 66-76: zespół budynków lub pomieszczeń mieszkalnych i gospodarczych o różnej strukturze, przeznaczonych do prowadzenia życia pustelniczego (zob. ławra) lub wspólnotowego życia ascetycznego (zob. asceza), występujący w religiach pozachrześcijańskich i chrześcijaństwie. -- Czasem rozbudowane założenia klasztorne tworzyły wręcz miasto, a nawet państwo mnichów (civitas monachorum)"@pl ;
-   rdfs:isDefinedBy ontohgis:document_7
- ] .
+                             rdfs:subClassOf ontohgis:object_50 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_133
 ontohgis:settlement_type_133 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_23 ;
-                             dct:creator ontohgis:person_6 ;
-                             rdfs:comment "In most analysed cases, if the sawmill was morphologically distinct, it had the same name as the neighboring village or another locality, such as: forester's lodge. Occasionally it had its particular name."@en ,
-                                          "W większości analizowanych przypadków, jeżeli tartak był odrębny morfologicznie, to miał tę samą nazwę, co sąsiadująca wieś lub inna miejscowość, np. leśniczówka. Sporadycznie cechowała go odrębność nazewnicza."@pl ;
-                             rdfs:isDefinedBy "Obiekt lub zespół obiektów gospodarczych często zlokalizowanych w lesie lub jego pobliżu, gdzie dokonuje się przerobu drewna okrągłego na tarcicę w procesie przecierania (tarcia)."@pl ,
-                                              "Sawmill is an industrial facility often located within or near the forest, where wood is processed into sawn timber in the wiping process."@en ;
-                             rdfs:label "sawmill"@en ,
-                                        "tartak - obiekt"@pl ;
-                             rdfs:seeAlso "#Orgelbrand, t. 14, s. 412: pilarnia, machina do piłowania drzewa, której główną częścią składową jest piła, poruszana siłą wody lub pary. Tartaki istnieją już od wieku XIV, a obecnie stanowią machiny niekiedy bardzo zawiłe, które robotę wykonywają szybko i dokładnie"@pl ,
-                                          "t. 3, s. 607: młyn do tarcia drzew na tarcice, dyle"@pl ,
-                                          "t. 7, s. 29: Pilarnia, młyn do tarcia drzewa na tarcice, dyle: Tartak wodny, parowy"@pl ,
-                                          "zakład przemysłowy zajmujący się przecieraniem drewna na tarcicę"@pl ,
-                                          "«zakład zajmujący się rozpiłowywaniem kłód na tarcicę oraz przerobem tarcicy na różne elementy»"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "das Sägewerk (de), lesopilnyi zawod (ru)" ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "młyn (pl), piła (pl),die Säge (de), osada młyńska (pl), osada leśna (pl)" ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "sawmill"@en ,
-                                                                             "tartak"@pl ;
-                             ontohgis:hasExternalIdentifier "133"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_133 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 3, s. 607: młyn do tarcia drzew na tarcice, dyle"@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_133 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 7, s. 29: Pilarnia, młyn do tarcia drzewa na tarcice, dyle: Tartak wodny, parowy"@pl ;
-   rdfs:isDefinedBy ontohgis:document_5
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_133 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "zakład przemysłowy zajmujący się przecieraniem drewna na tarcicę"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4 ,
-                    <https://sjp.pwn.pl/doroszewski/tartak;5506829.html>
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_133 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "«zakład zajmujący się rozpiłowywaniem kłód na tarcicę oraz przerobem tarcicy na różne elementy»"@pl ;
-   rdfs:isDefinedBy ontohgis:document_3 ,
-                    <https://sjp.pwn.pl/sjp/tartak;2528864.html>
- ] .
+                             rdfs:subClassOf ontohgis:object_23 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_134
 ontohgis:settlement_type_134 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_23 ;
-                             dct:creator ontohgis:person_6 ;
-                             rdfs:comment "In all the analysed cases, in Bystrzycki's register, peat mines had the same names as the locality nearby: village and peat mine, manor and peat mine."@en ,
-                                          "We wszystkich analizowanych przypadkach z tzw. skorowidza Bystrzyckiego z 1931 r. torfiarnie posiadały takie same nazwy jak osada lub osady leżąca obok niej (wieś i torfiarnia, folwark i torfiarnia)."@pl ;
-                             rdfs:isDefinedBy "Peat mine is a mine where a peat is mined"@en ,
-                                              "Torfiarnia (obiekt) jest to kopalnia torfu."@pl ;
-                             rdfs:label "peat mine"@en ,
-                                        "torfiarnia - obiekt"@pl ;
-                             rdfs:seeAlso "kopalnia torfu"@pl ,
-                                          "t. 7, s. 85: kopalnia torfu, torfowisko eksploatowane"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "torfowisko (pl)" ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "peat mine"@en ,
-                                                                             "torfiarnia"@pl ;
-                             ontohgis:hasExternalIdentifier "134"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_134 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "kopalnia torfu"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4 ,
-                    <https://sjp.pwn.pl/doroszewski/torfiarnia>
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_134 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 7, s. 85: kopalnia torfu, torfowisko eksploatowane"@pl ;
-   rdfs:isDefinedBy ontohgis:document_5
- ] .
+                             rdfs:subClassOf ontohgis:object_23 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_135
 ontohgis:settlement_type_135 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_23 ;
-                             dct:creator ontohgis:person_4 ;
-                             rdfs:comment "At the very beginning, breweries had been situated only within bigger settlement unit and had not had an individual name. Some of these had only a name corresponding to the owner's name, which was frequently changed. Subsequently, particular names were assigned to breweries; often in the form of trademarks, however the process of integrating the breweries under one trademark originated relatively early/ quickly. One may not find a difference between brewery and distillery in historical sources."@en ,
-                                          "Browary początkowo mieściły się wyłącznie w obrębie większych jednostek osadniczych i nie miały własnej nazwy, ew. nazwę wywiedzioną od nazwiska właściciela, często zmienianą. Z czasem browary zaczęły mieć własne nazwy, często w postaci znaków handlowych, jednakże dość szybko zaczął się proces łączenia się browarów pod wspólną nazwą. Źródłowo zdarza się brak rozróżnienia gorzelni i browaru."@pl ;
-                             rdfs:isDefinedBy "Brewery is a factory producing beer, as well as a complex of buildings established for production and accomodation for factory workers."@en ,
-                                              "Browar jest to zakład wytwarzający piwo jak również zespół budynków przeznaczonych na cele produkcyjne i mieszkalne dla obsługi zakladu."@pl ;
-                             rdfs:label "brewery"@en ,
-                                        "browar - obiekt"@pl ;
-                             rdfs:seeAlso <http://dbpedia.org/ontology/Brewery> ,
-                                          <http://vocab.getty.edu/aat/300006341> ,
-                                          <https://www.wikidata.org/wiki/Q131734> ,
-                                          "t. 1, cz.12, s. 272: Browar, budynek, gdzie się piwo warzy, piwowarnia, mielcuch"@pl ,
-                                          "t. 2, s. 455-456: budynek, w którym się warzy piwo, piwowarnia"@pl ,
-                                          "zakład produkujący piwo"@pl ,
-                                          "zakład przemysłowy, w którym wyrabia się piwo; wytwórnia piwa"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "Bierbrauerei"@de ,
-                                                                            "Brauerei"@de ,
-                                                                            "Brauhaus"@de ,
-                                                                            "braxatorium"@la ,
-                                                                            "piwowarnia"@pl ,
-                                                                            "пивоварня"@ru ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "mielcuch"@pl ,
-                                                                               "warzelnia"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "brewery"@en ,
-                                                                             "browar - obiekt"@pl ;
-                             ontohgis:hasExternalIdentifier "135"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_135 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 1, cz.12, s. 272: Browar, budynek, gdzie się piwo warzy, piwowarnia, mielcuch"@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_135 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 2, s. 455-456: budynek, w którym się warzy piwo, piwowarnia"@pl ;
-   rdfs:isDefinedBy ontohgis:document_2
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_135 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "zakład produkujący piwo"@pl ;
-   rdfs:isDefinedBy <http://sjp.pwn.pl/slowniki/browar.html> ,
-                    ontohgis:document_3
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_135 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "zakład przemysłowy, w którym wyrabia się piwo; wytwórnia piwa"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
+                             rdfs:subClassOf ontohgis:object_23 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_136
 ontohgis:settlement_type_136 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_23 ;
-                             dct:creator ontohgis:person_4 ;
-                             rdfs:comment "In each case analysed, a brickyard with a particular name has been located near a village, a city or a town, or a settlement with the same name. If it was an integral part of a superior locality, it had not been given a proper name. (One should remember that exporting produced goods outside the area of production was difficult)."@en ,
-                                          "We wszystkich analizowanych przypadkach jeżeli cegielnia jest odrębną miejscowością, to znajduje się w pobliżu wsi, miasta lub osady o tej samej nazwie. Jeśli znajduje się w obrębie większej miejscowości to dość długo nie ma nazwy własnej. (Trudności w eksporcie towaru poza miejsce wyrobu.)"@pl ;
-                             rdfs:isDefinedBy "Brickyard is a factory where bricks and other ceramic building materials and elements are being produced together with a complex of buildings established for production and houses for factory workers."@en ,
-                                              "Cegielnia jest to zakład wytwarzający cegły oraz ew. inne ceramiczne elementy budowlane jak również zespół budynków przeznaczonych na cele produkcyjne i mieszkalne dla obsługi zakładu."@pl ;
-                             rdfs:label "brickyard"@en ,
-                                        "cegielnia - obiekt"@pl ;
-                             rdfs:seeAlso <http://vocab.getty.edu/aat/300006278> ,
-                                          <https://www.wikidata.org/wiki/Q198632> ,
-                                          "t. 1, cz. 1, s. 221: Cegielnia, Cegielnica, budynek z piecem od palenia cegieł, die Ziegelscheune, der Ziegelofen"@pl ,
-                                          "t. 3, s. 142: cegielnia – miejsce wyrobu cegieł"@pl ,
-                                          "wytwórnia cegly oraz innych materiałów budowlanych z gliny: dachówek, sączków (drenów), kafli, klinkierów, płytek itp."@pl ,
-                                          "wytwórnia cegły oraz innych materiałów budowlanych z gliny"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "Ziegelei"@de ,
-                                                                            "cegielnica"@pl ,
-                                                                            "кирпичный завод"@ru ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Ziegelscheune"@de ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "brickyard"@en ,
-                                                                             "cegielnia"@pl ;
-                             ontohgis:hasExternalIdentifier "136"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_136 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 1, cz. 1, s. 221: Cegielnia, Cegielnica, budynek z piecem od palenia cegieł, die Ziegelscheune, der Ziegelofen"@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_136 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 3, s. 142: cegielnia – miejsce wyrobu cegieł"@pl ;
-   rdfs:comment ontohgis:document_2
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_136 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "wytwórnia cegly oraz innych materiałów budowlanych z gliny: dachówek, sączków (drenów), kafli, klinkierów, płytek itp."@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_136 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "wytwórnia cegły oraz innych materiałów budowlanych z gliny"@pl ;
-   rdfs:isDefinedBy <http://sjp.pwn.pl/sjp/cegielnia.html> ,
-                    ontohgis:document_3
- ] .
+                             rdfs:subClassOf ontohgis:object_23 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_137
 ontohgis:settlement_type_137 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_23 ;
-                             dct:creator ontohgis:person_4 ;
-                             rdfs:comment "Mines presented on majority of analysed maps had their individual symbol."@en ,
-                                          "Na wszystkich badanych mapach kopalnie miały własny znak umowny."@pl ;
-                             rdfs:isDefinedBy "A mine is a factory extracting minerals from the earth. It may be connected with a settlement, it may be inhabited by the personnel."@en ,
-                                              "Kopalnia jest to zakład wydobywający z ziemi kopaliny. Może być połączony z osadą, miewa stale zamieszkujący personel."@pl ;
-                             rdfs:label "kopalnia - obiekt"@pl ,
-                                        "mine"@en ;
-                             rdfs:seeAlso <http://dbpedia.org/ontology/Mine> ,
-                                          <http://vocab.getty.edu/aat/300000390> ,
-                                          <https://www.wikidata.org/wiki/Q820477> ,
-                                          "Teren zakładu górniczego, zajmującego się wydobywaniem z ziemi kopalin użytecznych. Ze względu na sposób wydobycia rozróżnia się kopalnie odkrywkowe (naziemne), głębinowe (podziemne) i otworowe."@pl ,
-                                          "t. 1, cz. 2, s. 1077: Kopalnia, miejsce gdzie się iakowe rzeczy kopalne z ziemi dobywają"@pl ,
-                                          "zakład górniczy zajmujący się wydobywaniem z ziemi kopalin"@pl ,
-                                          "zakład górniczy zajmujący się wydobywaniem z ziemi kopalin użytecznych"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "Bergwerk"@de ,
-                                                                            "gruba"@pl ,
-                                                                            "рудник"@ru ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Binge"@de ,
-                                                                               "Bruch"@de ,
-                                                                               "Miene"@de ,
-                                                                               "Schacht"@de ,
-                                                                               "шахта"@ru ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "kopalnia"@pl ,
-                                                                             "mine"@en ;
-                             ontohgis:hasExternalIdentifier "137"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_137 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "Teren zakładu górniczego, zajmującego się wydobywaniem z ziemi kopalin użytecznych. Ze względu na sposób wydobycia rozróżnia się kopalnie odkrywkowe (naziemne), głębinowe (podziemne) i otworowe."@pl ;
-   rdfs:isDefinedBy ontohgis:document_9
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_137 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 1, cz. 2, s. 1077: Kopalnia, miejsce gdzie się iakowe rzeczy kopalne z ziemi dobywają"@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_137 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "zakład górniczy zajmujący się wydobywaniem z ziemi kopalin"@pl ;
-   rdfs:isDefinedBy ontohgis:document_3 ,
-                    <https://sjp.pwn.pl/sjp/kopalnia;2473819.html>
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_137 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "zakład górniczy zajmujący się wydobywaniem z ziemi kopalin użytecznych"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
+                             rdfs:subClassOf ontohgis:object_23 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_138
 ontohgis:settlement_type_138 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_23 ;
-                             dct:creator ontohgis:person_4 ;
-                             rdfs:comment "Cukrownia może mieć własną nazwę, najczęściej powiązaną z nazwą firmy lub znakiem firmowym, ale nie musi. Rzadko zaznaczana na mapach."@pl ,
-                                          "Sugar factory or refinery may have its own name - usually related to the factory name or a trademark - however it is not nocessary. Very seldom, it has been indicated on maps."@en ;
-                             rdfs:isDefinedBy "A sugar factory or refinery is a factory producing sugar, as well as a complex of buildings established for production and accomodation for factory workers."@en ,
-                                              "Cukrownia jest to zakład wytwarzający cukier jak również zespół budynków przeznaczonych na cele produkcyjne i mieszkalne dla obsługi zakładu."@pl ;
-                             rdfs:label "cukrownia - obiekt"@pl ,
-                                        "sugar factory"@en ;
-                             rdfs:seeAlso "fabryka cukru"@pl ,
-                                          "t. 1, cz. 1, s. 327: [Brak hasła „cukrownia”.] Cukrowarz, fabrykant cukru, warzący sok na cukier, derZuckersieder, cf. Cukiernik."@pl ,
-                                          "zakład przemysłowy produkujący cukier"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "die Zuckerfabrik (de), die Zuckersiederei (de) Сахарный завод (ru)" ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "cukrownia"@pl ,
-                                                                             "sugar factory"@en ;
-                             ontohgis:hasExternalIdentifier "138" ,
-                                                            "138"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_138 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "fabryka cukru"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_138 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 1, cz. 1, s. 327: [Brak hasła „cukrownia”.] Cukrowarz, fabrykant cukru, warzący sok na cukier, derZuckersieder, cf. Cukiernik."@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_138 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "zakład przemysłowy produkujący cukier"@pl ;
-   rdfs:isDefinedBy <http://sjp.pwn.pl/sjp/cukrownia.html> ,
-                    ontohgis:document_3
- ] .
+                             rdfs:subClassOf ontohgis:object_23 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_139
 ontohgis:settlement_type_139 rdf:type owl:Class ;
-                             rdfs:subClassOf ontohgis:object_23 ;
-                             dct:creator ontohgis:person_6 ;
-                             rdfs:comment "Distillery may have its own name - usually related to the factory name or a trademark - however it is not nocessary. As a separate locality, it may - however it is not obligatory - be located near a village, a city or a town, or a settlement sharing the same name. One may not find a difference between brewery and distillery in historical sources."@en ,
-                                          "Gorzelnie znajdujące się w obrębie miast mogą, ale nie muszą mieć własnej nazwy, zazwyczaj nazwa ta powiązana jest z nazwą firmy, znakiem firmowym. Jeśli jest odrębną miejscowością to może ale nie musi znajdować się w pobliżu wsi, miasta lub osady o tej samej nazwie. Źródłowo zdarza się brak rozróżnienia gorzelni i browaru."@pl ;
-                             rdfs:isDefinedBy "Distillery is a factory where alcohol and spirits requiring distillation whilst manufacturing are produced."@en ,
-                                              "Gorzelnia jest to zakład wytwarzający spirytus oraz napoje alkoholowe o wysokiej zawartości alkoholu, wymagające w trakcie procesu produkcyjnego destylacji."@pl ;
-                             rdfs:label "distillery"@en ,
-                                        "gorzelnia - obiekt"@pl ;
-                             rdfs:seeAlso <http://vocab.getty.edu/aat/300006346> ,
-                                          <https://www.wikidata.org/wiki/Q1251750> ,
-                                          "t. 1, cz. 2, s. 54: Gorzalnia, gorzelnia, budowanie do palenia gorzałki (pospolicie zowią: browarem, ale borwar na piwo iest.)"@pl ,
-                                          "zakład przemysłowy produkujący alkohol etylowy"@pl ,
-                                          "zakład przemysłowy produkujący spirytus i wódki głównie z kartofli lub zboża"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#altLabel> "Brantweinbrennerei"@de ,
-                                                                            "Brennerei"@de ,
-                                                                            "Brennhaus"@de ,
-                                                                            "Destillerie"@de ,
-                                                                            "gorzalnia"@pl ,
-                                                                            "винокуренныйзавод"@ru ,
-                                                                            "винокурня"@ru ;
-                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "browar"@pl ;
-                             <http://www.w3.org/2004/02/skos/core#prefLabel> "distillery"@en ,
-                                                                             "gorzelnia"@pl ;
-                             ontohgis:hasExternalIdentifier "139"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_139 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 1, cz. 2, s. 54: Gorzalnia, gorzelnia, budowanie do palenia gorzałki (pospolicie zowią: browarem, ale borwar na piwo iest.)"@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_139 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "zakład przemysłowy produkujący alkohol etylowy"@pl ;
-   rdfs:isDefinedBy <http://sjp.pwn.pl/slowniki/gorzelnia.html> ,
-                    ontohgis:document_3
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_139 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "zakład przemysłowy produkujący spirytus i wódki głównie z kartofli lub zboża"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
+                             rdfs:subClassOf ontohgis:object_23 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_17
@@ -12151,27 +10855,7 @@ ontohgis:settlement_type_17 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function4
-                                            ] ;
-                            dct:creator ontohgis:person_5 ;
-                            rdfs:comment "Forest-guard's lodge is a kind of forester's lodge; criteria for distinguishing a forester's lodge, forestry and forest-guard's lodge are unknown (in the context of topographic maps); the term forest-guard's lodge is very rarely used in Bystrzycki's register 1931 (Forest-guard's lodges depicted on MGI maps are forester's lodges in Bystrzycki's register 1931 or are not included in Bystrzycki's register 1931 whereas depicted on MGI maps)."@en ,
-                                         "Gajówka jest rodzajem leśniczówki; kryteria odróżniania leśniczówki, leśnictwa i gajówki są nieznane (w świetle kartografii); termin bardzo rzadko stosowany w skorowidzu Bystrzyckiego z 1931 r. (gajówki na mapach WIG to często leśniczówki w skorowidzu Bystrzyckiego z 1931 r.; gajówki nie ujęte w skorowidzu Bystrzyckiego z 1931 r. występują na mapach WIG)"@pl ;
-                            rdfs:isDefinedBy "Forest-guard's lodge (a locality) is a settlement in which the main role is played by a forest-guard's lodge (a facility). Forest-guard's lodge is a locality as long as it has its own name and is not located in the immediate vicinity of another locality."@en ,
-                                             "Gajówka (miejscowość) to miejscowość, w której główną rolę pełni gajówka (obiekt). Gajówka jest miejscowością jeżeli posiada nazwę własną i jest przestrzennie wyodrębniona od innej miejscowości."@pl ;
-                            rdfs:label "forest-guard's lodge"@en ,
-                                       "gajówka"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Forestrey"@de ,
-                                                                              "Forst Amt"@de ,
-                                                                              "Hegerhaus"@de ,
-                                                                              "Jägerhaus"@de ,
-                                                                              "leśnictwo"@pl ,
-                                                                              "leśniczówka"@pl ,
-                                                                              "nadleśnictwo"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "forest-guard's lodge"@en ,
-                                                                            "gajówka"@pl ;
-                            ontohgis:hasExternalIdentifier "17"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_18
@@ -12185,27 +10869,7 @@ ontohgis:settlement_type_18 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function8
-                                            ] ;
-                            dct:creator ontohgis:person_4 ;
-                            rdfs:comment "A distillery may be a separate locality, both individual and a part of a cluster of localities sharing the same name, however most often it has been an integral part of a city or a town and has not been distinguished."@en ,
-                                         "Gorzelnia może być odrębną miejscowością, zarówno samodzielną jak i częścią grupy miejscowości o tej samej nazwie, ale najczęściej znajduje się w obrębie miasta i nie jest wyróżniona."@pl ;
-                            rdfs:isDefinedBy "A distillery (locality) is a settlement, where a distillery (a factory) plays the most important role."@en ,
-                                             "Gorzelnia (miejscowość) jest to osada, w której główną role odgrywa gorzelnia (obiekt)."@pl ;
-                            rdfs:label "distillery"@en ,
-                                       "gorzelnia"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Brantweinbrennerei"@de ,
-                                                                              "Brennerei"@de ,
-                                                                              "Brennhaus"@de ,
-                                                                              "Destillerie"@de ,
-                                                                              "browar"@pl ,
-                                                                              "винокуренныйзавод"@ru ,
-                                                                              "винокурня"@ru ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "distillery"@en ,
-                                                                            "gorzelnia"@pl ;
-                            ontohgis:hasExternalIdentifier "18"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_19
@@ -12225,26 +10889,7 @@ ontohgis:settlement_type_19 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function3
-                                            ] ;
-                            dct:creator ontohgis:person_6 ;
-                            rdfs:comment "Klasztor może być odrębną miejscowością (rzadko, przed II wojną światową) lub częścią miejscowości."@pl ,
-                                         "Monastery can be a separate locality (rarely, before the Second World War) or a part of a locality."@en ;
-                            rdfs:isDefinedBy "Monastery (locality) is a settlement in which the main role is played by a monastery (facility)."@en ,
-                                             "Osada klasztorna jest to osada, w której główą rolę odgrywa klasztor (obiekt)."@pl ;
-                            rdfs:label "monastery"@en ,
-                                       "osada klasztorna"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Kloster"@de ,
-                                                                              "claustrum"@la ,
-                                                                              "monaster"@pl ,
-                                                                              "monasterium"@la ,
-                                                                              "opactwo"@pl ,
-                                                                              "ławra"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "monastery"@en ,
-                                                                            "osada klasztorna"@pl ;
-                            ontohgis:hasExternalIdentifier "19"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_2
@@ -12258,210 +10903,13 @@ ontohgis:settlement_type_2 rdf:type owl:Class ;
                                            [ rdf:type owl:Restriction ;
                                              owl:onProperty ontohgis:hasProperFunction ;
                                              owl:hasValue ontohgis:function1
-                                           ] ;
-                           dct:creator ontohgis:person_3 ;
-                           rdfs:comment """A development in a village may be dense (i.e. villages established according to a German law introducing a linear development) or scattered (i.e. Hauländer colonies, Dutch settlement, from 18th century or early medieval single manor settlements). A village may preponderate (be a superior settlement) any other units, such as: a hamlet or a mill settlement; it is also dependent on a manor, which supervises a village in legal and administrative issues. Inhabitants from all units forming a village comprise a village community. Studies on this type of localities distinguish an abandoned village, a settlement that lost its functions due to environmental, political, or economic incidents. In historiography, one can find an expression a lost village, which stands for a village, where settlement was not re-established.
-In German language in the nineteenth century, two terms could coexist - Pfarrdorf and Kirchdorf. The first meant a larger village with a parish church, and a second smaller village with an auxiliary (filial) church, but these criteria of distinction were not strict and neither used consistently. For example on the Gilly map (1802-1803), only the following categories exist: Kirchdorf and Dorf ohne Kirche."""@en ,
-                                        """Wieś może posiadać zwartą (np. wsie lokowane na prawie niemieckim np. ulicówki, łańcuchówki) lub rozproszoną zabudowę (często kolonie olęderskie w XVIII w. lub wczesnośredniowieczne osady jednodworcze). Wieś może dominować (być jednostką nadrzędną osadniczo) w stosunku do innych jednostek takich jak np. przysiółek, osada młyńska; jest także zależna od pana gruntowego, który sprawuje nad nią nadzór własnościowy. Mieszkańcy wszystkich jednostek składających się na wieś tworzą jedną wspólnotę wiejską. W badaniach nad wsią rozróżnia się także pojęcie wsi opustoszałej, czyli takiej, która fizycznie przestała pełnić swoje funkcje w wyniku zdarzeń o charakterze losowym, środowiskowym, politycznym lub gospodarczym. W literaturze przedmiotu funkcjonuje także określenie wieś zaginiona, które odnosi się do wsi, w których nie wznowiono osadnictwa.
-W języku niemieckim w XIX wieku mogły funkcjonować równolegle dwa terminy – Pfarrdorf i Kirchdorf.  Pierwszy oznaczał raczej większą wieś z kościołem parafialnym, zaś drugi mniejszą wieś z kościołem pomocniczym. Terminy te nie były jednak ścisłe i używane konsekwentnie, np. na mapie Gilly’ego z lat 1802-1803 występują tylko kategorie: Kirchdorf oraz Dorf ohne Kirche."""@pl ;
-                           rdfs:isDefinedBy "Village is a locality composed of a group of buildings, mostly of residential and economic character, but sometimes, also industrial ones (i.e. ironworks, mill) as well as a belonging land, inhabited by people involved particularly in agricultural and construction activities or in farming industry (i.e. blacksmith or mill work), and not having city rights nor a status of a city or a town. Some villages in Early Middle Ages had a right to organise a fair and a market."@en ,
-                                            "Wieś jest to miejscowość składająca się z zabudowań mieszkalno-gospodarczych, niekiedy przemysłowych (np. kuźnia, młyn) wraz z przynależnymi do nich gruntami (rozłogi), zamieszkała przez ludność zajmującą się w większości zajęciami rolniczo-hodowlanymi oraz przemysłem wiejskim (np. kowalstwo, młynarstwo), nieposiadająca praw miejskich ani statusu miasta. Niekiedy we wczesnym średniowieczu posiadająca prawo odbywania targu."@pl ;
-                           rdfs:label "village"@en ,
-                                      "wieś"@pl ;
-                           rdfs:seeAlso <http://dbpedia.org/page/Village> ,
-                                        <http://gov.genealogy.net/types.owl#55> ,
-                                        <http://linkedgeodata.org/ontology/Village> ,
-                                        <http://vocab.getty.edu/aat/300008372> ,
-                                        <https://pzgik.geoportal.gov.pl/ontologies/prng/wies> ,
-                                        <https://www.wikidata.org/wiki/Q532> ,
-                                        "1. miejscowość zamieszkała przez ludzi, którzy trudnią się pracą na roli, 2. mieszkańcy takiej miejscowości, 3. tereny pozamiejskie, rolnicze, letniskowe, 4. ludzie trudniący się pracą na roli"@pl ,
-                                        "Jednostka osadnicza o zwartej lub rozproszonej zabudowie i istniejących funkcjach rolniczych lub związanych z nimi usługowych lub turystycznych, nieposiadająca praw miejskich lub statusu miasta"@pl ,
-                                        "Kirchdorf: Dorf mit Kirche (I) und Pfarrer, rechtlicher und religiöser Mittelpunkt einer (eventuell aus mehreren Filialdörfern bestehenden) politischen oder Pfarr-Gemeinde [Wieś z kościołem i parafią, prawne i religijne centrum gminy politycznej albo parafialnej (ewentualnie składającej się z kilku wsi filialnych, wsi z kościołami filialnymi]"@de ,
-                                        "Pfarrdorf: 1. Dorf, in dem die für die Pfarrgemeinde konstitutive Pfarrkirche (I) steht [wieś, w której stoi kościół parafialny właściwy dla całej parafii, gminy parafialnej]; 2. zu einer Pfarre (I) gehöriges Dorf [wieś należąca do parafii]"@de ,
-                                        "s. 15: 1. osada, której ludność zajmuje się uprawą roślin i chowem zwierząt, wieś: osada (osiedle wiejskie; teren zabudowany), na którym mieszka ludność pracująca w gospodarstwach wiejskich, koncentrująca większość środków produkcji, i na którym są dokonywane różne procesy produkcyjne, istnieje życie społeczne oraz kulturalne mieszkańców wsi (def. na podstawie Nowosielski 1964, Kiełczewska-Zaleska 1976, Chowaniem 1989); 2. podstawą (atomem) dla wsi nie jest pojedynczy wiejski budynek lecz ich komplet (zagroda), tworzący samodzielne gospodarstwo rolne z należącą doń powierzchnią ziemi --. Wieś w sensie antropogeograficznym jest częścią gminy (lub gromady), która stanowi grupę gospodarstw rolnych zabudowaną według jednolitego planu i tworzącą typ kształtu i skupienia (def. na podstawie Zaborski 1926); 3. to zbiorowisko ludzi albo osiedle z należącymi doń gruntami. Wieś: rozłóg i osada. O istnieniu wsi ma decydować także zestaw więzi wewnątrz wsi: rozłóg, siedlisko i ludność rolnicza (def. na podstawie Szymański 1969, Olechowski 1948); 4. wieś to społeczność lokalna, której funkcję produkcyjną uzupełniała funkcja rodziny. Wieś stanowi pewną historyczną formę struktury społecznej, względnie trwałą i jednolitą całość, której członkowie są ze sobą powiązani siecią zależności i więzi sprawiających, że całość ta jest wewnętrznie zintegrowana. Cechą konstytutywną tak rozumianej grupy jest określone terytorium geograficzne, które wspólnie użytkują, a efektem tego jest pewien stopień psychologicznego zespolenia całości lub części społeczności ze strukturą społeczno-przestrzenną jako znaczącą wartością kulturową. Podstawową funkcją środowiska kulturowego wsi, a zwłaszcza jego wartości przestrzennych jest kształtowanie poczucia tożsamości z rodzinną tradycją i jej wartościami oraz wynikającej stąd świadomości przynależności do miejscowej społeczności oraz identyfikacja z jej przestrzenią życiową (def. na podstawie Turowski 1992); 5. twór terytorialny mający granice, rozłóg ziemi, siedlisko (zagrodę),  stanowiące całość przestrzenną o określonych więzach społecznych i terytorialnych oraz uprawnieniach prawnych. -- Jest to osiedle nie mające praw miejskich (def. wg Tkocza 1992, s. 15–16)."@pl ,
-                                        "s. 29: wsią nazywamy osiedle w zasadzie otwarte, której ludność zajmuje się produkcją śródków żywności oraz surowców technicznych (tj. rolnictwem, hodowlą bydła, rybołówstwem itd.)"@pl ,
-                                        "t. 4, s. 365: wioska, imienie, dobro, grunt leżący; wieś targowa, wsie łowcze, osoczne, wołoskie."@pl ,
-                                        "t. 7, s. 594–595: osada rolnicza, z pewnej liczby chat złożona, sioło"@pl ,
-                                        "t. XX, s. 199–201: 1. osada, w której ludność zajmuje się głównie rolnictwem, 2. mieszkańcy wsi, ogół mieszkańców wsi."@pl ;
-                           <http://www.w3.org/2004/02/skos/core#altLabel> "Dorf"@de ,
-                                                                          "pagus"@la ,
-                                                                          "sioło"@pl ,
-                                                                          "villa"@la ,
-                                                                          "село"@ru ;
-                           <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Kirchdorf"@de ,
-                                                                             "Pfarrdorf"@de ,
-                                                                             "ager"@la ,
-                                                                             "osada"@pl ,
-                                                                             "osiedle wiejskie"@pl ,
-                                                                             "rus"@la ,
-                                                                             "siedlisko wiejskie"@pl ,
-                                                                             "vicus"@la ,
-                                                                             "wioseczka"@pl ,
-                                                                             "wioska"@pl ,
-                                                                             "włość i klucz"@pl ,
-                                                                             "źreb"@pl ,
-                                                                             "погост"@ru ;
-                           <http://www.w3.org/2004/02/skos/core#prefLabel> "village"@en ,
-                                                                           "wieś"@pl ;
-                           ontohgis:hasExternalIdentifier "2"^^xsd:string ;
-                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                           ontohgis:hasTranslator ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_2 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "1. miejscowość zamieszkała przez ludzi, którzy trudnią się pracą na roli, 2. mieszkańcy takiej miejscowości, 3. tereny pozamiejskie, rolnicze, letniskowe, 4. ludzie trudniący się pracą na roli"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_2 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "Jednostka osadnicza o zwartej lub rozproszonej zabudowie i istniejących funkcjach rolniczych lub związanych z nimi usługowych lub turystycznych, nieposiadająca praw miejskich lub statusu miasta"@pl ;
-   rdfs:isDefinedBy ontohgis:document_9
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_2 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "Kirchdorf: Dorf mit Kirche (I) und Pfarrer, rechtlicher und religiöser Mittelpunkt einer (eventuell aus mehreren Filialdörfern bestehenden) politischen oder Pfarr-Gemeinde [Wieś z kościołem i parafią, prawne i religijne centrum gminy politycznej albo parafialnej (ewentualnie składającej się z kilku wsi filialnych, wsi z kościołami filialnymi]"@de ;
-   rdfs:isDefinedBy ontohgis:document_10
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_2 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "Pfarrdorf: 1. Dorf, in dem die für die Pfarrgemeinde konstitutive Pfarrkirche (I) steht [wieś, w której stoi kościół parafialny właściwy dla całej parafii, gminy parafialnej]; 2. zu einer Pfarre (I) gehöriges Dorf [wieś należąca do parafii]"@de ;
-   rdfs:isDefinedBy ontohgis:document_10
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_2 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "s. 15: 1. osada, której ludność zajmuje się uprawą roślin i chowem zwierząt, wieś: osada (osiedle wiejskie; teren zabudowany), na którym mieszka ludność pracująca w gospodarstwach wiejskich, koncentrująca większość środków produkcji, i na którym są dokonywane różne procesy produkcyjne, istnieje życie społeczne oraz kulturalne mieszkańców wsi (def. na podstawie Nowosielski 1964, Kiełczewska-Zaleska 1976, Chowaniem 1989); 2. podstawą (atomem) dla wsi nie jest pojedynczy wiejski budynek lecz ich komplet (zagroda), tworzący samodzielne gospodarstwo rolne z należącą doń powierzchnią ziemi --. Wieś w sensie antropogeograficznym jest częścią gminy (lub gromady), która stanowi grupę gospodarstw rolnych zabudowaną według jednolitego planu i tworzącą typ kształtu i skupienia (def. na podstawie Zaborski 1926); 3. to zbiorowisko ludzi albo osiedle z należącymi doń gruntami. Wieś: rozłóg i osada. O istnieniu wsi ma decydować także zestaw więzi wewnątrz wsi: rozłóg, siedlisko i ludność rolnicza (def. na podstawie Szymański 1969, Olechowski 1948); 4. wieś to społeczność lokalna, której funkcję produkcyjną uzupełniała funkcja rodziny. Wieś stanowi pewną historyczną formę struktury społecznej, względnie trwałą i jednolitą całość, której członkowie są ze sobą powiązani siecią zależności i więzi sprawiających, że całość ta jest wewnętrznie zintegrowana. Cechą konstytutywną tak rozumianej grupy jest określone terytorium geograficzne, które wspólnie użytkują, a efektem tego jest pewien stopień psychologicznego zespolenia całości lub części społeczności ze strukturą społeczno-przestrzenną jako znaczącą wartością kulturową. Podstawową funkcją środowiska kulturowego wsi, a zwłaszcza jego wartości przestrzennych jest kształtowanie poczucia tożsamości z rodzinną tradycją i jej wartościami oraz wynikającej stąd świadomości przynależności do miejscowej społeczności oraz identyfikacja z jej przestrzenią życiową (def. na podstawie Turowski 1992); 5. twór terytorialny mający granice, rozłóg ziemi, siedlisko (zagrodę),  stanowiące całość przestrzenną o określonych więzach społecznych i terytorialnych oraz uprawnieniach prawnych. -- Jest to osiedle nie mające praw miejskich (def. wg Tkocza 1992, s. 15–16)."@pl ;
-   rdfs:isDefinedBy ontohgis:document_8
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_2 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "s. 29: wsią nazywamy osiedle w zasadzie otwarte, której ludność zajmuje się produkcją śródków żywności oraz surowców technicznych (tj. rolnictwem, hodowlą bydła, rybołówstwem itd.)"@pl ;
-   rdfs:isDefinedBy ontohgis:document_16
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_2 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 4, s. 365: wioska, imienie, dobro, grunt leżący; wieś targowa, wsie łowcze, osoczne, wołoskie."@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_2 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 7, s. 594–595: osada rolnicza, z pewnej liczby chat złożona, sioło"@pl ;
-   rdfs:isDefinedBy ontohgis:document_5
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_2 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. XX, s. 199–201: 1. osada, w której ludność zajmuje się głównie rolnictwem, 2. mieszkańcy wsi, ogół mieszkańców wsi."@pl ;
-   rdfs:isDefinedBy ontohgis:document_6
- ] .
+                                           ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_20
 ontohgis:settlement_type_20 rdf:type owl:Class ;
                             rdfs:subClassOf ontohgis:object_1000 ,
-                                            ontohgis:settlement_type_1000 ;
-                            dct:creator ontohgis:person_7 ,
-                                       ontohgis:person_8 ;
-                            rdfs:comment "Colony is usually a part of another locality, more rarely, although these are not exceptional cases, it can have the status of a separate locality, usually a village. Both in the case where the colony is a separate locality or it is apart of another one, it is always located near the village (village or - sometimes - small town) from which its name is derived. On topographic maps, a colony is distinguished mainly by the explanatory abbreviation (pol.: kol.), by its own name, and morphologically."@en ,
-                                         "Kolonia jest przeważnie częścią miejscowości, rzadziej, choć nie są to wyjątkowe przypadki, ma obecnie status odrębnej miejscowości, z reguły wsi. Zarówno w przypadku, gdy kolonia jest odrębną miejscowością jak i częścią miejscowości, zawsze znajduje się w pobliżu miejscowości (wsi a wyjątkowo małego miasta) od której pochodzi jej nazwa. W ujęciu kartograficznym wyodrębniona przede wszystkim przez skrót kategorii (kol.), nazwę własną, oraz morfologicznie."@pl ;
-                            rdfs:isDefinedBy "Colony (pol. kolonia) is a built-up area located away from previously existing buildings (locality) to which it is related. It is created on newly developed land allocated as a result of enfranchisement, parceling, consolidation, or internal migration."@en ,
-                                             "Kolonia jest to obszar zabudowany oddalony od wcześniej istniejącej zabudowy, od której jest zależna, powstały na nowo zagospodarowanych gruntach przydzielonych w wyniku uwłaszczenia, parcelacji, komasacji lub migracji wewnętrznej."@pl ;
-                            rdfs:label "colony"@en ,
-                                       "kolonia"@pl ;
-                            rdfs:seeAlso <http://gov.genealogy.net/types.owl#121> ,
-                                         <https://pzgik.geoportal.gov.pl/ontologies/prng/kolonia> ,
-                                         <https://www.wikidata.org/wiki/Q12015918> ,
-                                         "Jednostka osadnicza powstała jako rezultat ekspansji miejscowości poza obszar wcześniej istniejącej zabudowy, w szczególności kolonia miasta, kolonia wsi."@pl ,
-                                         "t. 1, s. 900: Osiedla mieszkaniowe położone z dala od centrum miasta, osady: niewielka posiadłość ziemska , nowa osada lub gospodarstwo rolne na gruntach przydzielonych w wyniku uwłaszczenia, parcelacji, komasacji, migracji wewnętrznej itp."@pl ,
-                                         "t. 1-2, s. 1566: część miejscowości, zwykle  z dale od jej centrum, składająca się z nowobudowanych domostw, will, itp."@pl ,
-                                         "t. 2,  s. 240: zabudowa, osiedle, domy znajdujące się z dala od miasta, wsi, osady; kolonia mieszkaniowa na przedmieściach, kolonia położona daleko za wsią, gospodarstwo rolne położone za wsią, posiadłość ziemska z dala od innych."@pl ,
-                                         "t. 2, s. 404: mała posiadłość ziemska należąca do przybysza z obcego kraju; osada włościańska po uwłaszczeniu włościan; osada, miejsce, gdzie koloniści osadnicy mieszkają, budy, szopy, majdan."@pl ,
-                                         "t. 5, s. 720: kolonia rolna -- gospodarstwo rolne powstałe w oddaleniu od wsi na gruntach przydzielonych w wyniku uwłaszczenia, parcelacji, komasacji, itp.; także kilka lub kilkanaście zagród w rozproszeniu -- osada na ziemiach nowo zagospodarowanych"@pl ,
-                                         "„W ten sposób termin 'osada' może tutaj oznaczać nie tylko małe osiedla, złożone z jednego lub kilku wyodrębnionych terytorialnie gospodarstw włościańskich, jak to miało miejsce na innych ziemiach polskich, lecz i większe, o charakterze kolonii, t. j. osiedli rozrzuconych na większej przestrzeni, a powstałych zazwyczaj na gruntach rozparcelowanych przez władze zaborcze”"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "Kolonie"@de ,
-                                                                           "colonia"@la ,
-                                                                           "колония"@ru ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "chutor"@pl ,
-                                                                              "część wsi"@pl ,
-                                                                              "housing estate"@en ,
-                                                                              "osada"@pl ,
-                                                                              "osiedle"@pl ,
-                                                                              "przysiółek"@pl ,
-                                                                              "settlement"@en ,
-                                                                              "sioło"@pl ,
-                                                                              "stanica"@pl ,
-                                                                              "wybudowanie"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "colony"@en ,
-                                                                            "kolonia"@pl ;
-                            ontohgis:hasExternalIdentifier "20"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_20 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "Jednostka osadnicza powstała jako rezultat ekspansji miejscowości poza obszar wcześniej istniejącej zabudowy, w szczególności kolonia miasta, kolonia wsi."@pl ;
-   rdfs:isDefinedBy ontohgis:document_9
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_20 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 1, s. 900: Osiedla mieszkaniowe położone z dala od centrum miasta, osady: niewielka posiadłość ziemska , nowa osada lub gospodarstwo rolne na gruntach przydzielonych w wyniku uwłaszczenia, parcelacji, komasacji, migracji wewnętrznej itp."@pl ;
-   rdfs:isDefinedBy ontohgis:document_19
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_20 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 1-2, s. 1566: część miejscowości, zwykle  z dale od jej centrum, składająca się z nowobudowanych domostw, will, itp."@pl ;
-   rdfs:isDefinedBy ontohgis:document_18
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_20 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 2,  s. 240: zabudowa, osiedle, domy znajdujące się z dala od miasta, wsi, osady; kolonia mieszkaniowa na przedmieściach, kolonia położona daleko za wsią, gospodarstwo rolne położone za wsią, posiadłość ziemska z dala od innych."@pl ;
-   rdfs:comment ontohgis:document_20
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_20 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 2, s. 404: mała posiadłość ziemska należąca do przybysza z obcego kraju; osada włościańska po uwłaszczeniu włościan; osada, miejsce, gdzie koloniści osadnicy mieszkają, budy, szopy, majdan."@pl ;
-   rdfs:isDefinedBy ontohgis:document_5
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_20 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 5, s. 720: kolonia rolna -- gospodarstwo rolne powstałe w oddaleniu od wsi na gruntach przydzielonych w wyniku uwłaszczenia, parcelacji, komasacji, itp.; także kilka lub kilkanaście zagród w rozproszeniu -- osada na ziemiach nowo zagospodarowanych"@pl ;
-   rdfs:isDefinedBy ontohgis:document_11
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_20 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "„W ten sposób termin 'osada' może tutaj oznaczać nie tylko małe osiedla, złożone z jednego lub kilku wyodrębnionych terytorialnie gospodarstw włościańskich, jak to miało miejsce na innych ziemiach polskich, lecz i większe, o charakterze kolonii, t. j. osiedli rozrzuconych na większej przestrzeni, a powstałych zazwyczaj na gruntach rozparcelowanych przez władze zaborcze”"@pl ;
-   rdfs:isDefinedBy ontohgis:document_91
- ] .
+                                            ontohgis:settlement_type_1000 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_2000
@@ -12512,37 +10960,7 @@ ontohgis:settlement_type_21 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function8
-                                            ] ;
-                            dct:creator ontohgis:person_4 ;
-                            rdfs:comment "A mine may be a separate locality, an individual one or a part of a cluster of localities sharing the same name, however, even if a mine is an integral part of a bigger locality, it has its particular name."@en ,
-                                         "Kopalnia może być odrębną miejscowością, zarówno samodzielną jak i częścią grupy miejscowości o tej samej nazwie, ale najczęściej, nawet jeśli znajduje się w obrębie większej miejscowości, ma własną nazwę."@pl ;
-                            rdfs:isDefinedBy "A mine (a locality) is a settlement with a mine (a factory) as the most important element."@en ,
-                                             "Kopalnia (miejscowość) jest to osada, w której główną rolę odgrywa kopalnia (obiekt)."@pl ;
-                            rdfs:label "mining settlement"@en ,
-                                       "osada górnicza"@pl ;
-                            rdfs:seeAlso <http://vocab.getty.edu/aat/300008464> ,
-                                         <https://www.wikidata.org/wiki/Q820254> ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "Bergwerksort"@de ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Bergwerk"@de ,
-                                                                              "Binge"@de ,
-                                                                              "Bruch"@de ,
-                                                                              "Miene"@de ,
-                                                                              "Schacht"@de ,
-                                                                              "gruba"@pl ,
-                                                                              "kopalnia"@pl ,
-                                                                              "mine"@en ,
-                                                                              "mining camp"@en ,
-                                                                              "mining community"@en ,
-                                                                              "mining town"@en ,
-                                                                              "рудник"@ru ,
-                                                                              "шахта"@ru ,
-                                                                              "шахтёрский город"@ru ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "mining settlement"@en ,
-                                                                            "osada górnicza"@pl ;
-                            ontohgis:hasExternalIdentifier "21"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_22
@@ -12556,7 +10974,7 @@ ontohgis:settlement_type_22 rdf:type owl:Class ;
                             rdfs:label "barracks"@en ,
                                        "koszary"@pl ;
                             rdfs:seeAlso <http://linkedgeodata.org/ontology/Barracks> ;
-                            ontohgis:hasExternalIdentifier "22"^^xsd:string .
+                            ontohgis:hasExternalIdentifier "22" .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_23
@@ -12570,26 +10988,7 @@ ontohgis:settlement_type_23 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function9
-                                            ] ;
-                            dct:creator ontohgis:person_5 ;
-                            rdfs:comment """Included as a kind of locality in Bystrzycki's register as abbreviation (\"lat. mor.\"); dinstinct symbol on topographic maps; included in DBTO10k as a \"communication buildings, stations and terminals\" (BUBD feature class).
-Functional distinctivness - distinguished as a kind of locality in Bystrzycki's register, and on topographic maps as distinct symbol, sometimes with the proper name.
-Morphological and spatial distinctivness - usually a lightouse is a building (structure) within the area of the locality or in its vicinity. 
-If it has its a particular (proper) name, it can be treated as a separate locality (interpretation of maps is necessary, see: Rozewie). Otherwise it is either part of another locality or an object (building/structure) in it (see: Hel, Jastarnia)."""@en ,
-                                         """Występuje jako rodzaj miejscowości u Bystrzyckiego w spisie (\"lat. mor.\"); na mapach osobna sygnatura. W BDOT10k jako budynek łączności, dworców i terminali.
-Odrębność funkcjonalna – wyróżniana jako rodzaj miejscowości u Bystrzyckiego, a na mapach topograficznych odrębnym znakiem, niekiedy z nazwą własną. Odrębność morfologiczna/przestrzenna – przeważnie jest obiektem na obszarze miejscowości lub w niewielkim od niej oddaleniu. Jeżeli posiada nazwę własną może być traktowana jako osobna miejscowość (konieczna interpretacja map; patrz: Rozewie). W przeciwnym razie jest albo częścią innej, większej miejscowości lub obiektem terenowym (budowlą) w niej (patrz: Hel, Jastarnia)."""@pl ;
-                            rdfs:isDefinedBy "A lighthouse (a locality) is a settlement in which a main role is played by a lighthouse (building)."@en ,
-                                             "Latarnia morska (miejscowość) to osada obejmująca latarnię morską (obiekt)."@pl ;
-                            rdfs:label "latarnia morska"@pl ,
-                                       "lighthouse"@en ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "Leuchtturm"@de ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "latarnia morska"@pl ,
-                                                                            "lighthouse"@en ;
-                            ontohgis:hasExternalIdentifier "23"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 ,
-                                                   ontohgis:person_9 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_25
@@ -12598,47 +10997,7 @@ ontohgis:settlement_type_25 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function7
-                                            ] ;
-                            dct:creator ontohgis:person_5 ;
-                            rdfs:comment """It can be either a separate locality (e.g. Celestynów) or a part of another locality, morphologically it is most often a complex of (summer) houses (Chylice, Skolimów), but also a typical (based on the interpretation of the topographic map drawing) non-urban built-up area (Choszczówka).
-Included as a kind of locality in Bystrzycki's register as explanatory abbreviation (\"letn.\"). All summer resorts in Bystrzycki's register are located near Warsaw. Exception: Wisła, Zełmianka (Stryj district).
-Included on topographic maps as a part of a place name annotation (\"letn.\"), but not in symbology keys (legends). On the MGI maps, summer resort is one of the types of localities. In DBTO10k as \"summer house\" (pol \"dom letniskowy\") in the feature class of single-family residential buildings (BUBD01)."""@en ,
-                                         """Może być albo osobną miejscowością (Celestynów) albo częścią miejscowości. Morfologicznie jest to najczęściej zabudowa złożona z domków letniskowych (Chylice, Skolimów), ale również typowa (na podstawie interpretacji rysunku mapy) zabudowa zwarta niemiejska (Choszczówka). 
-Występuje jako rodzaj miejscowości u Bystrzyckiego w spisie (\"letn.\"). 
-Wszystkie letniska u Bystrzyckiego znajdują się w okolicach Warszawy. Wyjątek: Wisła, Zełmianka (pow. Stryj).
-Występuje na mapach w nazwach miejscowości (letn.), ale nie w kluczach znaków. W legendach map WIG jest to jeden z rodzajów osiedli. W BDOT10k („dom letniskowy”) w klasie budynki mieszkalne jednorodzinne (BUBD01)."""@pl ;
-                            rdfs:isDefinedBy "Letnisko to miejscowość o charakterze wypoczynkowym, złożona z domków letniskowych lub posiadająca zwartą zabudowę"@pl ,
-                                             "Summer resort is a holiday locality consisting of holiday houses or densely built-up"@en ;
-                            rdfs:label "letnisko"@pl ,
-                                       "summer resort"@en ;
-                            rdfs:seeAlso <http://vocab.getty.edu/aat/300000547> ,
-                                         <http://vocab.getty.edu/aat/300000558> ,
-                                         <https://www.wikidata.org/wiki/Q317548> ,
-                                         <https://www.wikidata.org/wiki/Q875157> ,
-                                         "miejscowość wypoczynkowa; letni pobyt poza miastem w celach wypoczynkowych"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "osada letniskowa"@pl ,
-                                                                           "resort destination"@en ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Erholungsort"@de ,
-                                                                              "dom letniskowy"@pl ,
-                                                                              "resort town"@en ,
-                                                                              "sanatorium"@pl ,
-                                                                              "uzdrowisko"@pl ,
-                                                                              "willa"@pl ,
-                                                                              "курортный город"@ru ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "letnisko"@pl ,
-                                                                            "summer resort"@en ;
-                            ontohgis:hasExternalIdentifier "25"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 ,
-                                                   ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_25 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "miejscowość wypoczynkowa; letni pobyt poza miastem w celach wypoczynkowych"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_27
@@ -12657,29 +11016,7 @@ ontohgis:settlement_type_27 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function4
-                                            ] ;
-                            dct:creator ontohgis:person_5 ;
-                            rdfs:comment "Dziś leśniczówka jest miejscowością lub budynkiem (BDOT10k), ale nie wszystkie leśniczówki-budynki (BUBD01) to leśniczówki-miejscowości (ADMS11). Przed wojną leśniczówka prawie zawsze była wyróżniana jako odrębna miejscowość."@pl ,
-                                         "Today, the forester's lodge is a locality or a building (DBTO10k), but not all forester's lodges (feature class: BUBD01) which are buildings are forester's lodges (feature class: ADMS11) understood as localities. Before the second world war, forester's lodge was almost always distinguished as a separate locality."@en ;
-                            rdfs:isDefinedBy "Forester's lodge (a locality) is a locality in which the main role is played by a forester's lodge (an area). Forester's lodge is a locality as long as it has a particular (proper) name and is not located in the immediate vicinity of another locality."@en ,
-                                             "Leśniczówka (miejscowość) to miejscowość, w której główną rolę pełni leśniczówka (obiekt). Leśniczówka jest miejscowością jeżeli posiada nazwę własną i jest przestrzennie wyodrębniona od innej miejscowości."@pl ;
-                            rdfs:label "forester's lodge"@en ,
-                                       "leśniczówka"@pl ;
-                            rdfs:seeAlso <http://gov.genealogy.net/types.owl#115> ,
-                                         <https://pzgik.geoportal.gov.pl/ontologies/prng/lesniczowka> ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Forestrey"@de ,
-                                                                              "Forst Amt"@de ,
-                                                                              "Hegerhaus"@de ,
-                                                                              "Jägerhaus"@de ,
-                                                                              "gajówka"@pl ,
-                                                                              "nadleśnictwo"@pl ,
-                                                                              "osada leśna"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "forester's lodge"@en ,
-                                                                            "leśniczówka"@pl ;
-                            ontohgis:hasExternalIdentifier "27"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_28
@@ -12688,57 +11025,7 @@ ontohgis:settlement_type_28 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty <http://www.geonames.org/ontology#featureCode> ;
                                               owl:hasValue <http://www.geonames.org/ontology#P.PPL>
-                                            ] ;
-                            dct:creator ontohgis:person_2 ;
-                            rdfs:comment "Miasteczko z zasady jest odrębną miejscowością. Na ziemiach polskich nie istniało rozróżnienie formalne między miastem i miasteczkiem, funkcjonowało ono natomiast na niektórych obszarach Rzeszy Niemieckiej (Flecken, Marktsiedlung - Stadt)."@pl ,
-                                         "Town is always (ex definitione) a separate locality. On the Polish lands, there was no formal distinction between the city and the town, but such distinction was present in some areas of the German Reich (Flecken, Marktsiedlung - Stadt)."@en ;
-                            rdfs:isDefinedBy "Miasteczko to małe miasto, odróżniające się od dużych miast wielkością (liczoną według miary właściwej dla danej epoki i regionu) i stopniem złożoności."@pl ,
-                                             "Town (pol. miasteczko) is a small city, distniguished from larger cities by it size (estimated by standards appropriate for given period and region) and complexity."@en ;
-                            rdfs:label "miasteczko"@pl ,
-                                       "town"@en ;
-                            rdfs:seeAlso <http://dbpedia.org/ontology/Town> ,
-                                         <http://gov.genealogy.net/types.owl#51> ,
-                                         <http://linkedgeodata.org/ontology/Town> ,
-                                         <http://vocab.getty.edu/aat/300008375> ,
-                                         <https://www.wikidata.org/wiki/Q3957> ,
-                                         "małe miasto, -- przen. ludność małego miasta"@pl ,
-                                         "małe miasto; pot. mieszkańcy małego miasta"@pl ,
-                                         "t. 13, s. 369-372: 1. Od znacz. 'miejsce' --; 2. Od znacz. 'wytyczony i najczęściej otoczony murem teren pokryty gęstą i planową zabudową"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "Städtchen"@de ,
-                                                                           "oppidulum"@la ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Flecken"@de ,
-                                                                              "miasto"@pl ,
-                                                                              "oppidum"@la ,
-                                                                              "osada targowa"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "miasteczko"@pl ,
-                                                                            "town"@en ;
-                            ontohgis:hasExternalIdentifier "28"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_28 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "małe miasto, -- przen. ludność małego miasta"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4 ,
-                    <https://sjp.pwn.pl/doroszewski/miasteczko;5451005.html>
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_28 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "małe miasto; pot. mieszkańcy małego miasta"@pl ;
-   rdfs:isDefinedBy ontohgis:document_3 ,
-                    <https://sjp.pwn.pl/sjp/miasteczko;2482785.html>
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_28 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 13, s. 369-372: 1. Od znacz. 'miejsce' --; 2. Od znacz. 'wytyczony i najczęściej otoczony murem teren pokryty gęstą i planową zabudową"@pl ;
-   rdfs:isDefinedBy ontohgis:document_2
- ] .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_3
@@ -12754,68 +11041,7 @@ ontohgis:settlement_type_3 rdf:type owl:Class ;
                                            [ rdf:type owl:Restriction ;
                                              owl:onProperty ontohgis:hasProperFunction ;
                                              owl:hasValue ontohgis:function3
-                                           ] ;
-                           dct:creator ontohgis:person_2 ;
-                           rdfs:comment "During those periods, when legal status of localities was established and defined, cities/towns were granted specific municipal rights (location bill), which should be considered as an auxiliary indicator for distinguishing cities/towns. A city/town may consists of other settlement units, like: a core city/town (a founded one), a district, a suburb, a castle, a gord. At least from the 13th to the 18th century, two parallel notions existed: general (meaning the whole settlement unit with its own society, economy, and urban structure, perceived mostly by intuition), and a city in its political and legal meaning, as a community with an extensive autonomy. As a consequence, cities within other city or units lying partly in and partly outside the city existed. For these complex structures, in this project, first explanations of the city should be applied."@en ,
-                                        "W okresach, w których status prawny miejscowości był ukształtowany miasta posiadały szczególne prawa miejskie (lokacyjne), które stanowią postawowe kryterium pomocnicze odróżniania miast. W skład miasta mogą wchodzić inne jednostki osadnicze, jak miasto właściwe (lokacyjne), dzielnica, przedmieście, zamek, gród. Przynamniej w okresie od XIII do XVIII w. funkcjonowały równolegle dwa pojęcia miasta: ogólne, obejmujące cały zespół osadniczy o odrębności społecznej, gospodarczej i urbanistycznej, postrzegane przede wszystkim intuicyjnie oraz miasto w sensie polityczno-prawnym, obdarzona względnie szeroką autonomią gmina. W konsekwencji mogły istnieć miasta w mieście i obiekty leżące jednocześnie w mieście i poza nim. Dla takich złożonych struktur w niniejszym projekcie należy się posługiwać pierwszym znaczeniem miasta."@pl ;
-                           rdfs:isDefinedBy "A city/town is a superior locality, distinguished from others, surrounding basic units by size (measured differently in different periods of time and regions), a level of complexity, and central functions provided for those units."@en ,
-                                            "Miasto jest to miejscowość wyższego rzędu, odróżniająca się od otaczających je podstawowych wielkością (liczoną według miary właściwej dla danej epoki i regionu), stopniem złożoności i funkcjami centralnymi względem nich."@pl ;
-                           rdfs:label "city / town"@en ,
-                                      "miasto"@pl ;
-                           rdfs:seeAlso <http://dbpedia.org/ontology/City> ,
-                                        <http://gov.genealogy.net/types.owl#51> ,
-                                        <http://linkedgeodata.org/ontology/City> ,
-                                        <http://vocab.getty.edu/aat/300008389> ,
-                                        <https://pzgik.geoportal.gov.pl/ontologies/prng/miasto> ,
-                                        <https://schema.org/City> ,
-                                        <https://www.wikidata.org/wiki/Q515> ,
-                                        "Jednostka osadnicza (wyodrębniony przestrzennie obszar zabudowy mieszkaniowej wraz z obiektami infrastruktury technicznej zamieszkany przez ludzi) o przewadze zwartej zabudowy i funkcjach nierolniczych posiadająca prawa miejskie bądź status miasta nadany w trybie określonym odrębnymi przepisami."@pl ,
-                                        "Skupisko ludności, odróżniające się od innych swymi głównie nierolniczymi funkcjami, znaczną wielkością oraz intensywnością zabudowy. Definicja ta musi być jednak interpretowana elastycznie i zawsze na tle aktualnej sieci osadniczej."@pl ,
-                                        "s. 63: Miasto jest osadą różniącą się od wsi i nierolniczych osad monofunkcyjnych względną wielkością z zagęszczoną i rozczłonkowaną zabudową, z ludnością wyspecjalizowaną zawodowo i rozwarstwioną społecznie oraz funkcjami centralnymi pełnionymi wobec określonego regionu lub lokalnej ludności w sferze polityki, panowania, obronności, gospodarki, kultu i kultury [Stadt ist eine vom Dorf und nichtagrarischen Einzwecksiedlungen unterschiedene Siedlung relativer Größe mit verdichteter, gegliederter Bebauung, beruflich spezialisierter und sozial geschichteter Bevölkerung und zentralen Funktionen politisch-herrschaftlich-militärischer, wirtschaftlicher und kultisch-kultureller Art für eine bestimmte Region oder regionale Bevölkerung]"@de ,
-                                        "t. 13, s. 37: Wytyczony i najczęściej otoczony murem teren, pokryty gęstą i planową zabudową tworzącą place i ulice, stanowiący mniej lub więcej samodzielną jednostkę administracyjną, samorządową, a czasem polityczną."@pl ;
-                           <http://www.w3.org/2004/02/skos/core#altLabel> "Stadt"@de ,
-                                                                          "civitas"@la ,
-                                                                          "oppidum"@la ,
-                                                                          "urbs"@la ,
-                                                                          "город"@ru ;
-                           <http://www.w3.org/2004/02/skos/core#hiddenLabel> "aglomeracja"@pl ,
-                                                                             "miasteczko"@pl ,
-                                                                             "osada miejska"@pl ,
-                                                                             "месте́чко"@ru ;
-                           <http://www.w3.org/2004/02/skos/core#prefLabel> "city / town"@en ,
-                                                                           "miasto"@pl ;
-                           ontohgis:hasExternalIdentifier "3"^^xsd:string ;
-                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                           ontohgis:hasTranslator ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_3 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "Jednostka osadnicza (wyodrębniony przestrzennie obszar zabudowy mieszkaniowej wraz z obiektami infrastruktury technicznej zamieszkany przez ludzi) o przewadze zwartej zabudowy i funkcjach nierolniczych posiadająca prawa miejskie bądź status miasta nadany w trybie określonym odrębnymi przepisami."@pl ;
-   rdfs:isDefinedBy ontohgis:document_9
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_3 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "Skupisko ludności, odróżniające się od innych swymi głównie nierolniczymi funkcjami, znaczną wielkością oraz intensywnością zabudowy. Definicja ta musi być jednak interpretowana elastycznie i zawsze na tle aktualnej sieci osadniczej."@pl ;
-   rdfs:isDefinedBy ontohgis:document_11
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_3 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "s. 63: Miasto jest osadą różniącą się od wsi i nierolniczych osad monofunkcyjnych względną wielkością z zagęszczoną i rozczłonkowaną zabudową, z ludnością wyspecjalizowaną zawodowo i rozwarstwioną społecznie oraz funkcjami centralnymi pełnionymi wobec określonego regionu lub lokalnej ludności w sferze polityki, panowania, obronności, gospodarki, kultu i kultury [Stadt ist eine vom Dorf und nichtagrarischen Einzwecksiedlungen unterschiedene Siedlung relativer Größe mit verdichteter, gegliederter Bebauung, beruflich spezialisierter und sozial geschichteter Bevölkerung und zentralen Funktionen politisch-herrschaftlich-militärischer, wirtschaftlicher und kultisch-kultureller Art für eine bestimmte Region oder regionale Bevölkerung]"@de ;
-   rdfs:isDefinedBy ontohgis:document_12
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_3 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 13, s. 37: Wytyczony i najczęściej otoczony murem teren, pokryty gęstą i planową zabudową tworzącą place i ulice, stanowiący mniej lub więcej samodzielną jednostkę administracyjną, samorządową, a czasem polityczną."@pl ;
-   rdfs:isDefinedBy ontohgis:document_2
- ] .
+                                           ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_3003
@@ -12903,101 +11129,7 @@ ontohgis:settlement_type_33 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasFunction ;
                                               owl:hasValue ontohgis:function3
-                                            ] ;
-                            dct:creator ontohgis:person_7 ,
-                                       ontohgis:person_8 ;
-                            rdfs:comment "A small locality organised in relation to a workplace or a particular occupation of its inhabitants. Settlement had usually been established as a separate locality, later on – especially in case of industrial settlements – particular settlements could develop into a city, merge with other settlement to create a new locality, or it could be incorporated into another locality. Depending on the type of inhabitants’ occupations one can, or could in the past, indicate a fair (market), craft, industrial, fishing, forestry, and railway settlements."@en ,
-                                         "Niewielka miejscowość zorganizowana w związku z miejscem lub rodzajem pracy mieszkańców. Osada powstawała z reguły jako odrębna miejscowość, później, dość często, szczególnie w przypadku osad przemysłowych, rozwijała się do rangi miasta, łączyła się z inną osadą jako odrębna miejscowość, lub była włączana do innej miejscowości. W zależności od rodzaju wykonywanej pracy wyróżnia lub wyróżniało się osady targowe, rzemieślnicze, przemysłowe, rybackie, leśne, kolejowe."@pl ,
-                                         "„W ten sposób termin 'osada' może tutaj oznaczać nie tylko małe osiedla, złożone z jednego lub kilku wyodrębnionych terytorialnie gospodarstw włościańskich, jak to miało miejsce na innych ziemiach polskich, lecz i większe, o charakterze kolonii, t. j. osiedli rozrzuconych na większej przestrzeni, a powstałych zazwyczaj na gruntach rozparcelowanych przez władze zaborcze”"@pl ;
-                            rdfs:isDefinedBy "Niewielka miejscowość zamieszkała przez ludność związaną z określonym typem lokalizacji lub rodzajem pracy nierolniczej i usytuowana z reguły w bezpośrednim sąsiedztwie miejsca pracy."@pl ,
-                                             "Settlement is a small locality inhabited by people associated with a particular type of location or a type of a non-agricultural work and lying mostly in the vicinity of a workplace."@en ;
-                            rdfs:label "osada"@pl ,
-                                       "settlement"@en ;
-                            rdfs:seeAlso <http://dbpedia.org/page/Hamlet_(place)> ,
-                                         <http://gov.genealogy.net/types.owl#120> ,
-                                         <http://vocab.getty.edu/aat/300008369> ,
-                                         <https://pzgik.geoportal.gov.pl/ontologies/prng/osada> ,
-                                         <https://www.wikidata.org/wiki/Q5084> ,
-                                         "Niewielka jednostka osadnicza na terenie wiejskim o odmiennym (wyróżniającym się) charakterze zabudowy albo zamieszkana przez ludność związaną z miejscem lub rodzajem pracy, innymi niż wyżej wymienione [osada młyńska, osada leśna, osada rybacka, osada kolejowa, osada po byłem PGR]; źródło: ustawa z dnia 29 sierpnia 2003 r. o urzędowych nazwach miejscowości i obiektów fizjograficznych."@pl ,
-                                         "Niewielka jednostka osadnicza na terenie wiejskim o odmiennym(wyróżniającym się) charakterze zabudowy albo zamieszkana przez ludność zwiazaną z określonym miejscem lub rodzajem pracy, w szczególności: osada młyńska, osada leśna, osada rybacka, osada kolejowa, osada po byłym państwowym gospodarstwie rolnym; osada może być samodzielna lub może stanowić część innej jednostki osadniczej."@pl ,
-                                         "niewielka miejscowość, niemająca praw osiedla czy miasta; też: mieszkańcy takiej miejscowości"@pl ,
-                                         "osiedle typu wiejskiego pośrednie między wsią a miasteczkiem; kolonia, mieszkańcy tego osiedla"@pl ,
-                                         "t. 22, s. 99: 1. Osiedle, miejsce zamieszkałe przez osadzoną ludność, terytorium zamieszkałe, -- a. Siedlisko, mieszkanie --; 2. Mieszkańcy osiedla; ludność żyjąca na jakimś terenie --; 3. Miejsce zdatne, dogodne do osiedlenia się --; 4. Zasiedlenie pustego miejsca, colonia."@pl ,
-                                         "t. 3, s. 547: osada, koloniia, mieysce, gdzie się nowi mieszkańcy sadowią, eine Kolonie (cf. wola), Pflanzstadt, Pflanzort, Ansiedlung; -- Vd. selizhzhe, preselishe, selitva, naselitva; Rs.  колонїя, селенїе (ob. sieło, sioło), поселенїе, селишьба."@pl ,
-                                         "t. 3, s. 836-837: 1.a. miejsce, gdzie ś. nowi mieszkańcy usadowili, kolonja --; b. miejsce zajęte przez mieszkańców, większe od wsi a mniejsze do miasta --; c. [Osiedle] grunt, na którym osadzano chłopa; sadyba, zagroda włościańska"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "посёлок"@ru ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Ansiedlung"@de ,
-                                                                              "Kolonie"@de ,
-                                                                              "Siedlung"@de ,
-                                                                              "kolonia"@pl ,
-                                                                              "miasteczko"@pl ,
-                                                                              "osiedle"@pl ,
-                                                                              "sadyba"@pl ,
-                                                                              "zagroda włościańska"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "osada"@pl ,
-                                                                            "settlement"@en ;
-                            ontohgis:hasExternalIdentifier "33"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_33 ;
-   owl:annotatedProperty rdfs:comment ;
-   owl:annotatedTarget "„W ten sposób termin 'osada' może tutaj oznaczać nie tylko małe osiedla, złożone z jednego lub kilku wyodrębnionych terytorialnie gospodarstw włościańskich, jak to miało miejsce na innych ziemiach polskich, lecz i większe, o charakterze kolonii, t. j. osiedli rozrzuconych na większej przestrzeni, a powstałych zazwyczaj na gruntach rozparcelowanych przez władze zaborcze”"@pl ;
-   rdfs:isDefinedBy ontohgis:document_91
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_33 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "Niewielka jednostka osadnicza na terenie wiejskim o odmiennym (wyróżniającym się) charakterze zabudowy albo zamieszkana przez ludność związaną z miejscem lub rodzajem pracy, innymi niż wyżej wymienione [osada młyńska, osada leśna, osada rybacka, osada kolejowa, osada po byłem PGR]; źródło: ustawa z dnia 29 sierpnia 2003 r. o urzędowych nazwach miejscowości i obiektów fizjograficznych."@pl ;
-   rdfs:isDefinedBy ontohgis:document_22
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_33 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "Niewielka jednostka osadnicza na terenie wiejskim o odmiennym(wyróżniającym się) charakterze zabudowy albo zamieszkana przez ludność zwiazaną z określonym miejscem lub rodzajem pracy, w szczególności: osada młyńska, osada leśna, osada rybacka, osada kolejowa, osada po byłym państwowym gospodarstwie rolnym; osada może być samodzielna lub może stanowić część innej jednostki osadniczej."@pl ;
-   rdfs:isDefinedBy ontohgis:document_9
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_33 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "niewielka miejscowość, niemająca praw osiedla czy miasta; też: mieszkańcy takiej miejscowości"@pl ;
-   rdfs:isDefinedBy ontohgis:document_3 ,
-                    <https://sjp.pwn.pl/sjp/osada;2496282.html>
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_33 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "osiedle typu wiejskiego pośrednie między wsią a miasteczkiem; kolonia, mieszkańcy tego osiedla"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4 ,
-                    <https://sjp.pwn.pl/doroszewski/osada;5467524.html>
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_33 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 22, s. 99: 1. Osiedle, miejsce zamieszkałe przez osadzoną ludność, terytorium zamieszkałe, -- a. Siedlisko, mieszkanie --; 2. Mieszkańcy osiedla; ludność żyjąca na jakimś terenie --; 3. Miejsce zdatne, dogodne do osiedlenia się --; 4. Zasiedlenie pustego miejsca, colonia."@pl ;
-   rdfs:isDefinedBy ontohgis:document_2
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_33 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 3, s. 547: osada, koloniia, mieysce, gdzie się nowi mieszkańcy sadowią, eine Kolonie (cf. wola), Pflanzstadt, Pflanzort, Ansiedlung; -- Vd. selizhzhe, preselishe, selitva, naselitva; Rs.  колонїя, селенїе (ob. sieło, sioło), поселенїе, селишьба."@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_33 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 3, s. 836-837: 1.a. miejsce, gdzie ś. nowi mieszkańcy usadowili, kolonja --; b. miejsce zajęte przez mieszkańców, większe od wsi a mniejsze do miasta --; c. [Osiedle] grunt, na którym osadzano chłopa; sadyba, zagroda włościańska"@pl ;
-   rdfs:isDefinedBy ontohgis:document_5
- ] .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_34
@@ -13016,115 +11148,7 @@ ontohgis:settlement_type_34 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function3
-                                            ] ;
-                            dct:creator ontohgis:person_7 ,
-                                       ontohgis:person_8 ;
-                            rdfs:comment """In a general meaning, currently obsolete, an expression for every settlement unit (urban or rural one). Understood as such, it had been considered a separate locality.
-In urban studies, this notion is derived from a \"neighbouring unit\" idea, covering a group of residential buildings with a service facilities and green areas. As a part of a locality, \"osiedle\" may be recognised by its particular name, physiognomy (i. e. a group of blocks of flats, detached houses), topography (occupied area), and a period, when it was established. 
-In cartography, it may be distinguished by its own name preceded by an abbreviation (i.e. Os. Zdobycz Robotnicza) as well as morphology."""@en ,
-                                         """W znaczeniu ogólnym, rzadko obecnie stosowanym, określenie każdej jednostki osadniczej (osiedle miejskie, osiedle wiejskie). W tym znaczeniu jest to osobna miejscowość.
-W urbanistyce (planowaniu przestrzennym) pojęcie osiedla wywodzi się z koncepcji „jednostki sąsiedzkiej”, na którą składa się zespół budynków mieszkalnych wraz z zapleczem obiektów usługowych oraz terenów zielonych. Jako część miejscowości osiedle wyróżnia się poprzez nazwę, swoją fizjonomię (np. osiedle bloków mieszkalnych, domków jednorodzinnych), topografię (jest wyodrębnione przestrzennie), a także przez okres powstania.
-W ujęciu kartograficznym wyodrębnione przez nazwę własną, poprzedzoną  skrótem  kategorii (np. Os. Zdobycz Robotnicza) oraz morfologicznie."""@pl ;
-                            rdfs:isDefinedBy "Housing estate is an area covering a group of residential buildings, being an integral part of a city ( a town), or - rarely - a village."@en ,
-                                             "Obszar obejmujący zespół budynków mieszkalnych, stanowiący integralną część miasta, a niekiedy wsi."@pl ;
-                            rdfs:label "housing developments"@en ,
-                                       "osiedle"@pl ;
-                            rdfs:seeAlso <http://dbpedia.org/page/Housing_development> ,
-                                         <http://vocab.getty.edu/aat/300000498> ,
-                                         <https://pzgik.geoportal.gov.pl/ontologies/prng/osiedle> ,
-                                         <https://www.wikidata.org/wiki/Q2282602> ,
-                                         "10. Rodzaj miejscowości (Klasa: AD_RodzajMiejscowosciKod): Zespół mieszkaniowy stanowiący integralną część miasta lub wsi; źródło: ustawa z dnia 29 sierpnia 2003 r. o urzędowych nazwach miejscowości i obiektów fizjograficznych."@pl ,
-                                         "12. Typ ciągu komunikacyjnego (Klasa: AD_TypUlicyKod): Część miasta, wsi lub osady, dla której utworzono odrębny spójny zbiór numerów porządkowych nieprzyporządkowanych do żadnej ulicy ani placu."@pl ,
-                                         "Rodzaj jednostki pomocniczej (Klasa: AD_RodzajJednostkiPomocniczej): Część miasta lub wsi, której uchwałą rady gminy nadano status jednostki pomocniczej."@pl ,
-                                         "t. 2, s. 526: nieduże skupisko budynków miejskich lub wiejskich, zespół bloków mieszkalnych, willowe, przyfabryczne, robotnicze, mieszkaniowe"@pl ,
-                                         "t. 20, s. 56: osiedle mieszkaniowe – zespół  mieszkaniowy stanowiący strukturalną jednostkę mieszkaniową w mieście; pojęcie „osiedle mieszkaniowe” wywodzi się z koncepcji jednostki sąsiedzkiej; wielkość osiedla mieszkaniowego wynika z zasięgu pieszego dojścia (600–800 m) do ośrodka usługowego oraz gęstości zaludnienia (5–20 tys. mieszk.) obszaru obsługiwanego przez ten ośrodek. Stanowi zespół budynków mieszkalnych wraz z integralnym zapleczem obiektów usługowych oraz terenów zieleni; niekiedy są wydzielane części osiedli mieszkaniowych – kolonie, złożone z kilku bloków mieszkalnych; kilka osiedli mieszkaniowych tworzy dzielnicę."@pl ,
-                                         "t. 22, s. 124: osiedla, osiedlisko – siedziba, gospodarstwo wraz z zabudowaniami"@pl ,
-                                         "t. 3, s. 590: osiedlić, na osadzie czyli siedlisku postanowić kogoś, osadzić go; osiedlisko – miejsce osiedlenia, osada, osiadłość"@pl ,
-                                         "t. 6, s. 1121: nieduże skupienie siedzib ludzkich (miejskich lub wiejskich); reg. na wsi: dom mieszkalny wraz z zabudowaniami gospodarczymi, zagroda, dostatnie osiedle bogatego chłopa, sołtysowe osiedle"@pl ,
-                                         "zespół mieszkaniowy stanowiący integralną część miasta lub wsi"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "Wohnsiedlung"@de ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Ansiedlung"@de ,
-                                                                              "Siedlung"@de ,
-                                                                              "część miasta"@pl ,
-                                                                              "dzielnica"@pl ,
-                                                                              "hamlet"@en ,
-                                                                              "housing estate"@en ,
-                                                                              "kolonia"@pl ,
-                                                                              "osada"@pl ,
-                                                                              "osiedle willowe"@pl ,
-                                                                              "osiedlisko"@pl ,
-                                                                              "residential quarter"@en ,
-                                                                              "settlement"@en ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "housing developments"@en ,
-                                                                            "osiedle"@pl ;
-                            ontohgis:hasExternalIdentifier "34"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 ,
-                                                   ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_34 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "10. Rodzaj miejscowości (Klasa: AD_RodzajMiejscowosciKod): Zespół mieszkaniowy stanowiący integralną część miasta lub wsi; źródło: ustawa z dnia 29 sierpnia 2003 r. o urzędowych nazwach miejscowości i obiektów fizjograficznych."@pl ;
-   rdfs:isDefinedBy ontohgis:document_22
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_34 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "12. Typ ciągu komunikacyjnego (Klasa: AD_TypUlicyKod): Część miasta, wsi lub osady, dla której utworzono odrębny spójny zbiór numerów porządkowych nieprzyporządkowanych do żadnej ulicy ani placu."@pl ;
-   rdfs:isDefinedBy ontohgis:document_22
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_34 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "Rodzaj jednostki pomocniczej (Klasa: AD_RodzajJednostkiPomocniczej): Część miasta lub wsi, której uchwałą rady gminy nadano status jednostki pomocniczej."@pl ;
-   rdfs:isDefinedBy ontohgis:document_22
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_34 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 2, s. 526: nieduże skupisko budynków miejskich lub wiejskich, zespół bloków mieszkalnych, willowe, przyfabryczne, robotnicze, mieszkaniowe"@pl ;
-   rdfs:isDefinedBy ontohgis:document_19
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_34 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 20, s. 56: osiedle mieszkaniowe – zespół  mieszkaniowy stanowiący strukturalną jednostkę mieszkaniową w mieście; pojęcie „osiedle mieszkaniowe” wywodzi się z koncepcji jednostki sąsiedzkiej; wielkość osiedla mieszkaniowego wynika z zasięgu pieszego dojścia (600–800 m) do ośrodka usługowego oraz gęstości zaludnienia (5–20 tys. mieszk.) obszaru obsługiwanego przez ten ośrodek. Stanowi zespół budynków mieszkalnych wraz z integralnym zapleczem obiektów usługowych oraz terenów zieleni; niekiedy są wydzielane części osiedli mieszkaniowych – kolonie, złożone z kilku bloków mieszkalnych; kilka osiedli mieszkaniowych tworzy dzielnicę."@pl ;
-   rdfs:isDefinedBy ontohgis:document_21
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_34 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 22, s. 124: osiedla, osiedlisko – siedziba, gospodarstwo wraz z zabudowaniami"@pl ;
-   rdfs:isDefinedBy ontohgis:document_2
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_34 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 3, s. 590: osiedlić, na osadzie czyli siedlisku postanowić kogoś, osadzić go; osiedlisko – miejsce osiedlenia, osada, osiadłość"@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_34 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 6, s. 1121: nieduże skupienie siedzib ludzkich (miejskich lub wiejskich); reg. na wsi: dom mieszkalny wraz z zabudowaniami gospodarczymi, zagroda, dostatnie osiedle bogatego chłopa, sołtysowe osiedle"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_34 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "zespół mieszkaniowy stanowiący integralną część miasta lub wsi"@pl ;
-   rdfs:isDefinedBy ontohgis:document_9
- ] .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_35
@@ -13133,34 +11157,7 @@ ontohgis:settlement_type_35 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function2
-                                            ] ;
-                            dct:creator ontohgis:person_7 ,
-                                       ontohgis:person_8 ;
-                            rdfs:comment "Industrial settlement usually emerged as a separate locality, later, quite often, it developed to the rank of the city, merged with another locality creating a separate one, or was incorporated into another locality."@en ,
-                                         "Osada fabryczna powstawała z reguły jako odrębna miejscowość, później, dość często rozwijała się do rangi miasta, łączyła się z inną osadą jako odrębna miejscowość, lub była włączana do innej miejscowości."@pl ;
-                            rdfs:isDefinedBy "Industrial settlement is a settlement in which a main role is played by a factory."@en ,
-                                             "Osada fabryczna jest to osada, w której główną rolę pełni fabryka."@pl ;
-                            rdfs:label "industrial settlement"@en ,
-                                       "osada fabryczna"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "osada przemysłowa (pl)" ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "conlocationen"@la ,
-                                                                              "der Ortschaft"@de ,
-                                                                              "der Siedlung"@de ,
-                                                                              "die Ansiedlung"@de ,
-                                                                              "die Kolonie"@de ,
-                                                                              "kolonia"@pl ,
-                                                                              "miasteczko"@pl ,
-                                                                              "miejscowość"@pl ,
-                                                                              "osiedle"@pl ,
-                                                                              "sadyba"@pl ,
-                                                                              "settlement"@en ,
-                                                                              "zagroda włościańska"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "industrial settlement"@en ,
-                                                                            "osada fabryczna"@pl ;
-                            ontohgis:hasExternalIdentifier "35"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_36
@@ -13169,30 +11166,7 @@ ontohgis:settlement_type_36 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function4
-                                            ] ;
-                            dct:creator ontohgis:person_5 ,
-                                       ontohgis:person_7 ,
-                                       ontohgis:person_8 ;
-                            rdfs:comment "Osada leśna powstawała z reguły jako odrębna, niewielka miejscowość, położona w obrębie lub na skraju obszaru leśnego."@pl ,
-                                         "The forest settlements were usually formed as a separate, small locality, located within or near the forest."@en ;
-                            rdfs:isDefinedBy "A forest settlement is a small settlement located within or at the boundaries of a forest area, inhabited by people involved in administration, exploitation, or availing the surrounding forest areas."@en ,
-                                             "Osada leśna jest to niewielka osada położona w obrębie lub na skraju obszaru leśnego, zamieszkała przez ludność związaną z administrowaniem, eksploatacją lub wykorzystywaniem otaczających obszarów leśnych."@pl ;
-                            rdfs:label "forest settlement"@en ,
-                                       "osada leśna"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Forestrey"@de ,
-                                                                              "Forst Amt"@de ,
-                                                                              "Jagerhaus"@de ,
-                                                                              "gajówka"@pl ,
-                                                                              "leśnictwo"@pl ,
-                                                                              "leśniczówka"@pl ,
-                                                                              "nadleśnictwo"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "forest settlement"@en ,
-                                                                            "osada leśna"@pl ;
-                            ontohgis:hasExternalIdentifier "36"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 ,
-                                                   ontohgis:person_9 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_37
@@ -13205,34 +11179,7 @@ ontohgis:settlement_type_37 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function3
-                                            ] ;
-                            dct:creator ontohgis:person_2 ;
-                            rdfs:comment "Osada miejska to miejscowość."@pl ,
-                                         "Termin był stosowany dla oznaczenia ośrodków, które utraciły prawa miejskie po powstaniu styczniowym. Osada miejska mogła być stosowana także sensie szerszym, obejmującym wszystkie jednostki osadnicze o charakterze miejskim, np. duże miasto, przedmieścia itp."@pl ,
-                                         "This notion was used to mark localites that lost their city rights after the \"January Uprising\". The urban settlement could also be used in a broader sense, encompassing all settlement units of urban character, e.g. a big city, suburbs, etc."@en ,
-                                         "Urban settlement is a locality."@en ;
-                            rdfs:isDefinedBy "Osada miejska to miejscowość posiadająca wcześniej prawa miejskie i aktualnie ich pozbawiona."@pl ,
-                                             "Urban settlement is a locality which used to have city rights, but currently without them."@en ;
-                            rdfs:label "osada miejska"@pl ,
-                                       "urban settlement"@en ;
-                            rdfs:seeAlso <http://dbpedia.org/page/Urban-type_settlement> ,
-                                         <https://www.wikidata.org/wiki/Q18432972> ,
-                                         <https://www.wikidata.org/wiki/Q2989457> ,
-                                         "t. 20. s.47: od 1867 nazwa „osada miejska” jest używana dla niewielkich osiedli pozbawionych praw miejskich, które nie są wsiami."@enpl ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "miasteczko"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "osada miejska"@pl ,
-                                                                            "urban settlement"@en ;
-                            ontohgis:hasExternalIdentifier "37"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_37 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 20. s.47: od 1867 nazwa „osada miejska” jest używana dla niewielkich osiedli pozbawionych praw miejskich, które nie są wsiami."@enpl ;
-   rdfs:comment ontohgis:document_21
- ] .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_38
@@ -13241,32 +11188,7 @@ ontohgis:settlement_type_38 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function2
-                                            ] ;
-                            dct:creator ontohgis:person_7 ;
-                            rdfs:comment "Mill settlement often emereged as a separete locality, which might later be combined with another locality or become a part of it."@en ,
-                                         "Osada młyńska powstawała często jako odrębna miejscowość, później łączyła się niekiedy z inną osadą  lub była włączana do innej miejscowości."@pl ;
-                            rdfs:isDefinedBy "Mill settlement is a settlement in which a main role is played by a mill, most often a watermill, but it also might be a windmill or wind turbine."@en ,
-                                             "Osada młyńska jest to osada, w której główną rolę pełni młyn, najczęściej młyn wodny, ale może to być też również wiatrak lub turbina wiatrowa."@pl ;
-                            rdfs:label "mill settlement"@en ,
-                                       "osada młyńska"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "conlocationen"@la ,
-                                                                              "der Ortschaft"@de ,
-                                                                              "der Siedlung"@de ,
-                                                                              "die Ansiedlung"@de ,
-                                                                              "die Kolonie"@de ,
-                                                                              "kolonia"@pl ,
-                                                                              "miasteczko"@pl ,
-                                                                              "miejscowość"@pl ,
-                                                                              "osiedle"@pl ,
-                                                                              "sadyba"@pl ,
-                                                                              "settlement"@en ,
-                                                                              "zagroda włościańska"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "mill settlement"@en ,
-                                                                            "osada młyńska"@pl ;
-                            ontohgis:hasExternalIdentifier "38"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_41
@@ -13281,33 +11203,7 @@ ontohgis:settlement_type_41 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function3
-                                            ] ;
-                            dct:creator ontohgis:person_6 ;
-                            rdfs:comment "In each analysed case, a rectory being a separate settlement, lays in a vicinity of a village, or a town/city with the same name. In cartographical sources, one can find it presented separately, with its proper name, an abbreviation of a category (i.e. pol “pleb.”, which is “rect.”), and distinguished by its morphology. A rectory differs slightly from the house of a provost, but we leave this difference aside."@en ,
-                                         "We wszystkich analizowanych przypadkach jeżeli plebania jest odrębną miejscowością, to znajduje się w pobliżu wsi, miasta lub osady o tej samej nazwie. W ujęciu kartograficznym wyodrębniona przez nazwę własną, skrót kategorii (np. pleb.) oraz morfologicznie. Plebania różni się nieco od probostwa, gdyż pleban nie jest tożsamy z proboszczem, ale różnicę tę pomijamy."@pl ;
-                            rdfs:isDefinedBy "Plebania jest to miejscowość, w której główną rolę pełni plebania jako obiekt sakralny."@pl ,
-                                             "Rectory is a locality, where the main role is played by a rectory, a home of a provost, as a sacral object."@en ;
-                            rdfs:label "plebania"@pl ,
-                                       "rectory"@en ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "curionatus"@la ,
-                                                                              "curionis domus"@la ,
-                                                                              "curionium"@la ,
-                                                                              "die Pfarre"@de ,
-                                                                              "die Pfarrwohnung"@de ,
-                                                                              "dom plebański"@pl ,
-                                                                              "parafia"@pl ,
-                                                                              "parochia"@la ,
-                                                                              "pastorówka"@pl ,
-                                                                              "plebanatus"@la ,
-                                                                              "popówka"@pl ,
-                                                                              "probostwo"@pl ,
-                                                                              "wikariatka"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "plebania"@pl ,
-                                                                            "rectory"@en ;
-                            ontohgis:hasExternalIdentifier "41"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_43
@@ -13318,86 +11214,14 @@ ontohgis:settlement_type_43 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                               owl:someValuesFrom ontohgis:settlement_type_3
-                                            ] ;
-                            dct:creator ontohgis:person_2 ;
-                            rdfs:comment """Przedmieście z zasady jest częścią miejscowości: miasta. 
-W miastach obwarowanych obrębem miasta była linia fortyfikacji, szczególnie murów.
-Przedmieście mogło mieć różny stopień odrębności prawnej względem miasta. Jest fenomenem charakterystycznym raczej dla epoki przedprzemysłowej. Większość przedmieść, szczególnie od schyłku XVIII w., była wcielana prawnie i następnie funkcjonalnie i morfologicznie do miasta; nazwa zazwyczaj zanikała lub nabierała innego znaczenia.
-Należy odróżnić od przedmieścia osady przedmiejskie, które były w znacznym stopniu niezależne od miasta właściwego lub wręcz sprawowały funkcje centralne względem niego, np. ze względu na siedzibę władz. Taka sytuacja była częsta w okresie lokacyjnym w przypadku większych ośrodków (gród książęcy i katedra poza gminą lokacyjną)."""@pl ,
-                                         """Suburb is always (ex definitione) a part of a locality (city, town).
-In the fortified cities, the area of the core city was limted by the fortifications, especially by the walls.
-The suburb could have a different degree of legal separation from the city. It is an entity typical rather for the pre-industrial era. Most of the suburbs, especially from the end of the 18th c., were incorporated legally and then functionally as well as morphologically into the city. The particular name of the suburb usually disappeared or obtained a different meaning.
-It is necessary to distinguish  suburbs from the suburban settlements which were largely independent of the neighboring city or even held central functions to it, e.g. due to the location of the seats of the authorities. Such a situation was common during the first stages of cities establishment, especially for larger centers (prince's stronghold and the cathedral outside the main municipality)."""@en ;
-                            rdfs:isDefinedBy "Przedmieście to peryferyjna część miasta, tj. położona poza obrębem miasta właściwego (lokacyjnego), wyodrębniona przestrzennie lub morfologicznie i z własną nazwą, wobec której miasto pełni funkcje centralne."@pl ,
-                                             "Suburb is a peripheral part of the city, towards which the city performs central functions. A suburb is located outside its initial location city; distinguished spatially or morphologically and with its own (proper) name."@en ;
-                            rdfs:label "Vorstadt"@de ,
-                                       "przedmieście"@pl ,
-                                       "suburb"@en ,
-                                       "suburbium"@la ;
-                            rdfs:seeAlso <http://linkedgeodata.org/ontology/Suburb> ,
-                                         "Obszar wokół miasta, w ówczesnej Polsce i Europie uzależniony od niego prawnie i gospodarczo"@pl ,
-                                         "osada, teren, posiadłość poza obrębem murów miejskich"@pl ,
-                                         "peryferyjna dzielnica miasta"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "osada podmiejska"@pl ,
-                                                                              "osada przedmiejska"@pl ,
-                                                                              "wieś podmiejska"@pl ;
-                            ontohgis:hasExternalIdentifier "43"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_43 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "Obszar wokół miasta, w ówczesnej Polsce i Europie uzależniony od niego prawnie i gospodarczo"@pl ;
-   rdfs:isDefinedBy ontohgis:document_2
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_43 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "osada, teren, posiadłość poza obrębem murów miejskich"@pl ;
-   rdfs:isDefinedBy ontohgis:document_6
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_43 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "peryferyjna dzielnica miasta"@pl ;
-   rdfs:isDefinedBy ontohgis:document_3
- ] .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_44
 ontohgis:settlement_type_44 rdf:type owl:Class ;
                             rdfs:subClassOf ontohgis:object_1000 ,
                                             ontohgis:settlement_type_1000 ,
-                                            ontohgis:settlement_type_3008 ;
-                            dct:creator ontohgis:person_3 ;
-                            rdfs:isDefinedBy "Hamlet (pol \"przysiółek\") is a small group of buildings belonging to another locality, located on its land, in a remote part, and legally associated with it."@en ,
-                                             "Przysiółek to mała grupa zabudowań, należących do innej miejscowości, położona na jej gruntach, w oddaleniu od niej i prawnie z nią związana."@pl ;
-                            rdfs:label "hamlet"@en ,
-                                       "przysiółek"@pl ;
-                            rdfs:seeAlso <http://linkedgeodata.org/ontology/Hamlet> ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "mała wioska (pl), niesamodzielna osada (pl), skupisko gospodarstw (pl)" ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Colonie"@de ,
-                                                                              "Dorf"@de ,
-                                                                              "Unsiedlung"@de ,
-                                                                              "kolonia"@pl ,
-                                                                              "osada"@pl ,
-                                                                              "predium"@la ,
-                                                                              "przeszolek"@pl ,
-                                                                              "siadło"@pl ,
-                                                                              "siedlisko"@pl ,
-                                                                              "siedziba"@pl ,
-                                                                              "wieś"@pl ,
-                                                                              "wioska"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "hamlet"@en ,
-                                                                            "przysiółek"@pl ;
-                            ontohgis:hasExternalIdentifier "44"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ontohgis:settlement_type_3008 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_45
@@ -13416,32 +11240,16 @@ ontohgis:settlement_type_45 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function8
-                                            ] ;
-                            dct:creator ontohgis:person_5 ;
-                            rdfs:comment "Included as locality type in Bystrzycki's register in the abbreviation list (pol \"kol.\"; \"prz. k.\");included on topographic maps marked with the explanatory abbreviation (pol \"p.\"; ger \"hp.\");included in DBTO10k in the \"objects related to communication\" feature class (OIKM)."@en ,
-                                         "Występuje jako rodzaj miejscowości u Bystrzyckiego w spisie (prz. kol.; prz.. k.); na mapach jako „p.” – przystanek lub „hp.” (ger Haltepunkt). W BDOT10k w klasie obiekt związany z komunikacją."@pl ,
-                                         "dworzec kolejowy"@pl ;
-                            rdfs:isDefinedBy "Przystanek kolejowy (miejscowość) jest to osada, w której główną rolę odgrywa przystanek kolejowy (obiekt)."@pl ,
-                                             "Train stop (locality) is a settlement where the main role is played by a train stop (object)."@en ;
-                            rdfs:label "przystanek kolejowy"@pl ,
-                                       "train stop"@en ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "Haltepunkt (de)" ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Stacja kolejowa"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "przystanek kolejowy"@pl ,
-                                                                            "train stop"@en ;
-                            ontohgis:hasExternalIdentifier "45"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_46
 ontohgis:settlement_type_46 rdf:type owl:Class ;
                             rdfs:subClassOf ontohgis:object_100 ;
                             rdfs:isDefinedBy "abandoned place"@en ;
-                            rdfs:label "pustkowie"^^xsd:string ;
+                            rdfs:label "pustkowie" ;
                             rdfs:seeAlso <http://gov.genealogy.net/types.owl#90> ;
-                            ontohgis:hasExternalIdentifier "46"^^xsd:string .
+                            ontohgis:hasExternalIdentifier "46" .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_47
@@ -13456,25 +11264,7 @@ ontohgis:settlement_type_47 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function4
-                                            ] ;
-                            dct:creator ontohgis:person_6 ;
-                            rdfs:comment "If residential buildings were erected around the tar pitch, it could be a kind of a separate forest settlement. The boundary between a tar pitch as an economic facility and a kind of forest settlement was blurry. It dependended on the seasonality and permanence of habitation."@en ,
-                                         "Jeżeli wokół smolarni utrwaliła się zabudowa mieszkalna to smolarnia mogła stanowić rodzaj odrębnej osady leśnej. Granica między smolarnią jako obiektem gospodarczym a smolarnią jako rodzajem osady leśnej była płynna. Była uzależniona od sezonowości i stałości zamieszkiwania."@pl ;
-                            rdfs:isDefinedBy "Smolarnia (miejscowość) jest to osada, w której główną rolę pełni smolarnia jako obiekt gospodarczy."@pl ,
-                                             "Tar pitch (locality) is a settlement where the main role is played by a tar pitch (industrial facility)."@en ;
-                            rdfs:label "smolarnia"@pl ,
-                                       "tar pitch"@en ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "der Teerofen (de), smolanoi zawod (ru)" ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "dziegciarnia"@pl ,
-                                                                              "huta"@pl ,
-                                                                              "osada leśna"@pl ,
-                                                                              "terpentyniarnia"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "smolarnia"@pl ,
-                                                                            "tar pitch"@en ;
-                            ontohgis:hasExternalIdentifier "47"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_48
@@ -13492,27 +11282,7 @@ ontohgis:settlement_type_48 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function8
-                                            ] ;
-                            dct:creator ontohgis:person_5 ;
-                            rdfs:comment "Included as locality type in Bystrzycki's register in the abbreviation list (pl. \"st. kol.\"; \"st. k.\");included on topographic maps marked with the explanatory abbreviation (pl. \"St.\" or \"St. tow.\" [freight station], ger \"H.st.\" [Haltestation]);included in DBTO10k in the \"communication complex\" feature class (KUKO)."@en ,
-                                         "Stacja kolejowa występuje jako rodzaj miejscowości u Bystrzyckiego w spisie (st. kol.; st. k.); na mapach oznaczana skrótem objaśniającym „St.” lub „St. tow.” (stacja towarowa), „H.st.” (ger Haltestation);w BDOT10k w klasie kompleks komunikacyjny."@pl ;
-                            rdfs:isDefinedBy "Railway station (locality) is a settlement where the main role is played by a railway station (object)."@en ,
-                                             "Stacja kolejowa (miejscowość) jest to osada, w której główną rolę odgrywa stacja kolejowa (obiekt)."@pl ;
-                            rdfs:label "railway station"@en ,
-                                       "stacja kolejowa"@pl ;
-                            rdfs:seeAlso <http://dbpedia.org/ontology/RailwayStation> ,
-                                         <http://gov.genealogy.net/types.owl#119> ,
-                                         <http://linkedgeodata.org/ontology/RailwayStation> ,
-                                         <http://linkedgeodata.org/ontology/TrainStation> ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "Haltestation (de)" ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "dworzec kolejowy"@pl ,
-                                                                              "przystanek kolejowy"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "railway station"@en ,
-                                                                            "stacja kolejowa"@pl ;
-                            ontohgis:hasExternalIdentifier "48"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_50
@@ -13530,26 +11300,7 @@ ontohgis:settlement_type_50 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function8
-                                            ] ;
-                            dct:creator ontohgis:person_6 ;
-                            rdfs:comment "If residential buildings emerged around a sawmill, then it could be a kind of a separate forest settlement or a mill settlement. The distinction between the sawmill as an industrial facility and the sawmill as a kind of locality was blurry. It depended on the seasonality or permanence of habitation."@en ,
-                                         "Jeżeli wokół tartaku utrwaliła się zabudowa mieszkalna to tartak mógł stanowić rodzaj odrębnej osady leśnej lub osady młyńskiej. Granica między tartakiem jako obiektem gospodarczym a tartakiem jako rodzajem osady była płynna. Była uzależniona od sezonowości i stałości zamieszkiwania."@pl ,
-                                         "piła"@pl ;
-                            rdfs:isDefinedBy "Sawmill (locality) is a locality where the main role is played by a sawmill (facility)."@en ,
-                                             "Tartak (miejscowość) to miejscowość, w której główną rolę odgrywa tartak (obiekt)."@pl ;
-                            rdfs:label "sawmill"@en ,
-                                       "tartak"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "das Sägewerk (de), lesopilnyi zawod (ru)" ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "die Säge"@de ,
-                                                                              "młyn"@pl ,
-                                                                              "osada leśna"@pl ,
-                                                                              "osada młyńska"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "sawmill"@en ,
-                                                                            "tartak"@pl ;
-                            ontohgis:hasExternalIdentifier "50"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_51
@@ -13563,21 +11314,7 @@ ontohgis:settlement_type_51 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function8
-                                            ] ;
-                            dct:creator ontohgis:person_6 ;
-                            rdfs:comment "If residential buildings emerged around a peat mine, then it could be a kind of a separate mine settlement or an industrial settlement. The distinction between the peat mine as an industrial facility and the peat mine as a kind of locality was blurry. It depended on the seasonality or permanence of habitation."@en ,
-                                         "Jeżeli wokół torfiarni utrwaliła się zabudowa mieszkalna to torfiarnia mogła stanowić rodzaj odrębnej osady górniczej lub osady fabrycznej. Granica między torfiarnią jako obiektem gospodarczym a torfiarnią jako rodzajem osady była płynna. Była uzależniona od sezonowości i stałości zamieszkiwania."@pl ;
-                            rdfs:isDefinedBy "Peat mine (locality) is a locality where the main role is played by a peat mine (facility)."@en ,
-                                             "Torfiarnia (miejscowość) jest to miejscowość, w której główną rolę odgrywa torfiarnia (obiekt)."@pl ;
-                            rdfs:label "peat mine"@en ,
-                                       "torfiarnia"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "torfowisko"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "peat mine"@en ,
-                                                                            "torfiarnia"@pl ;
-                            ontohgis:hasExternalIdentifier "51"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_52
@@ -13590,26 +11327,7 @@ ontohgis:settlement_type_52 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function5
-                                            ] ;
-                            dct:creator ontohgis:person_2 ;
-                            rdfs:comment "A fortress might be a separate settlement unit or a building inside a superior unit."@en ,
-                                         "Twierdza mogła być samodzielną jednostką osadniczą lub obiektem w obrębie większej jednostki."@pl ;
-                            rdfs:isDefinedBy "Fortress is a locality for which a defensive function is dominant."@en ,
-                                             "Miejscowość, dla której dominująca jest funkcja obronna."@pl ;
-                            rdfs:label "fortress"@en ,
-                                       "twierdza"@pl ;
-                            rdfs:seeAlso <http://linkedgeodata.org/ontology/Fortress> ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "forteca (pl)" ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "fortyfikacje"@pl ,
-                                                                              "gród"@pl ,
-                                                                              "umocnienia"@pl ,
-                                                                              "zamek"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "fortress"@en ,
-                                                                            "twierdza"@pl ;
-                            ontohgis:hasExternalIdentifier "52"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_53
@@ -13622,48 +11340,7 @@ ontohgis:settlement_type_53 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function10
-                                            ] ;
-                            dct:creator ontohgis:person_5 ;
-                            rdfs:comment """Functional distinctivness - clearly defined function, a locality connected with the service of bathers/visitors; it seems this is not the most important criterion of defining a type of locality (e.g. Ciechocinek in Bystrzycki's register is a city, not a spa).
-Morphological distinctiness - loose built-up area (spa-type), mostly in the woods (e.g. Czarniecka Góra, Miłowody); Nałęczów in Bystrzycki's register is also referred to as a health resort, and is characterized as densely built-up area (see: MGI maps).
-Spatial distinctiveness - clear, as far as Czarniecka Góra and Miłowody (spas located among the forest) are concerned."""@en ,
-                                         "Included as a kind of locality in Bystrzycki's register in the abbreviations as \"spa\" (pol \"uzdrow.\").Included on MGI maps where spas are annotated in the same manner as localites (e.g. Czarniecka Góra, Nałęczów) or buildings/field objects (Miłowody); there is no distinct symbol/abbreviation explained in maps' key to symbols (legends)."@en ,
-                                         """Odrębność funkcjonalna – jasno zdefiniowana funkcja, miejscowość związana z obsługa kuracjuszy; wydaje się, że nie jest to najistotniejsze kryterium (np. Ciechocinek u Bystrzyckiego jest miastem, a nie uzdrowiskiem).
-Odrębność morfologiczna – luźna zabudowa (uzdrowiskowa), najczęściej pośród lasu (Czarniecka Góra, Miłowody); Nałęczów u Bystrzyckiego również jest określany jako uzdrowisko, a cechuje się zabudową zwartą (patrz: mapy WIG).
-Odrębność przestrzenna – wyraźna w przy Czarnieckiej Górze i Miłowodach (uzdrowiska położone pośród lasu)."""@pl ,
-                                         "Występuje jako rodzaj miejscowości u Bystrzyckiego w spisie (uzdrow.).Na mapach WIG oznaczane krojem pisma charakterystycznym dla miejscowości (Czarniecka Góra, Nałęczów) lub budynków/obiektów terenowych (Miłowody); brak odrębnej sygnatury/skrótu objaśniające w legendach."@pl ;
-                            rdfs:isDefinedBy "A spa is a locality, where climate enhances treatment, and a main function of which is to serve bathers and visitors."@en ,
-                                             "Uzdrowisko jest miejscowością, w której warunki klimatyczne sprzyjają leczeniu chorób i której główną funkcją jest obsługa kuracjuszy"@pl ;
-                            rdfs:label "spa"@en ,
-                                       "uzdrowisko"@pl ;
-                            rdfs:seeAlso <http://dbpedia.org/page/Spa_town> ,
-                                         <https://www.wikidata.org/wiki/Q4946461> ,
-                                         <https://www.wikidata.org/wiki/Q6882870> ,
-                                         "miejscowość, która ze względu na warunki klimatyczne, źródła lecznicze, pokłady borowiny, itp. sprzyja leczeniu chorób i służy jako ośrodek leczniczy i wypoczynkowy"@pl ,
-                                         "t. 7, s. 424 – zakład leczniczy, lecznisko, leczysko, sanatorium"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "spa town"@en ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "lecznica"@pl ,
-                                                                              "letnisko"@pl ,
-                                                                              "sanatorium"@pl ;
-                            ontohgis:hasExternalIdentifier "53"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 ,
-                                                   ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_53 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "miejscowość, która ze względu na warunki klimatyczne, źródła lecznicze, pokłady borowiny, itp. sprzyja leczeniu chorób i służy jako ośrodek leczniczy i wypoczynkowy"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_53 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 7, s. 424 – zakład leczniczy, lecznisko, leczysko, sanatorium"@pl ;
-   rdfs:isDefinedBy ontohgis:document_5
- ] .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_54
@@ -13672,91 +11349,7 @@ ontohgis:settlement_type_54 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function8
-                                            ] ;
-                            dct:creator ontohgis:person_6 ;
-                            rdfs:comment """Forest distrct as it had a separate name and was spatially distinct, it could have been a locality (inhabited forest district) or a settlement unit (uninhabited, deserted forest district). This second category was dominant. As an inhabited forest district (next to the village, town, farm, etc.), it is mentioned in the registers concerning the eastern provinces of the former Polish-Lithuanian Commonwealth. The number of residents usually did not exceed a dozen or so people. Currently, a forest district is a type of physiographic object in the \"Other physiographic object\" class of objects in the State Register of Geographical Names.
-The basic criterion of distinguishing forest district from other localities or settlement units from the perspective of its functionality is its relation to the organization of forestry or agricultural production. Individual parts of forest or agricultural areas for a better understanding of space received their own names. It also did not exclude the forest settlement form the process of settling and thus the transformation to the kind of locality. The morphological distinctiveness of forest districts due to the nature of natural boundaries (swamps, glades, etc.) is fuzzy. From the legal point of view, the status of the forest district is rather unclear because this term was also used in relation to various types of forest settlements or parts of forests such as \"bór\" or \"ostęp\"."""@en ,
-                                         """Uroczysko, ponieważ posiadało odrębną nazwę i było wydzielone przestrzennie, mogło być miejscowością (uroczysko zamieszkane) lub jednostką osadniczą (uroczysko niezamieszkane, uroczysko opuszczone). Ta druga kategoria była dominująca. Jako kategoria miejscowości (obok wsi, miasta, folwarku etc.) wymieniane jest w rejestrach dotyczących wschodnich województw dawnej Rzeczypospolitej. Liczba mieszkańców nie przekraczała zazwyczaj kilkunastu osób. Obecnie uroczysko jest rodzajem obiektu fizjograficznego w klasie obiektów \"Inny obiekt fizjograficzny\" w Państwowym Rejestrze Nazw Geograficznych.
-Podstawowym kryterium wyodrębniającym uroczysko od innych miejscowości lub jednostek osadniczych w aspekcie funkcjonalnym jest jego związek z organizacją produkcji leśnej lub rolniczej. Poszczególne części obszarów leśnych lub rolnych dla lepszej orientacji w przestrzeni otrzymywały swoje nazwy własne. Nie wykluczało to też procesu osiedlania się a tym samym przekształcania uroczyska w rodzaj miejscowości. Odrębność morfologiczna uroczysk ze względu na charakter granic naturalnych (bagna, polany etc.) jest rozmyta. Od strony prawnej status uroczyska jest dość niejasny, gdyż termin ten był używany także w odniesieniu do różnego typu osad leśnych lub części lasów takich jak bory czy ostępy."""@pl ;
-                            rdfs:isDefinedBy "Forest distrct is a part of a forest, meadow or swampy area separated by natural borders and an own (proper) name for better organization of social and economic life. Built-up and inhabited forest district used to be a locality."@en ,
-                                             "Uroczysko to obszar leśny, łąkowy lub bagnisty wyodrębniony naturalnymi granicami oraz nazwą własną w celu lepszej organizacji życia społecznego i gospodarczego. Uroczysko zabudowane i zamieszkane było miejscowością."@pl ;
-                            rdfs:label "forest district"@en ,
-                                       "uroczysko"@pl ;
-                            rdfs:seeAlso <http://vocab.getty.edu/aat/300379281> ,
-                                         <https://pzgik.geoportal.gov.pl/ontologies/prng/uroczysko> ,
-                                         <https://pzgik.geoportal.gov.pl/ontologies/prng/uroczysko-dawnaMiejsc> ,
-                                         <https://www.wikidata.org/wiki/Q1434274> ,
-                                         "1. teren trudno dostępny, najczęściej bagnisty, leśny; też: miejsce odludne, 2. część terenu otoczona naturalnymi granicami, wyodrębniona za pomocą nazwy topograficznej, 3. u dawnych Słowian: miejsce w głębi puszczy związane z kultem bóstwa, odbywaniem narad lub uważane za siedzibę złych duchów"@pl ,
-                                         "s. 57-80: uroczyska to cała gama pojęć, stale łąki i lokacje straży leśnej, czasem synonimy borów i ostępów, zjawiska terenowe zasadniczo rozległe o wielce zróżniczkowanej, a raczej nieuchwytnej i zatraconej już, treści. Można tylko utrzymywać, że uroczyska to teren eksploatacji par excellence."@pl ,
-                                         "t. 15, s. 34: nazwa kopca lub miejsca granicznego nieosiedlonego. Według Chodakowskiego, uroczyska, na Rusi horodyszczami zwane, były to w Słowiańszczyźnie przedchrześcijańskiej place, czyli świątyń posady, do sprawowania uroczystych pogańskich ofiar przeznaczone i nie mające śladu opisania wałami, byleby oddzielna, właściwe imię mająca, przywiązana do nich była jakaś pamiątka."@pl ,
-                                         "t. 6, s. 80: uroczysko, uroczyszcze -- (Rs. urocziszcze, = powiat, kraina); kopiec, mieysce graniczne. Tr. Gränzstein, Mohlhausen."@pl ,
-                                         "t. 7, s. 348: 1. starożytny , z czasów pogańskich nasyp ziemny w postaci mogiły a. okopu, kopiec, kurhan; miejsce graniczne. Troc. 2. miejsce odludne, tajemnicze – 3. miejscowość nie zamieszkana, nosząca jakie oddzielne charakterystyczne miano – 4. pewna część gruntu a. gruntów kilku posiadaczy w jednym miejscu, nosząca pewną nazwę – 5. miejsce w polu, składające się z gruntu i łąk, dawniej zarosłe lasem. 6. bart. okręg bartniczy --, 7. leśn. część lasu, oddzielona od innych części naturalnymi granicami, jako oto: wzgórzami, strumykami, łąkami, drogami i.t.p. albo też różniąca się drzewostanem"@pl ,
-                                         "t. 9, s. 431: 1. miedza graniczna, granica, limes agrorum, finis -- 2. teren poza granicą posiadłości, ale do niej przynależny, z własnymi granicami naturalnymi, locus extra fines praedii situs, sed ad id praedium pertinens, proprios fines naturales habens."@pl ,
-                                         "u dawnych Słowian: miejsce przed świątynią lub w głębi puszczy, związane z kultem jakiegoś bóstwa, z odbywaniem narad, sądów; ogólnie: miejsce odludne, tajemnicze; pustkowie -- 2. część terenu (zwykle lasu wyodrębniona za pomocą nazwy o charakterze topograficznym."@pl ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "урочище"@ru ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "bór"@pl ,
-                                                                              "leśniczówka"@pl ,
-                                                                              "osada leśna"@pl ,
-                                                                              "ostęp"@pl ,
-                                                                              "strażnica leśna"@pl ,
-                                                                              "łąka"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "forest district"@en ,
-                                                                            "uroczysko"@pl ;
-                            ontohgis:hasExternalIdentifier "54"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_54 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "1. teren trudno dostępny, najczęściej bagnisty, leśny; też: miejsce odludne, 2. część terenu otoczona naturalnymi granicami, wyodrębniona za pomocą nazwy topograficznej, 3. u dawnych Słowian: miejsce w głębi puszczy związane z kultem bóstwa, odbywaniem narad lub uważane za siedzibę złych duchów"@pl ;
-   rdfs:isDefinedBy <http://sjp.pwn.pl/sjp/uroczysko;2533316.html> ,
-                    ontohgis:document_3
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_54 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "s. 57-80: uroczyska to cała gama pojęć, stale łąki i lokacje straży leśnej, czasem synonimy borów i ostępów, zjawiska terenowe zasadniczo rozległe o wielce zróżniczkowanej, a raczej nieuchwytnej i zatraconej już, treści. Można tylko utrzymywać, że uroczyska to teren eksploatacji par excellence."@pl ;
-   rdfs:isDefinedBy ontohgis:document_14
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_54 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 15, s. 34: nazwa kopca lub miejsca granicznego nieosiedlonego. Według Chodakowskiego, uroczyska, na Rusi horodyszczami zwane, były to w Słowiańszczyźnie przedchrześcijańskiej place, czyli świątyń posady, do sprawowania uroczystych pogańskich ofiar przeznaczone i nie mające śladu opisania wałami, byleby oddzielna, właściwe imię mająca, przywiązana do nich była jakaś pamiątka."@pl ;
-   rdfs:isDefinedBy ontohgis:document_15
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_54 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 6, s. 80: uroczysko, uroczyszcze -- (Rs. urocziszcze, = powiat, kraina); kopiec, mieysce graniczne. Tr. Gränzstein, Mohlhausen."@pl ;
-   rdfs:isDefinedBy ontohgis:person_21
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_54 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 7, s. 348: 1. starożytny , z czasów pogańskich nasyp ziemny w postaci mogiły a. okopu, kopiec, kurhan; miejsce graniczne. Troc. 2. miejsce odludne, tajemnicze – 3. miejscowość nie zamieszkana, nosząca jakie oddzielne charakterystyczne miano – 4. pewna część gruntu a. gruntów kilku posiadaczy w jednym miejscu, nosząca pewną nazwę – 5. miejsce w polu, składające się z gruntu i łąk, dawniej zarosłe lasem. 6. bart. okręg bartniczy --, 7. leśn. część lasu, oddzielona od innych części naturalnymi granicami, jako oto: wzgórzami, strumykami, łąkami, drogami i.t.p. albo też różniąca się drzewostanem"@pl ;
-   rdfs:isDefinedBy ontohgis:document_5
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_54 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 9, s. 431: 1. miedza graniczna, granica, limes agrorum, finis -- 2. teren poza granicą posiadłości, ale do niej przynależny, z własnymi granicami naturalnymi, locus extra fines praedii situs, sed ad id praedium pertinens, proprios fines naturales habens."@pl ;
-   rdfs:isDefinedBy ontohgis:document_6
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_54 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "u dawnych Słowian: miejsce przed świątynią lub w głębi puszczy, związane z kultem jakiegoś bóstwa, z odbywaniem narad, sądów; ogólnie: miejsce odludne, tajemnicze; pustkowie -- 2. część terenu (zwykle lasu wyodrębniona za pomocą nazwy o charakterze topograficznym."@pl ;
-   rdfs:isDefinedBy <http://sjp.pwn.pl/doroszewski/uroczysko;5512266.html> ,
-                    ontohgis:document_4
- ] .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_55
@@ -13771,7 +11364,7 @@ ontohgis:settlement_type_55 rdf:type owl:Class ;
                                        "więzienie"@pl ;
                             rdfs:seeAlso <http://dbpedia.org/ontology/Prison> ,
                                          <http://linkedgeodata.org/ontology/Prison> ;
-                            ontohgis:hasExternalIdentifier "55"^^xsd:string .
+                            ontohgis:hasExternalIdentifier "55" .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_56
@@ -13781,26 +11374,7 @@ ontohgis:settlement_type_56 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function1
-                                            ] ;
-                            dct:creator ontohgis:person_3 ;
-                            rdfs:comment "\"Zaścianek\" is typical mostly for Mazovia, Podlachia and areas of the former Grand Duchy of Lithuania."@en ,
-                                         "Zaścianki są najbardziej charakterystyczne dla Mazowsza, Podlasia i obszarów dawnego Wielkiego Księstwa Litewskiego."@pl ;
-                            rdfs:isDefinedBy "\"Zaścianek\" is an agricultural locality inhabited by the poor nobility who cultivate their land on their own."@en ,
-                                             "Zaścianek to miejscowość o charakterze rolniczym zamieszkała przez drobną szlachtę samodzielnie uprawiającą posiadaną ziemię."@pl ;
-                            rdfs:label "\"zaścianek\""@en ,
-                                       "zaścianek"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "okolica"@pl ,
-                                                                           "zagroda"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "obszar"@pl ,
-                                                                              "osada"@pl ,
-                                                                              "przysiółek"@pl ,
-                                                                              "wieś"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "\"zaścianek\""@en ,
-                                                                            "zaścianek"@pl ;
-                            ontohgis:hasExternalIdentifier "56"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_6
@@ -13812,7 +11386,7 @@ ontohgis:settlement_type_6 rdf:type owl:Class ;
                                       "dzielnica"@pl ;
                            rdfs:seeAlso <http://dbpedia.org/ontology/CityDistrict> ,
                                         <http://linkedgeodata.org/ontology/Subdivision> ;
-                           ontohgis:hasExternalIdentifier "6"^^xsd:string .
+                           ontohgis:hasExternalIdentifier "6" .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_60
@@ -13827,21 +11401,7 @@ ontohgis:settlement_type_60 rdf:type owl:Class ;
                                                 ] ;
                             rdfs:subClassOf ontohgis:object_1000 ,
                                             ontohgis:settlement_type_1000 ,
-                                            ontohgis:settlement_type_3008 ;
-                            dct:creator ontohgis:person_7 ,
-                                       ontohgis:person_8 ;
-                            rdfs:comment "Część kolonii jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Części kolonii występują najczęściej w woj. lubelskim, łódzkim i pomorskim. W sumie jest ich w Polsce 281."@pl ,
-                                         "Part of a colony is a separate settlement unit, a kind of locality, always has a particular name. Parts of colonies occur most often in Lubelskie, Łódzkie, and Pomorskie voivodships. In total, there are 281 parts of colonies in Poland."@en ;
-                            rdfs:isDefinedBy "Część kolonii to miejscowość stanowiąca integralną część miejscowości podstawowej kolonii, jest wydzielona administracyjnie, ale należy do jednostki nadrzędnej."@pl ,
-                                             "Part of a colony is an integral part of the main locality a colony; it is administratively separated, but belongs to the superior unit."@en ;
-                            rdfs:label "część kolonii"@pl ,
-                                       "part of a colony"@en ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "część kolonii"@pl ,
-                                                                            "part of a colony"@en ;
-                            ontohgis:hasExternalIdentifier "60"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ontohgis:settlement_type_3008 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_61
@@ -13860,31 +11420,7 @@ ontohgis:settlement_type_61 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function3
-                                            ] ;
-                            dct:creator ontohgis:person_7 ,
-                                       ontohgis:person_8 ;
-                            rdfs:comment "Część miasta jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. W sumie jest ich w Polsce 10425. Są to części miejscowości skupiające się często wokół większych miejscowości w całej Polsce, większe skupiska części miejscowości są m. in. w woj. śląskim, mazowieckim, małopolskim, wielkopolskim, pomorskim."@pl ,
-                                         "Part of a city is a separate settlement unit, a kind of locality, it always has a particular name. There are 10425 of these units in Poland at the moment. These are mostly parts of localities converging upon bigger localities around Poland. Large clusters of these units are located i.e. in Śląskie, Mazowieckie, Małopolskie, Wielkopolskie, and Pomorskie voivodeships."@en ;
-                            rdfs:isDefinedBy "Część miasta to miejscowość stanowiąca integralną część miejscowości podstawowej miasta, jest wydzielona administracyjnie, ale należy do jednostki nadrzędnej."@pl ,
-                                             "Part of a city is an integral part of the main locality a city (or a town); it is administratively separated, but belongs to the superior unit."@en ;
-                            rdfs:label "część miasta"@pl ,
-                                       "part of a city"@en ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Stadt"@de ,
-                                                                              "city"@en ,
-                                                                              "gorod"@ru ,
-                                                                              "gród"@pl ,
-                                                                              "metropolia"@pl ,
-                                                                              "miasteczko"@pl ,
-                                                                              "miejscowość"@pl ,
-                                                                              "mieścina"@pl ,
-                                                                              "town"@en ,
-                                                                              "urbs"@la ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "część miasta"@pl ,
-                                                                            "part of a city"@en ;
-                            ontohgis:hasExternalIdentifier "61"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_62
@@ -13903,33 +11439,7 @@ ontohgis:settlement_type_62 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function3
-                                            ] ;
-                            dct:creator ontohgis:person_7 ,
-                                       ontohgis:person_8 ;
-                            rdfs:comment "Część osady jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Części osady występują w większości na Pomorzu. W sumie jest ich w Polsce 76."@pl ,
-                                         "Part of a settlement is a separate settlement unit, a kind of locality, it always has a particular name. Parts of settlements occur mostly in Pomorze. In total, there are 76 parts of settlements in Poland."@en ;
-                            rdfs:isDefinedBy "Część osady to miejscowość stanowiąca integralną część miejscowości podstawowej osady, jest wydzielona administracyjnie, ale należy do jednostki nadrzędnej."@pl ,
-                                             "Part of a settlement is an integral part of the main locality a settlement, it is administratively separated, but belongs to the superior unit."@en ;
-                            rdfs:label "część osady"@pl ,
-                                       "part of a settlement"@en ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "conlocationen"@la ,
-                                                                              "der Ortschaft"@de ,
-                                                                              "der Siedlung"@de ,
-                                                                              "die Ansiedlung"@de ,
-                                                                              "die Kolonie"@de ,
-                                                                              "kolonia"@pl ,
-                                                                              "miasteczko"@pl ,
-                                                                              "miejscowość"@pl ,
-                                                                              "osiedle"@pl ,
-                                                                              "sadyba"@pl ,
-                                                                              "settlement"@en ,
-                                                                              "zagroda włościańska"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "część osady"@pl ,
-                                                                            "part of a settlement"@en ;
-                            ontohgis:hasExternalIdentifier "62"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_63
@@ -13948,30 +11458,7 @@ ontohgis:settlement_type_63 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function1
-                                            ] ;
-                            dct:creator ontohgis:person_7 ,
-                                       ontohgis:person_8 ;
-                            rdfs:comment "A part of a village is a separate settlement unit, a kind of locality, and always has its own (individual) name. There are 41942 parts of villages around the whole Poland at the moment."@en ,
-                                         "Część wsi jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Części wsi występują w całej Polsce. W sumie jest ich w Polsce 41942."@pl ;
-                            rdfs:isDefinedBy "A part of a village is a locality being an integral part of the main locality a village; it is administratively separated, but belongs to the superior unit."@en ,
-                                             "Część wsi to miejscowość stanowiąca integralną część miejscowości podstawowej wsi, jest wydzielona administracyjnie, ale przynależy do jednostki nadrzędnej."@pl ;
-                            rdfs:label "część wsi"@pl ,
-                                       "part of a village"@en ;
-                            rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/czescWsi> ,
-                                         <https://www.wikidata.org/wiki/Q41970180> ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Dorf"@de ,
-                                                                              "Land"@de ,
-                                                                              "country"@en ,
-                                                                              "derewnia"@ru ,
-                                                                              "pagus"@la ,
-                                                                              "seło"@ru ,
-                                                                              "sioło"@pl ,
-                                                                              "village"@en ,
-                                                                              "wioska"@pl ;
-                            ontohgis:hasExternalIdentifier "63"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_64
@@ -13986,34 +11473,7 @@ ontohgis:settlement_type_64 rdf:type owl:Class ;
                                                 ] ;
                             rdfs:subClassOf ontohgis:settlement_type_20 ,
                                             ontohgis:settlement_type_3008 ,
-                                            ontohgis:settlement_type_60 ;
-                            dct:creator ontohgis:person_7 ,
-                                       ontohgis:person_8 ;
-                            rdfs:comment "Colony of a colony is a separate settlement unit, a kind of locality, and always has its particular name. They occur most often in the Lubelskie and Podlaskie voivodships. In total, there are 31 colonies of colony at the moment."@en ,
-                                         "Kolonia kolonii jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Kolonia kolonii występują w większości w woj. lubelskim i woj. podlaskim. W sumie jest ich obecnie w Polsce 31."@pl ;
-                            rdfs:isDefinedBy "Colony of a colony is a colony which is related to a colony."@en ,
-                                             "Kolonia osady to kolonia zależna od kolonii."@pl ;
-                            rdfs:label "colony of a colony"@en ,
-                                       "kolonia kolonii"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "chutor"@pl ,
-                                                                              "coloniam"@la ,
-                                                                              "część wsi"@pl ,
-                                                                              "die Kolonie"@de ,
-                                                                              "housing estate"@en ,
-                                                                              "koloniya"@ru ,
-                                                                              "kolonizacja"@pl ,
-                                                                              "osiedle"@pl ,
-                                                                              "przysiółek"@pl ,
-                                                                              "settlement"@en ,
-                                                                              "sioło"@pl ,
-                                                                              "stanica"@pl ,
-                                                                              "wybudowanie"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "colony of a colony"@en ,
-                                                                            "kolonia kolonii"@pl ;
-                            ontohgis:hasExternalIdentifier "64"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ontohgis:settlement_type_60 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_65
@@ -14032,23 +11492,7 @@ ontohgis:settlement_type_65 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function3
-                                            ] ;
-                            dct:creator ontohgis:person_7 ,
-                                       ontohgis:person_8 ;
-                            rdfs:comment "A built-up area located away from previously existing buildings (locality) to which it is related. Colony of a settlement is a separate settlement unit, a kind of locality, always with its particular name. Colonies of settlements occur mainly in Zachodniopomorskie, Warmińsko-mazurskie and Podlaskie voivodships. In total, there are 17 colonies of settlements in Poland."@en ,
-                                         "Obszar zabudowany oddalony od wczesniejszej zabudowy, od której jest zależny. Kolonia osady jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Kolonie osady występują w większości w woj. zachodniopomorskim, warmińsko-mazurskim i woj. podlaskim. W sumie jest ich w Polsce 17."@pl ;
-                            rdfs:isDefinedBy "Colony of a settlement is a colony related to a settlement."@en ,
-                                             "Kolonia osady to kolonia zależna od osady."@pl ;
-                            rdfs:label "colony of a settlement"@en ,
-                                       "kolonia osady"@pl ;
-                            rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/koloniaOsady> ,
-                                         <https://www.wikidata.org/wiki/Q41970180> ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "colony of a settlement"@en ,
-                                                                            "kolonia osady"@pl ;
-                            ontohgis:hasExternalIdentifier "65"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_66
@@ -14067,34 +11511,7 @@ ontohgis:settlement_type_66 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function1
-                                            ] ;
-                            dct:creator ontohgis:person_7 ,
-                                       ontohgis:person_8 ;
-                            rdfs:comment "Colony of a village is a separate settlement unit, a kind of locality, and always has its particular name. They are spread all over modern Poland and there are 4043 collonies of villages at the moment."@en ,
-                                         "Kolonia wsi jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Kolonie wsi występują w całej Polsce. W sumie jest ich obecnie w Polsce 4043."@pl ;
-                            rdfs:isDefinedBy "Colony of a village is a colony related to a village."@en ,
-                                             "Kolonia wsi to kolonia zależna od wsi."@pl ;
-                            rdfs:label "colony of a village"@en ,
-                                       "kolonia wsi"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "chutor"@pl ,
-                                                                              "coloniam"@pl ,
-                                                                              "część wsi"@pl ,
-                                                                              "die Kolonie"@de ,
-                                                                              "housing estate"@en ,
-                                                                              "koloniya"@ru ,
-                                                                              "kolonizacja"@pl ,
-                                                                              "osiedle"@pl ,
-                                                                              "przysiółek"@pl ,
-                                                                              "settlement"@en ,
-                                                                              "sioło"@pl ,
-                                                                              "stanica"@pl ,
-                                                                              "wybudowanie"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "colony of a village"@en ,
-                                                                            "kolonia wsi"@pl ;
-                            ontohgis:hasExternalIdentifier "66"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_68
@@ -14113,23 +11530,7 @@ ontohgis:settlement_type_68 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function3
-                                            ] ;
-                            dct:creator ontohgis:person_7 ,
-                                       ontohgis:person_8 ;
-                            rdfs:comment "Brak oficjalnej definicji w \"Ustawie o nazwach urzędowych miejscowości i jednostek fizjograficznych\"."@pl ,
-                                         "No official definition in the \"Act on official names of localities and physiographic units\"."@en ,
-                                         "Są cztery takie obiekty w Polsce, wszystkie w woj. lubelskim."@pl ,
-                                         "There are 4 such a settlements is contemporary Poland: all in Lubelskie voivodship."@en ;
-                            rdfs:isDefinedBy "Osada kolonii jest to osada stanowiąca integralną część kolonii."@pl ,
-                                             "Settlement of a colony is a settlement which is an integral part of a colony."@en ;
-                            rdfs:label "osada kolonii"@pl ,
-                                       "settlement of a colony"@en ;
-                            rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/osadaKolonii> ,
-                                         <https://www.wikidata.org/wiki/Q41970180> ;
-                            ontohgis:hasExternalIdentifier "68"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_69
@@ -14147,119 +11548,12 @@ ontohgis:settlement_type_69 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function4
-                                            ] ;
-                            dct:creator ontohgis:person_7 ,
-                                       ontohgis:person_8 ;
-                            rdfs:comment "Brak oficjalnej definicji w \"Ustawie o nazwach urzędowych miejscowości i jednostek fizjograficznych\"."@pl ,
-                                         "No official definition in the \"Act on official names of localities and physiographic units\"."@en ,
-                                         "Są 233 takie obiekty w Polsce, świętokrzyskie, północnym lubelskim, północnym lubuskim, Borach Tucholskich."@pl ,
-                                         "There are 233 forest settlements of a village in Poland, mainly in Świętokrzyskie northern part of Lubelskie, northern part of Lubuskie voivodships as well as in \"Bory Tuchulskie\" (Pomorskie voivodship)."@en ;
-                            rdfs:isDefinedBy "Forest settlement of a village is a forest settlement which is an integral part of  a village."@en ,
-                                             "Osada leśna wsi to osada leśna stanowiąca integralną część wsi."@pl ;
-                            rdfs:label "forest settlement of a village"@en ,
-                                       "osada leśna wsi"@pl ;
-                            rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/osadaLesnaWsi> ,
-                                         <https://www.wikidata.org/wiki/Q41970180> ,
-                                         "t. 20. s.47: Osady przemysłowe - osiedla dla robotników i rzemieślników zakładane XVIII – XIX w. w związku z dokonującym się procesem uprzemysłowienia, niekiedy zwane osadami fabrycznymi; zwykle osady przemysłowe obejmowały zarówno zakłady przemysłowe jak i związane z nimi kolonie domów mieszkalnych. Na ziemiach polskich powstawały od końca XVIII wieku jako osady prywatne bądź rządowe i stopniowo uzyskiwały prawa miejskie;  w drugiej połowie XIX wieku termin „osady przemysłowe” zaczęto używać do wszelkich osiedli rozwijających się wokół zakładów przemysłowych; dzielnice mieszkaniowe, zwane koloniami lub domami fabrycznymi wznoszono w drugiej połowie XIX i w XX wieku przez wielkie zakłady przemysłowe w już istniejących miejscowościach dla robotników i urzędników niższego szczebla, zwykle o niskim standardzie i niewysokich czynszach."@pl ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "osada przemysłowa (pl)" ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Ansiedlung"@de ,
-                                                                              "Kolonie"@de ,
-                                                                              "Ortschaft"@de ,
-                                                                              "Siedlung"@de ,
-                                                                              "conlocationen"@la ,
-                                                                              "kolonia"@pl ,
-                                                                              "miasteczko"@pl ,
-                                                                              "miejscowość"@pl ,
-                                                                              "osiedle"@pl ,
-                                                                              "sadyba"@pl ,
-                                                                              "settlement"@en ,
-                                                                              "zagroda włościańska"@pl ;
-                            ontohgis:hasExternalIdentifier "69"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_69 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 20. s.47: Osady przemysłowe - osiedla dla robotników i rzemieślników zakładane XVIII – XIX w. w związku z dokonującym się procesem uprzemysłowienia, niekiedy zwane osadami fabrycznymi; zwykle osady przemysłowe obejmowały zarówno zakłady przemysłowe jak i związane z nimi kolonie domów mieszkalnych. Na ziemiach polskich powstawały od końca XVIII wieku jako osady prywatne bądź rządowe i stopniowo uzyskiwały prawa miejskie;  w drugiej połowie XIX wieku termin „osady przemysłowe” zaczęto używać do wszelkich osiedli rozwijających się wokół zakładów przemysłowych; dzielnice mieszkaniowe, zwane koloniami lub domami fabrycznymi wznoszono w drugiej połowie XIX i w XX wieku przez wielkie zakłady przemysłowe w już istniejących miejscowościach dla robotników i urzędników niższego szczebla, zwykle o niskim standardzie i niewysokich czynszach."@pl ;
-   rdfs:isDefinedBy ontohgis:document_21
- ] .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_7
 ontohgis:settlement_type_7 rdf:type owl:Class ;
-                           rdfs:subClassOf ontohgis:object_50 ;
-                           dct:creator ontohgis:person_3 ;
-                           rdfs:comment "Usually, a manor house was located away from the main group of houses in a village, on the outskirts, or in a vicinity. A manor house is recognised in historiography as identical with a manor (folwark, demesne), however a manor house appears in texts on culture, customs, legal issues, whereas a manor (folwark, demesne) usually corresponds with economic matters."@en ,
-                                        "Zazwyczaj dwór położony był poza głównym zbudową wsi, na jej obrzeżach lub w nieznacznym oddaleniu. Pojęcie często tożsame w literaturze z folwarkiem. Z czasem dwór pojawia się w kontekście pisania o życiu, kulturze, obyczajowości, a folwark dotyczy kwestii gospodarczych."@pl ;
-                           rdfs:isDefinedBy "A manor (a notion with a multiple meaning) is a home or a temporary house of a land lord and the managment of different clusters of estates, including a house and a farmstead ( a manor). In High and Late Middle Ages it could be a defensive tower (conical gord or a manor built on a mound) or a castle. Most of these, however, were one-floor homes (i.e. nobleman manor), which later (in 16th-20th century) evolved into palaces."@en ,
-                                            "Dwór (pojęcie wieloznaczne) jest to siedziba lub miejsce okresowego pobytu pana gruntowego oraz zarządu poszczególnych kluczy dóbr, składająca się z domu oraz zabudowań gospodarczych ( folwark). W pełnym i późnym średniowieczu mógł przyjmować charakter rezydencjonalno-obronnej wieży (tzw. grodzisko stożkowate, lub dworu na kopcu) ew. zamku. W większości były to jednak jednokondygnacyjne siedziby (tzw. dwór szlachecki) mogące później (XVI-XX w.) przybierać formę pałacową."@pl ;
-                           rdfs:label "dwór - obiekt"@pl ,
-                                      "manor house"@en ;
-                           rdfs:seeAlso <http://gov.genealogy.net/types.owl#24> ,
-                                        <http://linkedgeodata.org/ontology/Manor> ,
-                                        <http://vocab.getty.edu/aat/300005579> ,
-                                        <https://www.wikidata.org/wiki/Q879050> ,
-                                        "1. dom mieszkalny, budynek; siedziba szlachcica, właściciela majątku ziemskiego; majętność, posiadłość ziemska; 2. miejsce czasowego pobytu; lokal wynajęty (może dom zajezdny); 3. pałac, zamek, rezydencja; ewentualnie miejsce czasowego pobytu panującego; siedziba zwierzchnika (magnata) świeckiego lub duchownego; 4. miejsce posiedzeń senatu lub sądu w starożytnym Rzymie; także sama rada senatu; 5. otoczenie, środowisko skupiające się dokoła monarchy lub magnata, duchownego; dworzanie, urzędnicy, świta dworska, orszak; ogólnie: rząd danego państwa z panującym na czele; 6. siły zbrojne nadworne, żołnierze straży przybocznej monarchy; 7. praw. sąd królewski, w którym orzekał sam król osobiście przy asyście dygnitarzy królewskich lub zlecał rozpatrzenie sprawy i wydanie wyroku wyznaczonym dygnitarzom znajdującym się w danym momencie na dworze, to jest w miejscu pobytu władcy; 8. miejsce na zewnątrz domu, otaczająca dom; podwórze, dziedziniec, przestrzeń pod gołym niebem"@pl ,
-                                        "1. miejsce pod niebem zagrodzone przy pomieszkanu, podworze (por. dziedziniec); 2. sądy za dworem królewskim, przy boku króla odprawujące się; 3. w wiekach dawnych, zjazd króla na różne miejsca, gdzie święta uroczystsze odbywał, obywatelów zgromadzał, sprawy sądził, okoliczności powiatowe ułatwiał, igrzyska i uczty dawał; 4. dwór królewski, zgromadzenie u króla, pokoje"@pl ,
-                                        "1. przestrzeń otaczając dom, otwarte powietrze, miejsce pod gołym niebem; 2. podwórze, dziedziniec; 3. dom właściciela majątku ziemskiego, mieszkanie dziedzica; 4. gospodarstwo dworskie, folwark; 5. (przenośnie) mieszkańcy dworu wiejskiego, szczególnie dziedzic z rodziną, państwo; 6. dom, mieszkanie; 7. oficjaliści panów, szczególnie wyżsi, dworzanie; 8. miejsce pobytu albo mieszkanie panującego albo magnata; 9. panujący i jego otoczenie; 10. służba dworska; 11. zebranie u króla, sąd dworski, żołnierze nadworni"@pl ,
-                                        "1. siedziba panującego lub księcia; 2. ludzie otaczający panującego lub księcia; 3. obszerny dom mieszkalny, charakterystyczny dla dawnych posiadłości ziemskich; 4. majątek ziemski z domem i zabudowaniami; 5. właściciele posiadłości ziemskiej, jej mieszkańcy, administracja; 6. otwarta przestrzeń na zewnątrz domu"@pl ,
-                                        "s. 9: -- desygnatem dworu jest tzw. gródek stożkowaty, czyli stanowisko archeologiczne mające wyodrębnioną formę terenową, najczęściej w postaci kopca lub przestrzeni zamkniętej dookolnymi obronnymi wałami"@pl ;
-                           <http://www.w3.org/2004/02/skos/core#altLabel> "Hof"@de ,
-                                                                          "curia"@la ,
-                                                                          "dworzecz (określenie staropolskie)"@pl ,
-                                                                          "двор"@ru ;
-                           <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Gutshof"@de ,
-                                                                             "Herrenhof"@de ,
-                                                                             "aula"@la ,
-                                                                             "curiaculum"@la ,
-                                                                             "czwierdza (określenie staropolskie)"@pl ,
-                                                                             "mons seu fortalicium"@la ,
-                                                                             "rezydencja"@pl ,
-                                                                             "господский двор"@ru ,
-                                                                             "усадьба"@ru ;
-                           <http://www.w3.org/2004/02/skos/core#prefLabel> "dwór"@pl ,
-                                                                           "manor house"@en ;
-                           ontohgis:hasExternalIdentifier "7"^^xsd:string ;
-                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                           ontohgis:hasTranslator ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_7 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "1. dom mieszkalny, budynek; siedziba szlachcica, właściciela majątku ziemskiego; majętność, posiadłość ziemska; 2. miejsce czasowego pobytu; lokal wynajęty (może dom zajezdny); 3. pałac, zamek, rezydencja; ewentualnie miejsce czasowego pobytu panującego; siedziba zwierzchnika (magnata) świeckiego lub duchownego; 4. miejsce posiedzeń senatu lub sądu w starożytnym Rzymie; także sama rada senatu; 5. otoczenie, środowisko skupiające się dokoła monarchy lub magnata, duchownego; dworzanie, urzędnicy, świta dworska, orszak; ogólnie: rząd danego państwa z panującym na czele; 6. siły zbrojne nadworne, żołnierze straży przybocznej monarchy; 7. praw. sąd królewski, w którym orzekał sam król osobiście przy asyście dygnitarzy królewskich lub zlecał rozpatrzenie sprawy i wydanie wyroku wyznaczonym dygnitarzom znajdującym się w danym momencie na dworze, to jest w miejscu pobytu władcy; 8. miejsce na zewnątrz domu, otaczająca dom; podwórze, dziedziniec, przestrzeń pod gołym niebem"@pl ;
-   rdfs:isDefinedBy ontohgis:document_2
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_7 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "1. miejsce pod niebem zagrodzone przy pomieszkanu, podworze (por. dziedziniec); 2. sądy za dworem królewskim, przy boku króla odprawujące się; 3. w wiekach dawnych, zjazd króla na różne miejsca, gdzie święta uroczystsze odbywał, obywatelów zgromadzał, sprawy sądził, okoliczności powiatowe ułatwiał, igrzyska i uczty dawał; 4. dwór królewski, zgromadzenie u króla, pokoje"@pl ;
-   rdfs:isDefinedBy ontohgis:document_1
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_7 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "1. przestrzeń otaczając dom, otwarte powietrze, miejsce pod gołym niebem; 2. podwórze, dziedziniec; 3. dom właściciela majątku ziemskiego, mieszkanie dziedzica; 4. gospodarstwo dworskie, folwark; 5. (przenośnie) mieszkańcy dworu wiejskiego, szczególnie dziedzic z rodziną, państwo; 6. dom, mieszkanie; 7. oficjaliści panów, szczególnie wyżsi, dworzanie; 8. miejsce pobytu albo mieszkanie panującego albo magnata; 9. panujący i jego otoczenie; 10. służba dworska; 11. zebranie u króla, sąd dworski, żołnierze nadworni"@pl ;
-   rdfs:isDefinedBy ontohgis:document_5
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_7 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "1. siedziba panującego lub księcia; 2. ludzie otaczający panującego lub księcia; 3. obszerny dom mieszkalny, charakterystyczny dla dawnych posiadłości ziemskich; 4. majątek ziemski z domem i zabudowaniami; 5. właściciele posiadłości ziemskiej, jej mieszkańcy, administracja; 6. otwarta przestrzeń na zewnątrz domu"@pl ;
-   rdfs:isDefinedBy ontohgis:document_4
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_7 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "s. 9: -- desygnatem dworu jest tzw. gródek stożkowaty, czyli stanowisko archeologiczne mające wyodrębnioną formę terenową, najczęściej w postaci kopca lub przestrzeni zamkniętej dookolnymi obronnymi wałami"@pl ;
-   rdfs:comment ontohgis:document_13
- ] .
+                           rdfs:subClassOf ontohgis:object_50 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_70
@@ -14277,34 +11571,7 @@ ontohgis:settlement_type_70 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function3
-                                            ] ;
-                            dct:creator ontohgis:person_7 ,
-                                       ontohgis:person_8 ;
-                            rdfs:comment "Jest 17 takich obiektów w Polsce, zachodniopomorskie, północne wielkopolskie."@pl ,
-                                         "Therea are 17 such localities in Poland: in Zachodniopomorskie and in the northern part of Wielkopolskie voivodships."@en ;
-                            rdfs:isDefinedBy "Osada osady jest to osada stanowiąca integralną część innej osady."@pl ,
-                                             "Settlement of a settlement is a settlement which is an integral part of a settlement."@en ;
-                            rdfs:label "osada osady"@pl ,
-                                       "settlement of a settlement"@en ;
-                            rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/osadaOsady> ,
-                                         <https://www.wikidata.org/wiki/Q41970180> ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Ansiedlung"@de ,
-                                                                              "Kolonie"@de ,
-                                                                              "Ortschaft"@de ,
-                                                                              "Siedlung"@de ,
-                                                                              "conlocationen"@la ,
-                                                                              "kolonia"@pl ,
-                                                                              "miejscowość"@pl ,
-                                                                              "osiedle"@pl ,
-                                                                              "sadyba"@pl ,
-                                                                              "settlement"@en ,
-                                                                              "zagroda włościańska"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "osada osady"@pl ,
-                                                                            "settlement of a settlement"@en ;
-                            ontohgis:hasExternalIdentifier "70"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_71
@@ -14323,33 +11590,7 @@ ontohgis:settlement_type_71 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function3
-                                            ] ;
-                            dct:creator ontohgis:person_7 ,
-                                       ontohgis:person_8 ;
-                            rdfs:comment "Jest 778 takich obiektów w Polsce, są one równomiernie rozmieszczone w całej Polsce."@pl ,
-                                         "There are 778 such localities in Poland and they are evenly spread across Poland."@en ;
-                            rdfs:isDefinedBy "Osada wsi jest to osada przynależna administracyjnie do wsi."@pl ,
-                                             "Settlement of a village is a settlement which is related to a village."@en ;
-                            rdfs:label "osada wsi"@pl ,
-                                       "settlement of a village"@en ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "conlocationen"@la ,
-                                                                              "der Ortschaft"@de ,
-                                                                              "der Siedlung"@de ,
-                                                                              "die Ansiedlung"@de ,
-                                                                              "die Kolonie"@de ,
-                                                                              "kolonia"@pl ,
-                                                                              "miasteczko"@pl ,
-                                                                              "miejscowość"@pl ,
-                                                                              "osiedle"@pl ,
-                                                                              "sadyba"@pl ,
-                                                                              "settlement"@en ,
-                                                                              "zagroda włościańska"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "osada wsi"@pl ,
-                                                                            "settlement of a village"@en ;
-                            ontohgis:hasExternalIdentifier "71"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_72
@@ -14367,38 +11608,7 @@ ontohgis:settlement_type_72 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function3
-                                            ] ;
-                            dct:creator ontohgis:person_7 ,
-                                       ontohgis:person_8 ;
-                            rdfs:comment "In urban studies, this notion is derived from a \"neighbouring unit\" idea, which denotes a group of residential buildings with service facilities and green areas."@en ,
-                                         "Jest 11 takich obiektów w Polsce, są one rozmieszczone w północno-zachodniej Polsce."@pl ,
-                                         "There are 11 housing estates of a village which are located in NW Poland."@en ,
-                                         "W urbanistyce (planowaniu przestrzennym) pojęcie osiedla wywodzi się z koncepcji „jednostki sąsiedzkiej”, na którą składa się zespół budynków mieszkalnych wraz z zapleczem obiektów usługowych oraz terenów zielonych."@pl ;
-                            rdfs:isDefinedBy "Housing estate of a village is a housing estate which is an integral part of a village."@en ,
-                                             "Osiedle wsi jest to osiedle stanowiące integralną część wsi."@pl ;
-                            rdfs:label "housing estate of a village"@en ,
-                                       "osiedle wsi"@pl ;
-                            rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/osiedleWsi> ,
-                                         <https://www.wikidata.org/wiki/Q41970180> ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Ansiedlung"@de ,
-                                                                              "Siedlung"@de ,
-                                                                              "Wohnsiedlung"@de ,
-                                                                              "conlocationen"@la ,
-                                                                              "część miasta"@pl ,
-                                                                              "dzielnica"@pl ,
-                                                                              "hamlet"@en ,
-                                                                              "housing estate"@en ,
-                                                                              "kolonia"@pl ,
-                                                                              "osada"@pl ,
-                                                                              "osiedle willowe"@pl ,
-                                                                              "osiedlisko"@pl ,
-                                                                              "residential quarter"@en ,
-                                                                              "settlement"@en ;
-                            ontohgis:hasExternalIdentifier "72"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 ,
-                                                   ontohgis:person_9 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_73
@@ -14415,20 +11625,7 @@ ontohgis:settlement_type_73 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function1
-                                            ] ;
-                            dct:creator ontohgis:person_8 ;
-                            rdfs:comment "Hamlet of a colony is a separate settlement unit, a kind of locality, it always has a particular name. Hamlets of colonies occur most often in Lubelskie voivodship. In total, there are 72 hamlets of colonies in Poland."@en ,
-                                         "Przysiółek kolonii jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Przysiółki kolonii występują głównie w lubelskim. W sumie są to 72 obiekty."@pl ;
-                            rdfs:isDefinedBy "Hamlet of a colony is a hamlet, for which a colony is a superior unit."@en ,
-                                             "Przysiółek kolonii jest to przysiółek, dla którego jednostką nadrzędną jest kolonia."@pl ;
-                            rdfs:label "hamlet of a colony"@en ,
-                                       "przysiółek kolonii"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "hamlet of a colony"@en ,
-                                                                            "przysiółek kolonii"@pl ;
-                            ontohgis:hasExternalIdentifier "73"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_74
@@ -14441,33 +11638,7 @@ ontohgis:settlement_type_74 rdf:type owl:Class ;
                                                                      ) ;
                                                   rdf:type owl:Class
                                                 ] ;
-                            rdfs:subClassOf ontohgis:settlement_type_44 ;
-                            dct:creator ontohgis:person_8 ;
-                            rdfs:comment "Przysiółek osady jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Przysiółki osady występują główniezachodnio-pomorskim, pomorskim, warmińsko-mazurskim. W sumie jest 80 takich obiektów."@pl ,
-                                         "The hamlet of a settlement is a separate settlement unit, a kind of locality, always has its particular name. Hamlets of settlements occur mainly in the Zachodniopomorskie, Pomorskie, and Warmińsko-Mazurskie voivodships. In total, there are 80 hamlets of settlements in Poland. "@en ;
-                            rdfs:isDefinedBy "Hamlet of a settlement is a hamlet, for which a superior unit is a settlement."@en ,
-                                             "Przysiółek osady jest to przysiółek, dla którego jednostką nadrzędną jest osada."@pl ;
-                            rdfs:label "hamlet of a settlement"@en ,
-                                       "przysiółek osady"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#altLabel> "osada przemysłowa (pl)" ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "conlocationen"@la ,
-                                                                              "der Ortschaft"@de ,
-                                                                              "der Siedlung"@de ,
-                                                                              "die Ansiedlung"@de ,
-                                                                              "die Kolonie"@de ,
-                                                                              "kolonia"@pl ,
-                                                                              "miasteczko"@pl ,
-                                                                              "miejscowość"@pl ,
-                                                                              "osiedle"@pl ,
-                                                                              "sadyba"@pl ,
-                                                                              "settlement"@en ,
-                                                                              "zagroda włościańska"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "hamlet of a settlement"@en ,
-                                                                            "przysiółek osady"@pl ;
-                            ontohgis:hasExternalIdentifier "74"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            rdfs:subClassOf ontohgis:settlement_type_44 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_75
@@ -14484,22 +11655,7 @@ ontohgis:settlement_type_75 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function1
-                                            ] ;
-                            dct:creator ontohgis:person_8 ;
-                            rdfs:comment "Brak oficjalnej definicji w \"Ustawie o nazwach urzędowych miejscowości i jednostek fizjograficznych\"."@pl ,
-                                         "No official definition in the \"Act on official names of localities and physiographic units\"."@en ,
-                                         "Przysiółek wsi jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Przysiółki wsi występują głównie w woj. podkarpackim, małopolskim oraz w świętokrzyskim. W sumie jest ich 11580."@pl ,
-                                         "The hamlet of a village is a separate settlement unit, a kind of locality, always has its particular name. Hamlets of villages occur mainly in Podkarpackie, Małopolskie, and Świętokrzyskie voivodships. In total, there are 11 580 hamlets of villages in Poland. "@en ;
-                            rdfs:isDefinedBy "Hamlet of a village is a hamlet, for which a superior unit is a village."@en ,
-                                             "Przysiółek wsi jest to przysiółek, dla którego jednostką nadrzędną jest wieś."@pl ;
-                            rdfs:label "hamlet of a village"@en ,
-                                       "przysiółek wsi"@pl ;
-                            rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/przysiolekWsi> ,
-                                         <https://www.wikidata.org/wiki/Q41970180> ;
-                            ontohgis:hasExternalIdentifier "75"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_76
@@ -14513,27 +11669,7 @@ ontohgis:settlement_type_76 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function11
-                                            ] ;
-                            dct:creator ontohgis:person_5 ;
-                            rdfs:comment "In BDTO10k a tourist shelter is distinguished as a [1] building, [2] hotel services' complex, and [3] locality; in PRNG as a \"tourist shelter\". On MGI maps - a shelter [developed or undeveloped were depicted using different symbols] (\"schr.\"), on German maps - Jugenherberge (youth hostel, \"Jg. Hb.\"), Winterhutte (winter shelter, \"Wint. H.\"), Schutzhutte (hostel). Tourist shelters are not included in Bystrzycki's register."@en ,
-                                         "W BDOT10k schronisko turystyczne wyróżnione jest jako budynek, kompleks usług hotelarskich oraz miejscowość; w PRNG jako „schronisko turystyczne”.Na mapach WIG – schronisko [zagospodarowane lub niezagospodarowane odmiennym znakiem] („schr.”), niemieckich – Jugenherberge (schronisko młodzieżowe, „Jg. Hb.”), Winterhutte (schron zimowy, „Wint. H.”), Schutzhutte (schronisko). Brak u Bystrzyckiego."@pl ;
-                            rdfs:isDefinedBy "Schronisko turystyczne (miejscowość) to miejscowość, w której główną rolę pełni schronisko turystyczne (obiekt)."@pl ,
-                                             "Tourist shelter (locality) is a settlement where the main role is played by a tourist shelter (object)."@en ;
-                            rdfs:label "schronisko turystyczne"@pl ,
-                                       "schronisko turystyczne"^^xsd:string ,
-                                       "tourist shelter"@en ;
-                            rdfs:seeAlso <http://linkedgeodata.org/ontology/Shelter> ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "karczma"@pl ,
-                                                                              "schronisko"@pl ,
-                                                                              "schronisko górskie"@pl ,
-                                                                              "stacja turystyczna"@pl ,
-                                                                              "szałas"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "schronisko turystyczne"@pl ,
-                                                                            "tourist shelter"@en ;
-                            ontohgis:hasExternalIdentifier "76"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_8
@@ -14542,71 +11678,7 @@ ontohgis:settlement_type_8 rdf:type owl:Class ;
                                            [ rdf:type owl:Restriction ;
                                              owl:onProperty ontohgis:hasProperFunction ;
                                              owl:hasValue ontohgis:function1
-                                           ] ;
-                           dct:creator ontohgis:person_3 ;
-                           rdfs:comment "A demesne (manor) may be considered as an independent locality as long as it is distinguished by an individual name. Usually, a demesne was located away from the main group of houses in a village, on the outskirts, or in its vicinity."@en ,
-                                        "Folwark może być traktowany jako odrębna miejscowość, o ile posiadał własną nazwę. Zazwyczaj folwark położony był poza główną zabudową wsi, na jej obrzeżach lub w nieznacznym oddaleniu."@pl ;
-                           rdfs:isDefinedBy "A demesne (en: manor, pl: folwark, de: Volwerk) is a locality with an industrial function, often located near the manor (a building) or separate."@en ,
-                                            "Folwark (niem: Volwerk) to miejscowość o charakterze gospodarczym, często funkcjonująca obok dworu lub osobno."@pl ;
-                           rdfs:label "demesne"@en ,
-                                      "folwark"@pl ;
-                           rdfs:seeAlso <http://dbpedia.org/page/Demesne> ,
-                                        <http://dbpedia.org/page/Folwark> ,
-                                        <http://dbpedia.org/page/Manor> ,
-                                        <http://gov.genealogy.net/types.owl#64> ,
-                                        <http://vocab.getty.edu/aat/300000238> ,
-                                        <http://vocab.getty.edu/aat/300108235> ,
-                                        "duże gospodarstwo rolne wraz z zabudowaniami."@pl ,
-                                        "t. 1, s. 173: duże gospodarstwo rolne lub rolno-hodowlane, produkujące głównie na zbyt, posługujące się pracą chłopów pańszczyźnianych albo siłą najemną. Organizowane przez feudalnych właścicieli ziemskich już w XIV w., stanowiły kontynuację tzw. rezerwy pańskiej, czyli gruntów wyłączonych spod uprawy chłopskiej i przeznaczonych do zaspokajania bezpośrednich potrzeb dworu--’"@pl ,
-                                        "t. 1, s. 759: 1. mała wioska, leżąca obok dużej, oddzielona część wsi; przysiółek; 2. majętność, grunt z zabudowaniem, ferma; 3. dwór we wsi, mieszkanie dziedzica albo dzierżawcy razem z zabudowaniami dworskimi."@pl ,
-                                        "t. 7, s. 90–91: 1. ziemskie gospodarstwo, w przeciwieństwie do gospodarstwa chłopskiego, grunt z zabudowaniami gospodarskimi i mieszkalnymi, często będący częścią większej majętności; zazwyczaj wydzielona część wsi; 2. zabudowania gospodarcze; 3. ziemia orna, rola należąca do folwarku; 4. posiadłość ziemska, dworek z zabudowaniami gospodarskimi położony pod miastem; 5. wieś"@pl ;
-                           <http://www.w3.org/2004/02/skos/core#altLabel> "Vorwerk"@de ,
-                                                                          "praedium"@la ,
-                                                                          "фолварок"@ru ;
-                           <http://www.w3.org/2004/02/skos/core#hiddenLabel> "allodium"@la ,
-                                                                             "dobra"@pl ,
-                                                                             "domena"@pl ,
-                                                                             "dwór"@pl ,
-                                                                             "majątek"@pl ,
-                                                                             "manor"@en ,
-                                                                             "имение"@ru ,
-                                                                             "усадьба"@ru ,
-                                                                             "хутор"@ru ;
-                           <http://www.w3.org/2004/02/skos/core#prefLabel> "demesne"@en ,
-                                                                           "folwark"@pl ;
-                           ontohgis:hasExternalIdentifier "8"^^xsd:string ;
-                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                           ontohgis:hasTranslator ontohgis:person_9 .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_8 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "duże gospodarstwo rolne wraz z zabudowaniami."@pl ;
-   rdfs:isDefinedBy ontohgis:document_4 ,
-                    <https://sjp.pwn.pl/doroszewski/folwark;5428273.html>
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_8 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 1, s. 173: duże gospodarstwo rolne lub rolno-hodowlane, produkujące głównie na zbyt, posługujące się pracą chłopów pańszczyźnianych albo siłą najemną. Organizowane przez feudalnych właścicieli ziemskich już w XIV w., stanowiły kontynuację tzw. rezerwy pańskiej, czyli gruntów wyłączonych spod uprawy chłopskiej i przeznaczonych do zaspokajania bezpośrednich potrzeb dworu--’"@pl ;
-   rdfs:isDefinedBy ontohgis:document_17
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_8 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 1, s. 759: 1. mała wioska, leżąca obok dużej, oddzielona część wsi; przysiółek; 2. majętność, grunt z zabudowaniem, ferma; 3. dwór we wsi, mieszkanie dziedzica albo dzierżawcy razem z zabudowaniami dworskimi."@pl ;
-   rdfs:isDefinedBy ontohgis:document_5
- ] .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_8 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "t. 7, s. 90–91: 1. ziemskie gospodarstwo, w przeciwieństwie do gospodarstwa chłopskiego, grunt z zabudowaniami gospodarskimi i mieszkalnymi, często będący częścią większej majętności; zazwyczaj wydzielona część wsi; 2. zabudowania gospodarcze; 3. ziemia orna, rola należąca do folwarku; 4. posiadłość ziemska, dworek z zabudowaniami gospodarskimi położony pod miastem; 5. wieś"@pl ;
-   rdfs:isDefinedBy ontohgis:document_2
- ] .
+                                           ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_80
@@ -14615,26 +11687,7 @@ ontohgis:settlement_type_80 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function1
-                                            ] ;
-                            dct:creator ontohgis:person_3 ;
-                            rdfs:comment "Characteristic for the Commonwealth of Poland and Lithuania from 16th to 18th century."@en ,
-                                         "Charakterystycznego dla Rzeczypospolitej XVII–XVIII wieku"@pl ;
-                            rdfs:isDefinedBy "\"Holendry\" (a Dutch type locality) is a colony established on an empty territory, in areas not very useful for agriculture. It was a type of locality characteristic for a \"Dutch colonisation\", which was a specific form of a settlement movement - widespread in the Commonwealth of Poland and Lithuania from 16th to 18th century. Granting uncongenial land difficult to cultivate or for animal husbandry to local people or (more often) immigrants inflowing from Flanders, German countries and Silesia was the core element of this process."@en ,
-                                             "Holendry to kolonia zakładana na obszarach nieobjętych osadnictwem z powodu nikłej przydatności rolniczej, właściwa dla tzw. kolonizacji olęderskiej, czyli specyficznej formy ruchu osadniczego – charakterystycznego dla Rzeczypospolitej XVII–XVIII wieku – polegającego na nadaniu ludności rodzimej – lub częściej – imigrantom pochodzącym z Flandrii, państw niemieckich lub Śląska, trudnej (w uprawie lub hodowli) ziemi."@pl ;
-                            rdfs:label "\"holendry\""@en ,
-                                       "holendry"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Hauland"@de ,
-                                                                              "Holander"@de ,
-                                                                              "Olander"@de ,
-                                                                              "Olender"@pl ,
-                                                                              "Olęder"@pl ,
-                                                                              "kolonia"@pl ,
-                                                                              "osada"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "\"holendry\""@en ,
-                                                                            "holendry"@pl ;
-                            ontohgis:hasExternalIdentifier "80"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_82
@@ -14651,22 +11704,7 @@ ontohgis:settlement_type_82 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function8
-                                            ] ;
-                            dct:creator ontohgis:person_5 ;
-                            rdfs:comment "Port morski na austriackiej mapie 1:75 000 wyróżniony explicite i opisany krojem pisma takim jak miasta większe niż 100 000 mieszkańców i twierdze.W BDOT10k „port wodny lub przystań” w klasie kompleks komunikacyjny.Jest u Bystrzyckiego (nie w skrótach) – port, miasto portowe."@pl ,
-                                         "Sea harbour on the Austrian map 1:75,000 (Spezialkarte...) is explicitly distinguished as a placename using the same annotation style as \"cities larger than 100,000 inhabitants and fortresses\".Sea harbour is included in DBTO10k as \"sea harbour port or marina\" in the communication complex feature class (KUKO).Sea harbour is included in Bystrzycki's register (however, not in abbreviations list) as \"harbour\" (pol \"port\"), \"harbour city\" (pol \"miasto portowe\")."@en ;
-                            rdfs:isDefinedBy "Port morski (miejscowość) jest to miejscowość w której główną rolę pełni port morski jako obiekt"@pl ,
-                                             "Sea harbour (locality) is a locality where the main role is played by a sea harbour (area)."@en ;
-                            rdfs:label "port morski"@pl ,
-                                       "sea harbour"@en ;
-                            rdfs:seeAlso <http://dbpedia.org/ontology/Port> ,
-                                         <https://www.wikidata.org/wiki/Q15310171> ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "port morski"@pl ,
-                                                                            "sea harbour"@en ;
-                            ontohgis:hasExternalIdentifier "82"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_83
@@ -14680,9 +11718,9 @@ ontohgis:settlement_type_83 rdf:type owl:Class ;
                                                   rdf:type owl:Class
                                                 ] ;
                             rdfs:subClassOf ontohgis:settlement_type_2 ;
-                            rdfs:label "wieś kościelna"^^xsd:string ;
+                            rdfs:label "wieś kościelna" ;
                             rdfs:seeAlso <http://gov.genealogy.net/types.owl#66> ;
-                            ontohgis:hasExternalIdentifier "83"^^xsd:string .
+                            ontohgis:hasExternalIdentifier "83" .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_92
@@ -14695,7 +11733,7 @@ ontohgis:settlement_type_92 rdf:type owl:Class ;
                             rdfs:label "market place"@en ,
                                        "targ"@pl ;
                             rdfs:seeAlso <http://linkedgeodata.org/ontology/Marketplace> ;
-                            ontohgis:hasExternalIdentifier "92"^^xsd:string .
+                            ontohgis:hasExternalIdentifier "92" .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_99
@@ -14709,33 +11747,7 @@ ontohgis:settlement_type_99 rdf:type owl:Class ;
                                             [ rdf:type owl:Restriction ;
                                               owl:onProperty ontohgis:hasProperFunction ;
                                               owl:hasValue ontohgis:function13
-                                            ] ;
-                            dct:creator ontohgis:person_3 ;
-                            rdfs:isDefinedBy "Inn (locality) is a settlement in which the main role is played by an inn (builing)."@en ,
-                                             "Osada karczemna to osada, w której główną rolę pełni karczma (obiekt)."@pl ;
-                            rdfs:label "inn"@en ,
-                                       "osada karczemna"@pl ;
-                            rdfs:seeAlso <http://dbpedia.org/page/Hamlet_(place)> ,
-                                         <http://gov.genealogy.net/types.owl#120> ,
-                                         <https://www.wikidata.org/wiki/Q5084> ;
-                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Gasthof"@de ,
-                                                                              "Krug"@de ,
-                                                                              "Wirthaus"@de ,
-                                                                              "budynek"@pl ,
-                                                                              "gospoda"@pl ,
-                                                                              "gościniec"@pl ,
-                                                                              "gościnny dom"@pl ,
-                                                                              "oberża"@pl ,
-                                                                              "restauracja"@pl ,
-                                                                              "szynkowny dom"@pl ,
-                                                                              "taberna"@la ,
-                                                                              "zajazd"@pl ;
-                            <http://www.w3.org/2004/02/skos/core#prefLabel> "inn"@en ,
-                                                                            "osada karczemna"@pl ;
-                            ontohgis:hasExternalIdentifier "99"^^xsd:string ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                                            ] .
 
 
 ###  https://onto.kul.pl/ontohgis/source
@@ -14762,470 +11774,470 @@ ontohgis:source rdf:type owl:Class ;
 
 
 ###  http://purl.org/dc/terms/
-<http://purl.org/dc/terms/> rdf:type owl:NamedIndividual ;
-                            <http://purl.org/dc/terms/modified> "2012-06-14"^^xsd:date ;
-                            <http://purl.org/dc/terms/publisher> <http://purl.org/dc/aboutdcmi#DCMI> ;
-                            <http://purl.org/dc/terms/title> "DCMI Metadata Terms - other"@en .
+dct: rdf:type owl:NamedIndividual ;
+     dct:modified "2012-06-14"^^xsd:date ;
+     dct:publisher <http://purl.org/dc/aboutdcmi#DCMI> ;
+     dct:title "DCMI Metadata Terms - other"@en .
 
 
 ###  http://purl.org/dc/terms/Agent
-<http://purl.org/dc/terms/Agent> rdf:type owl:NamedIndividual ,
-                                          <http://purl.org/dc/terms/AgentClass> .
+dct:Agent rdf:type owl:NamedIndividual ,
+                   dct:AgentClass .
 
 
 ###  http://purl.org/dc/terms/BibliographicResource
-<http://purl.org/dc/terms/BibliographicResource> rdf:type owl:NamedIndividual .
+dct:BibliographicResource rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/Box
-<http://purl.org/dc/terms/Box> rdf:type owl:NamedIndividual .
+dct:Box rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/DCMIType
-<http://purl.org/dc/terms/DCMIType> rdf:type owl:NamedIndividual ,
-                                             <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
-                                    <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#DCMIType-005> ;
-                                    <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                    <http://purl.org/dc/terms/modified> "2012-06-14"^^xsd:date ;
-                                    rdfs:comment "The set of classes specified by the DCMI Type Vocabulary, used to categorize the nature or genre of the resource."@en ;
-                                    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                    rdfs:label "DCMI Type Vocabulary"@en ;
-                                    rdfs:seeAlso <http://purl.org/dc/dcmitype/> .
+dct:DCMIType rdf:type owl:NamedIndividual ,
+                      <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
+             dct:hasVersion <http://dublincore.org/usage/terms/history/#DCMIType-005> ;
+             dct:issued "2000-07-11"^^xsd:date ;
+             dct:modified "2012-06-14"^^xsd:date ;
+             rdfs:comment "The set of classes specified by the DCMI Type Vocabulary, used to categorize the nature or genre of the resource."@en ;
+             rdfs:isDefinedBy dct: ;
+             rdfs:label "DCMI Type Vocabulary"@en ;
+             rdfs:seeAlso <http://purl.org/dc/dcmitype/> .
 
 
 ###  http://purl.org/dc/terms/DDC
-<http://purl.org/dc/terms/DDC> rdf:type owl:NamedIndividual ,
-                                        <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
-                               <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#DDC-003> ;
-                               <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                               <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                               rdfs:comment "The set of conceptual resources specified by the Dewey Decimal Classification."@en ;
-                               rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                               rdfs:label "DDC"@en ;
-                               rdfs:seeAlso <http://www.oclc.org/dewey/> .
+dct:DDC rdf:type owl:NamedIndividual ,
+                 <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
+        dct:hasVersion <http://dublincore.org/usage/terms/history/#DDC-003> ;
+        dct:issued "2000-07-11"^^xsd:date ;
+        dct:modified "2008-01-14"^^xsd:date ;
+        rdfs:comment "The set of conceptual resources specified by the Dewey Decimal Classification."@en ;
+        rdfs:isDefinedBy dct: ;
+        rdfs:label "DDC"@en ;
+        rdfs:seeAlso <http://www.oclc.org/dewey/> .
 
 
 ###  http://purl.org/dc/terms/FileFormat
-<http://purl.org/dc/terms/FileFormat> rdf:type owl:NamedIndividual .
+dct:FileFormat rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/Frequency
-<http://purl.org/dc/terms/Frequency> rdf:type owl:NamedIndividual .
+dct:Frequency rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/IMT
-<http://purl.org/dc/terms/IMT> rdf:type owl:NamedIndividual ,
-                                        <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
-                               <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#IMT-004> ;
-                               <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                               <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                               rdfs:comment "The set of media types specified by the Internet Assigned Numbers Authority."@en ;
-                               rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                               rdfs:label "IMT"@en ;
-                               rdfs:seeAlso <http://www.iana.org/assignments/media-types/> .
+dct:IMT rdf:type owl:NamedIndividual ,
+                 <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
+        dct:hasVersion <http://dublincore.org/usage/terms/history/#IMT-004> ;
+        dct:issued "2000-07-11"^^xsd:date ;
+        dct:modified "2008-01-14"^^xsd:date ;
+        rdfs:comment "The set of media types specified by the Internet Assigned Numbers Authority."@en ;
+        rdfs:isDefinedBy dct: ;
+        rdfs:label "IMT"@en ;
+        rdfs:seeAlso <http://www.iana.org/assignments/media-types/> .
 
 
 ###  http://purl.org/dc/terms/ISO3166
-<http://purl.org/dc/terms/ISO3166> rdf:type owl:NamedIndividual .
+dct:ISO3166 rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/ISO639-2
-<http://purl.org/dc/terms/ISO639-2> rdf:type owl:NamedIndividual .
+dct:ISO639-2 rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/ISO639-3
-<http://purl.org/dc/terms/ISO639-3> rdf:type owl:NamedIndividual .
+dct:ISO639-3 rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/Jurisdiction
-<http://purl.org/dc/terms/Jurisdiction> rdf:type owl:NamedIndividual .
+dct:Jurisdiction rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/LCC
-<http://purl.org/dc/terms/LCC> rdf:type owl:NamedIndividual ,
-                                        <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
-                               <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#LCC-003> ;
-                               <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                               <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                               rdfs:comment "The set of conceptual resources specified by the Library of Congress Classification."@en ;
-                               rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                               rdfs:label "LCC"@en ;
-                               rdfs:seeAlso <http://lcweb.loc.gov/catdir/cpso/lcco/lcco.html> .
+dct:LCC rdf:type owl:NamedIndividual ,
+                 <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
+        dct:hasVersion <http://dublincore.org/usage/terms/history/#LCC-003> ;
+        dct:issued "2000-07-11"^^xsd:date ;
+        dct:modified "2008-01-14"^^xsd:date ;
+        rdfs:comment "The set of conceptual resources specified by the Library of Congress Classification."@en ;
+        rdfs:isDefinedBy dct: ;
+        rdfs:label "LCC"@en ;
+        rdfs:seeAlso <http://lcweb.loc.gov/catdir/cpso/lcco/lcco.html> .
 
 
 ###  http://purl.org/dc/terms/LCSH
-<http://purl.org/dc/terms/LCSH> rdf:type owl:NamedIndividual ,
-                                         <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
-                                <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#LCSH-003> ;
-                                <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                rdfs:comment "The set of labeled concepts specified by the Library of Congress Subject Headings."@en ;
-                                rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                rdfs:label "LCSH"@en .
+dct:LCSH rdf:type owl:NamedIndividual ,
+                  <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
+         dct:hasVersion <http://dublincore.org/usage/terms/history/#LCSH-003> ;
+         dct:issued "2000-07-11"^^xsd:date ;
+         dct:modified "2008-01-14"^^xsd:date ;
+         rdfs:comment "The set of labeled concepts specified by the Library of Congress Subject Headings."@en ;
+         rdfs:isDefinedBy dct: ;
+         rdfs:label "LCSH"@en .
 
 
 ###  http://purl.org/dc/terms/LicenseDocument
-<http://purl.org/dc/terms/LicenseDocument> rdf:type owl:NamedIndividual .
+dct:LicenseDocument rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/LinguisticSystem
-<http://purl.org/dc/terms/LinguisticSystem> rdf:type owl:NamedIndividual .
+dct:LinguisticSystem rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/Location
-<http://purl.org/dc/terms/Location> rdf:type owl:NamedIndividual .
+dct:Location rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/LocationPeriodOrJurisdiction
-<http://purl.org/dc/terms/LocationPeriodOrJurisdiction> rdf:type owl:NamedIndividual .
+dct:LocationPeriodOrJurisdiction rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/MESH
-<http://purl.org/dc/terms/MESH> rdf:type owl:NamedIndividual ,
-                                         <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
-                                <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#MESH-003> ;
-                                <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                rdfs:comment "The set of labeled concepts specified by the Medical Subject Headings."@en ;
-                                rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                rdfs:label "MeSH"@en ;
-                                rdfs:seeAlso <http://www.nlm.nih.gov/mesh/meshhome.html> .
+dct:MESH rdf:type owl:NamedIndividual ,
+                  <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
+         dct:hasVersion <http://dublincore.org/usage/terms/history/#MESH-003> ;
+         dct:issued "2000-07-11"^^xsd:date ;
+         dct:modified "2008-01-14"^^xsd:date ;
+         rdfs:comment "The set of labeled concepts specified by the Medical Subject Headings."@en ;
+         rdfs:isDefinedBy dct: ;
+         rdfs:label "MeSH"@en ;
+         rdfs:seeAlso <http://www.nlm.nih.gov/mesh/meshhome.html> .
 
 
 ###  http://purl.org/dc/terms/MediaType
-<http://purl.org/dc/terms/MediaType> rdf:type owl:NamedIndividual .
+dct:MediaType rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/MediaTypeOrExtent
-<http://purl.org/dc/terms/MediaTypeOrExtent> rdf:type owl:NamedIndividual .
+dct:MediaTypeOrExtent rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/MethodOfAccrual
-<http://purl.org/dc/terms/MethodOfAccrual> rdf:type owl:NamedIndividual .
+dct:MethodOfAccrual rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/MethodOfInstruction
-<http://purl.org/dc/terms/MethodOfInstruction> rdf:type owl:NamedIndividual .
+dct:MethodOfInstruction rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/NLM
-<http://purl.org/dc/terms/NLM> rdf:type owl:NamedIndividual ,
-                                        <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
-                               <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#NLM-002> ;
-                               <http://purl.org/dc/terms/issued> "2005-06-13"^^xsd:date ;
-                               <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                               rdfs:comment "The set of conceptual resources specified by the National Library of Medicine Classification."@en ;
-                               rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                               rdfs:label "NLM"@en ;
-                               rdfs:seeAlso <http://wwwcf.nlm.nih.gov/class/> .
+dct:NLM rdf:type owl:NamedIndividual ,
+                 <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
+        dct:hasVersion <http://dublincore.org/usage/terms/history/#NLM-002> ;
+        dct:issued "2005-06-13"^^xsd:date ;
+        dct:modified "2008-01-14"^^xsd:date ;
+        rdfs:comment "The set of conceptual resources specified by the National Library of Medicine Classification."@en ;
+        rdfs:isDefinedBy dct: ;
+        rdfs:label "NLM"@en ;
+        rdfs:seeAlso <http://wwwcf.nlm.nih.gov/class/> .
 
 
 ###  http://purl.org/dc/terms/Period
-<http://purl.org/dc/terms/Period> rdf:type owl:NamedIndividual .
+dct:Period rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/PeriodOfTime
-<http://purl.org/dc/terms/PeriodOfTime> rdf:type owl:NamedIndividual .
+dct:PeriodOfTime rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/PhysicalMedium
-<http://purl.org/dc/terms/PhysicalMedium> rdf:type owl:NamedIndividual .
+dct:PhysicalMedium rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/PhysicalResource
-<http://purl.org/dc/terms/PhysicalResource> rdf:type owl:NamedIndividual .
+dct:PhysicalResource rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/Point
-<http://purl.org/dc/terms/Point> rdf:type owl:NamedIndividual .
+dct:Point rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/Policy
-<http://purl.org/dc/terms/Policy> rdf:type owl:NamedIndividual .
+dct:Policy rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/ProvenanceStatement
-<http://purl.org/dc/terms/ProvenanceStatement> rdf:type owl:NamedIndividual .
+dct:ProvenanceStatement rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/RFC1766
-<http://purl.org/dc/terms/RFC1766> rdf:type owl:NamedIndividual .
+dct:RFC1766 rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/RFC3066
-<http://purl.org/dc/terms/RFC3066> rdf:type owl:NamedIndividual .
+dct:RFC3066 rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/RFC4646
-<http://purl.org/dc/terms/RFC4646> rdf:type owl:NamedIndividual .
+dct:RFC4646 rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/RFC5646
-<http://purl.org/dc/terms/RFC5646> rdf:type owl:NamedIndividual .
+dct:RFC5646 rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/RightsStatement
-<http://purl.org/dc/terms/RightsStatement> rdf:type owl:NamedIndividual .
+dct:RightsStatement rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/SizeOrDuration
-<http://purl.org/dc/terms/SizeOrDuration> rdf:type owl:NamedIndividual .
+dct:SizeOrDuration rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/Standard
-<http://purl.org/dc/terms/Standard> rdf:type owl:NamedIndividual .
+dct:Standard rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/TGN
-<http://purl.org/dc/terms/TGN> rdf:type owl:NamedIndividual ,
-                                        <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
-                               <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#TGN-003> ;
-                               <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                               <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                               rdfs:comment "The set of places specified by the Getty Thesaurus of Geographic Names."@en ;
-                               rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                               rdfs:label "TGN"@en ;
-                               rdfs:seeAlso <http://www.getty.edu/research/tools/vocabulary/tgn/index.html> .
+dct:TGN rdf:type owl:NamedIndividual ,
+                 <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
+        dct:hasVersion <http://dublincore.org/usage/terms/history/#TGN-003> ;
+        dct:issued "2000-07-11"^^xsd:date ;
+        dct:modified "2008-01-14"^^xsd:date ;
+        rdfs:comment "The set of places specified by the Getty Thesaurus of Geographic Names."@en ;
+        rdfs:isDefinedBy dct: ;
+        rdfs:label "TGN"@en ;
+        rdfs:seeAlso <http://www.getty.edu/research/tools/vocabulary/tgn/index.html> .
 
 
 ###  http://purl.org/dc/terms/UDC
-<http://purl.org/dc/terms/UDC> rdf:type owl:NamedIndividual ,
-                                        <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
-                               <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#UDC-003> ;
-                               <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                               <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                               rdfs:comment "The set of conceptual resources specified by the Universal Decimal Classification."@en ;
-                               rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                               rdfs:label "UDC"@en ;
-                               rdfs:seeAlso <http://www.udcc.org/> .
+dct:UDC rdf:type owl:NamedIndividual ,
+                 <http://purl.org/dc/dcam/VocabularyEncodingScheme> ;
+        dct:hasVersion <http://dublincore.org/usage/terms/history/#UDC-003> ;
+        dct:issued "2000-07-11"^^xsd:date ;
+        dct:modified "2008-01-14"^^xsd:date ;
+        rdfs:comment "The set of conceptual resources specified by the Universal Decimal Classification."@en ;
+        rdfs:isDefinedBy dct: ;
+        rdfs:label "UDC"@en ;
+        rdfs:seeAlso <http://www.udcc.org/> .
 
 
 ###  http://purl.org/dc/terms/URI
-<http://purl.org/dc/terms/URI> rdf:type owl:NamedIndividual .
+dct:URI rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/W3CDTF
-<http://purl.org/dc/terms/W3CDTF> rdf:type owl:NamedIndividual .
+dct:W3CDTF rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/abstract
-<http://purl.org/dc/terms/abstract> rdf:type owl:NamedIndividual .
+dct:abstract rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/accessRights
-<http://purl.org/dc/terms/accessRights> rdf:type owl:NamedIndividual .
+dct:accessRights rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/accrualMethod
-<http://purl.org/dc/terms/accrualMethod> rdf:type owl:NamedIndividual .
+dct:accrualMethod rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/accrualPeriodicity
-<http://purl.org/dc/terms/accrualPeriodicity> rdf:type owl:NamedIndividual .
+dct:accrualPeriodicity rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/accrualPolicy
-<http://purl.org/dc/terms/accrualPolicy> rdf:type owl:NamedIndividual .
+dct:accrualPolicy rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/alternative
-<http://purl.org/dc/terms/alternative> rdf:type owl:NamedIndividual .
+dct:alternative rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/audience
-<http://purl.org/dc/terms/audience> rdf:type owl:NamedIndividual .
+dct:audience rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/available
-<http://purl.org/dc/terms/available> rdf:type owl:NamedIndividual .
+dct:available rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/bibliographicCitation
-<http://purl.org/dc/terms/bibliographicCitation> rdf:type owl:NamedIndividual .
+dct:bibliographicCitation rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/conformsTo
-<http://purl.org/dc/terms/conformsTo> rdf:type owl:NamedIndividual .
+dct:conformsTo rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/contributor
-<http://purl.org/dc/terms/contributor> rdf:type owl:NamedIndividual .
+dct:contributor rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/coverage
-<http://purl.org/dc/terms/coverage> rdf:type owl:NamedIndividual .
+dct:coverage rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/created
-<http://purl.org/dc/terms/created> rdf:type owl:NamedIndividual .
+dct:created rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/creator
-<http://purl.org/dc/terms/creator> rdf:type owl:NamedIndividual .
+dct:creator rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/date
-<http://purl.org/dc/terms/date> rdf:type owl:NamedIndividual .
+dct:date rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/dateAccepted
-<http://purl.org/dc/terms/dateAccepted> rdf:type owl:NamedIndividual .
+dct:dateAccepted rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/dateCopyrighted
-<http://purl.org/dc/terms/dateCopyrighted> rdf:type owl:NamedIndividual .
+dct:dateCopyrighted rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/dateSubmitted
-<http://purl.org/dc/terms/dateSubmitted> rdf:type owl:NamedIndividual .
+dct:dateSubmitted rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/description
-<http://purl.org/dc/terms/description> rdf:type owl:NamedIndividual .
+dct:description rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/educationLevel
-<http://purl.org/dc/terms/educationLevel> rdf:type owl:NamedIndividual .
+dct:educationLevel rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/extent
-<http://purl.org/dc/terms/extent> rdf:type owl:NamedIndividual .
+dct:extent rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/format
-<http://purl.org/dc/terms/format> rdf:type owl:NamedIndividual .
+dct:format rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/hasFormat
-<http://purl.org/dc/terms/hasFormat> rdf:type owl:NamedIndividual .
+dct:hasFormat rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/hasPart
-<http://purl.org/dc/terms/hasPart> rdf:type owl:NamedIndividual .
+dct:hasPart rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/hasVersion
-<http://purl.org/dc/terms/hasVersion> rdf:type owl:NamedIndividual .
+dct:hasVersion rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/identifier
-<http://purl.org/dc/terms/identifier> rdf:type owl:NamedIndividual .
+dct:identifier rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/instructionalMethod
-<http://purl.org/dc/terms/instructionalMethod> rdf:type owl:NamedIndividual .
+dct:instructionalMethod rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/isFormatOf
-<http://purl.org/dc/terms/isFormatOf> rdf:type owl:NamedIndividual .
+dct:isFormatOf rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/isPartOf
-<http://purl.org/dc/terms/isPartOf> rdf:type owl:NamedIndividual .
+dct:isPartOf rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/isReferencedBy
-<http://purl.org/dc/terms/isReferencedBy> rdf:type owl:NamedIndividual .
+dct:isReferencedBy rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/isReplacedBy
-<http://purl.org/dc/terms/isReplacedBy> rdf:type owl:NamedIndividual .
+dct:isReplacedBy rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/isRequiredBy
-<http://purl.org/dc/terms/isRequiredBy> rdf:type owl:NamedIndividual .
+dct:isRequiredBy rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/isVersionOf
-<http://purl.org/dc/terms/isVersionOf> rdf:type owl:NamedIndividual .
+dct:isVersionOf rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/issued
-<http://purl.org/dc/terms/issued> rdf:type owl:NamedIndividual .
+dct:issued rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/language
-<http://purl.org/dc/terms/language> rdf:type owl:NamedIndividual .
+dct:language rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/license
-<http://purl.org/dc/terms/license> rdf:type owl:NamedIndividual .
+dct:license rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/mediator
-<http://purl.org/dc/terms/mediator> rdf:type owl:NamedIndividual .
+dct:mediator rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/medium
-<http://purl.org/dc/terms/medium> rdf:type owl:NamedIndividual .
+dct:medium rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/modified
-<http://purl.org/dc/terms/modified> rdf:type owl:NamedIndividual .
+dct:modified rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/provenance
-<http://purl.org/dc/terms/provenance> rdf:type owl:NamedIndividual .
+dct:provenance rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/publisher
-<http://purl.org/dc/terms/publisher> rdf:type owl:NamedIndividual .
+dct:publisher rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/references
-<http://purl.org/dc/terms/references> rdf:type owl:NamedIndividual .
+dct:references rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/relation
-<http://purl.org/dc/terms/relation> rdf:type owl:NamedIndividual .
+dct:relation rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/replaces
-<http://purl.org/dc/terms/replaces> rdf:type owl:NamedIndividual .
+dct:replaces rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/requires
-<http://purl.org/dc/terms/requires> rdf:type owl:NamedIndividual .
+dct:requires rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/rights
-<http://purl.org/dc/terms/rights> rdf:type owl:NamedIndividual .
+dct:rights rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/rightsHolder
-<http://purl.org/dc/terms/rightsHolder> rdf:type owl:NamedIndividual .
+dct:rightsHolder rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/source
-<http://purl.org/dc/terms/source> rdf:type owl:NamedIndividual .
+dct:source rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/spatial
-<http://purl.org/dc/terms/spatial> rdf:type owl:NamedIndividual .
+dct:spatial rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/subject
-<http://purl.org/dc/terms/subject> rdf:type owl:NamedIndividual .
+dct:subject rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/tableOfContents
-<http://purl.org/dc/terms/tableOfContents> rdf:type owl:NamedIndividual .
+dct:tableOfContents rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/temporal
-<http://purl.org/dc/terms/temporal> rdf:type owl:NamedIndividual .
+dct:temporal rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/title
-<http://purl.org/dc/terms/title> rdf:type owl:NamedIndividual .
+dct:title rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/type
-<http://purl.org/dc/terms/type> rdf:type owl:NamedIndividual .
+dct:type rdf:type owl:NamedIndividual .
 
 
 ###  http://purl.org/dc/terms/valid
-<http://purl.org/dc/terms/valid> rdf:type owl:NamedIndividual .
+dct:valid rdf:type owl:NamedIndividual .
 
 
 ###  http://www.geonames.org/ontology#L.PRT
@@ -15331,14 +12343,14 @@ ontohgis:source rdf:type owl:Class ;
 ###  https://onto.kul.pl/ontohgis/administrative_system_1
 ontohgis:administrative_system_1 rdf:type owl:NamedIndividual ,
                                           ontohgis:object_21 ;
+                                 dct:creator ontohgis:person_6 ;
                                  ontohgis:endsDominationAt "1939-12-31"^^xsd:date ;
                                  ontohgis:hasBeginning "1918-01-01"^^xsd:date ;
                                  ontohgis:hasEnd "1939-12-31"^^xsd:date ;
-                                 ontohgis:hasLegalBasis "Konstytucja Rzeczypospolitej Polskie z 17 marca 1921 r.; Rozporządzenie Prezydenta Rzeczypospolitej z dnia 19 stycznia 1928 r. o organizacji i zakresie działania władz administracji ogólnej; Ustawa z dnia 23 marca 1933 r. o częściowej zmianie ustroju samorządu terytorjalnego. (tzw. ustawa scaleniowa)"^^xsd:string ;
-                                 ontohgis:hasScope "terytorium II RP"^^xsd:string ;
+                                 ontohgis:hasLegalBasis "Konstytucja Rzeczypospolitej Polskie z 17 marca 1921 r.; Rozporządzenie Prezydenta Rzeczypospolitej z dnia 19 stycznia 1928 r. o organizacji i zakresie działania władz administracji ogólnej; Ustawa z dnia 23 marca 1933 r. o częściowej zmianie ustroju samorządu terytorjalnego. (tzw. ustawa scaleniowa)" ;
+                                 ontohgis:hasScope "terytorium II RP" ;
                                  ontohgis:individualHasExternalIdentifier 1 ;
                                  ontohgis:startsDominationAt "1918-01-01"^^xsd:date ;
-                                 dct:creator ontohgis:person_6 ;
                                  rdfs:comment "Chronologia obowiązywania systemu administracyjnego ma charakter generalny. Obejmuje także okres kształtowania się systemu administracyjnego w okresie przejściowym po odzyskaniu niepodległości."@pl ,
                                               "Konstytucja Rzeczypospolitej Polskie z 17 marca 1921 r.; Rozporządzenie Prezydenta Rzeczypospolitej z dnia 19 stycznia 1928 r. o organizacji i zakresie działania władz administracji ogólnej; Ustawa z dnia 23 marca 1933 r. o częściowej zmianie ustroju samorządu terytorjalnego. (tzw. ustawa scaleniowa)"@pl ,
                                               "The chronology of the administrative system is of gerenal nature. it covers also the origins of the system in the transition period after regaining independence"@en ;
@@ -15357,14 +12369,14 @@ ontohgis:administrative_system_1 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_10
 ontohgis:administrative_system_10 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_6 ;
                                   ontohgis:endsDominationAt "1918-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1867-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1918-12-31"^^xsd:date ;
-                                  ontohgis:hasLegalBasis "reforma administracyjna 1865-1867 (zniesienie cyrkułów, zniesienie rządu krajowego w Krakowie)"^^xsd:string ;
-                                  ontohgis:hasScope "terytorium Galicji"^^xsd:string ;
+                                  ontohgis:hasLegalBasis "reforma administracyjna 1865-1867 (zniesienie cyrkułów, zniesienie rządu krajowego w Krakowie)" ;
+                                  ontohgis:hasScope "terytorium Galicji" ;
                                   ontohgis:individualHasExternalIdentifier 10 ;
                                   ontohgis:startsDominationAt "1867-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_6 ;
                                   rdfs:label "Królestwo Galicji i Lodomerii (1867-1918)"@pl ,
                                              "The Kingdom of Galicia and Lodomeria (1867-1918)"@en ;
                                   rdfs:seeAlso ontohgis:document_34 ,
@@ -15377,15 +12389,15 @@ ontohgis:administrative_system_10 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_11
 ontohgis:administrative_system_11 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_5 ;
                                   ontohgis:endsDominationAt "1866-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1837-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1866-12-31"^^xsd:date ;
                                   ontohgis:hasLegalBasis """Ukaz carski z 7.3.1837 (Dziennik Praw Królestwa Polskiego, nr 68-70, t. 20, Warszawa 1836-1837, s. 412);
-Ukaz carski z 11.10.1842 (Dziennik Praw Królestwa Polskiego, nr 97, t. 30, Warszawa: 1842, s. 281-285)"""^^xsd:string ;
-                                  ontohgis:hasScope "terytorium Królestwa Polskiego"^^xsd:string ;
+Ukaz carski z 11.10.1842 (Dziennik Praw Królestwa Polskiego, nr 97, t. 30, Warszawa: 1842, s. 281-285)""" ;
+                                  ontohgis:hasScope "terytorium Królestwa Polskiego" ;
                                   ontohgis:individualHasExternalIdentifier 11 ;
                                   ontohgis:startsDominationAt "1842-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_5 ;
                                   rdfs:label "Congress Poland (1837-1866)"@en ,
                                              "Królestwo Polskie (1837-1866)"@pl ;
                                   rdfs:seeAlso ontohgis:document_164 ,
@@ -15397,13 +12409,13 @@ Ukaz carski z 11.10.1842 (Dziennik Praw Królestwa Polskiego, nr 97, t. 30, Wars
 ###  https://onto.kul.pl/ontohgis/administrative_system_12
 ontohgis:administrative_system_12 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_4 ;
                                   ontohgis:endsDominationAt "1918-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1815-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1918-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "terytorium Królestwa Saksonii, obejmuje część Łużyc leżących obecnie w Polsce (Bogatynia, Zgorzelec)"^^xsd:string ;
+                                  ontohgis:hasScope "terytorium Królestwa Saksonii, obejmuje część Łużyc leżących obecnie w Polsce (Bogatynia, Zgorzelec)" ;
                                   ontohgis:individualHasExternalIdentifier 12 ;
                                   ontohgis:startsDominationAt "1815-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_4 ;
                                   rdfs:label "Królestwo Saksonii (1815-1918)"@pl ,
                                              "The Kingdom of Saxony (1815-1918)"@en ;
                                   rdfs:seeAlso "https://www.wikidata.org/wiki/Q153015" .
@@ -15412,14 +12424,14 @@ ontohgis:administrative_system_12 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_13
 ontohgis:administrative_system_13 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_11 ;
                                   ontohgis:endsDominationAt "1806-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1713-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1814-12-31"^^xsd:date ;
-                                  ontohgis:hasLegalBasis "Edykt królewski z 13.08.1713 o niepodzielności wszystkich terytoriów Hohenzollernów tworzących integralne terytorium Królestwa Prus. Instrukcja królewska z 19 stycznia 1723 r. o utworzeniu General- Ober- Finanz- Kriegs- und Domänen-Direktorium."^^xsd:string ;
-                                  ontohgis:hasScope "terytorium Królestwa Prus, obejmuje obecne ziemie zachodniej i północnej Polski"^^xsd:string ;
+                                  ontohgis:hasLegalBasis "Edykt królewski z 13.08.1713 o niepodzielności wszystkich terytoriów Hohenzollernów tworzących integralne terytorium Królestwa Prus. Instrukcja królewska z 19 stycznia 1723 r. o utworzeniu General- Ober- Finanz- Kriegs- und Domänen-Direktorium." ;
+                                  ontohgis:hasScope "terytorium Królestwa Prus, obejmuje obecne ziemie zachodniej i północnej Polski" ;
                                   ontohgis:individualHasExternalIdentifier 13 ;
                                   ontohgis:startsDominationAt "1723-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_11 ;
                                   rdfs:comment "After Frederic William's ascension to the throne (1713-1740) a lengthy process of administrative system reform starts. In 1814, the interim period, when the Frederick's system was connected with the new one intorduced by Stein'. in 1723 - the General Directorate (Das Generaldirektorium) was established."@en ,
                                                "Edykt królewski z 13.08.1713 o niepodzielności wszystkich terytoriów Hohenzollernów tworzących integralne terytorium Królestwa Prus. Instrukcja królewska z 19 stycznia 1723 r. o utworzeniu General- Ober- Finanz- Kriegs- und Domänen-Direktorium."@pl ,
                                                "Po wstąpieniu na tron Fryderyk Wilhelm I (1713-1740) rozpoczyna długotrwały proces reform administracyjnych swego państwa. 1814 - koniec okresu przejściowego, w którym stary system fryderycjański łączył się z nowym, wprowadzonym przez reformy Steina. 1723 - Utworzenie Generalnego Dyrektorium (Das Generaldirektorium)"@pl ;
@@ -15435,14 +12447,14 @@ ontohgis:administrative_system_13 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_14
 ontohgis:administrative_system_14 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_3 ;
                                   ontohgis:endsDominationAt "1791-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1569-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1795-12-31"^^xsd:date ;
-                                  ontohgis:hasLegalBasis "Akt unii lubelskiej z dnia 1 lipca 1569 r.; Konstytucja 3 maja 1791 r.; "^^xsd:string ;
-                                  ontohgis:hasScope "terytorium Rzeczypospolitej Obojga Narodów"^^xsd:string ;
+                                  ontohgis:hasLegalBasis "Akt unii lubelskiej z dnia 1 lipca 1569 r.; Konstytucja 3 maja 1791 r.; " ;
+                                  ontohgis:hasScope "terytorium Rzeczypospolitej Obojga Narodów" ;
                                   ontohgis:individualHasExternalIdentifier 14 ;
                                   ontohgis:startsDominationAt "1569-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_3 ;
                                   rdfs:label "Rzeczpospolita Obojga Narodów (1569-1795)"@pl ,
                                              "The Polish-Lithuanian Commonwealth (1569-1795)"@en ;
                                   rdfs:seeAlso ontohgis:document_65 ,
@@ -15459,13 +12471,13 @@ ontohgis:administrative_system_14 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_15
 ontohgis:administrative_system_15 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_4 ;
                                   ontohgis:endsDominationAt "1805-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1545-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1805-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "terytorium Elektoratu Saksonii, obejmuje część Łużyc leżących obecnie w Polsce (Bogatynia, Zgorzelec)"^^xsd:string ;
+                                  ontohgis:hasScope "terytorium Elektoratu Saksonii, obejmuje część Łużyc leżących obecnie w Polsce (Bogatynia, Zgorzelec)" ;
                                   ontohgis:individualHasExternalIdentifier 15 ;
                                   ontohgis:startsDominationAt "1545-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_4 ;
                                   rdfs:label "Elektorat Saksonii (1545-1805)"@pl ,
                                              "The Electorate of Saxony (1545-1805)"@en ;
                                   rdfs:seeAlso "https://www.wikidata.org/wiki/Q156199" .
@@ -15474,13 +12486,13 @@ ontohgis:administrative_system_15 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_16
 ontohgis:administrative_system_16 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_9 ;
                                   ontohgis:endsDominationAt "1783-01-01"^^xsd:date ;
                                   ontohgis:hasBeginning "1783-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1848-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "terytorium Gubernium Morawsko-Śląskiego, obejmuje obecną ziemię cieszyńską"^^xsd:string ;
+                                  ontohgis:hasScope "terytorium Gubernium Morawsko-Śląskiego, obejmuje obecną ziemię cieszyńską" ;
                                   ontohgis:individualHasExternalIdentifier 16 ;
                                   ontohgis:startsDominationAt "1783-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_9 ;
                                   rdfs:label "Gubernium Morawsko-Śląskie (1783-1848)"@pl ,
                                              "Provincial government of Moravian-Silesian Region (1783-1848)"@en ;
                                   rdfs:seeAlso ontohgis:document_29 ,
@@ -15492,14 +12504,14 @@ ontohgis:administrative_system_16 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_17
 ontohgis:administrative_system_17 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_6 ;
                                   ontohgis:endsDominationAt "1848-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1772-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1848-12-31"^^xsd:date ;
-                                  ontohgis:hasLegalBasis "Edykt z 11 września 1772 r. o utworzeniu guberium we Lwowie; listopad-grudzień 1773 r: podział na 6 cyrkułów (Kreis) oraz 59 okręgów (Kreisdistricten); dekret z 22 marca 1782 r. o zniesieniu okręgów"^^xsd:string ;
-                                  ontohgis:hasScope "terytorium Galicji, bez Wolnego Miasta Krakowa w latach 1815-1846"^^xsd:string ;
+                                  ontohgis:hasLegalBasis "Edykt z 11 września 1772 r. o utworzeniu guberium we Lwowie; listopad-grudzień 1773 r: podział na 6 cyrkułów (Kreis) oraz 59 okręgów (Kreisdistricten); dekret z 22 marca 1782 r. o zniesieniu okręgów" ;
+                                  ontohgis:hasScope "terytorium Galicji, bez Wolnego Miasta Krakowa w latach 1815-1846" ;
                                   ontohgis:individualHasExternalIdentifier 17 ;
                                   ontohgis:startsDominationAt "1773-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_6 ;
                                   rdfs:comment "Edict from 11 September 1772 on establishing a geovernorate in Lvov, November-December 1773: division into 6 circles (Ger. Kreis) and 59 districts (Ger. Kreisdistricten); decree from 22 March 1782 on waiving the circles"@en ,
                                                "Edykt z 11 września 1772 r. o utworzeniu guberium we Lwowie; listopad-grudzień 1773 r: podział na 6 cyrkułów (Kreis) oraz 59 okręgów (Kreisdistricten); dekret z 22 marca 1782 r. o zniesieniu okręgów"@pl ;
                                   rdfs:label "Królestwo Galicji i Lodomerii (1772-1848)"@pl ,
@@ -15517,14 +12529,14 @@ ontohgis:administrative_system_17 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_18
 ontohgis:administrative_system_18 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_6 ;
                                   ontohgis:endsDominationAt "1918-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1200-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1918-12-31"^^xsd:date ;
-                                  ontohgis:hasLegalBasis "Ustrój terytoriualny oparty o komitaty (megye) i powiaty (processus, reambulatio, węg. szolgabírói járás) ukształtował się w średniowieczu, od XI wieku, i mimo wielu prób reform administracyjnych obowiązuje zasadniczo po dzień dzisiejszy. Najważniejsze reformy miały miejsce w latach 1785-1790, 1849-1860 i były związane z próbą centralizacji administracyjnej w ramach monarchii austriackiej."^^xsd:string ;
-                                  ontohgis:hasScope "terytorium Królestwa Węgier, obejmuje południowe skrawki obecnej Polski, okolice Orawy i Niedzicy (dawne komitaty Spisz i Orawa)"^^xsd:string ;
+                                  ontohgis:hasLegalBasis "Ustrój terytoriualny oparty o komitaty (megye) i powiaty (processus, reambulatio, węg. szolgabírói járás) ukształtował się w średniowieczu, od XI wieku, i mimo wielu prób reform administracyjnych obowiązuje zasadniczo po dzień dzisiejszy. Najważniejsze reformy miały miejsce w latach 1785-1790, 1849-1860 i były związane z próbą centralizacji administracyjnej w ramach monarchii austriackiej." ;
+                                  ontohgis:hasScope "terytorium Królestwa Węgier, obejmuje południowe skrawki obecnej Polski, okolice Orawy i Niedzicy (dawne komitaty Spisz i Orawa)" ;
                                   ontohgis:individualHasExternalIdentifier 18 ;
                                   ontohgis:startsDominationAt "1200-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_6 ;
                                   rdfs:comment "The administrative division based on counties (konitat/Hun.megye) and districts (powiat/processus Hun.  szolgabírói járás) had emerged in the Middle Ages since the 11th c., and despite the numerous administrative reforms is still valid. The key reforms were introduced in 1785-1790 and 1849-1860 and attempted ot centralise the adminittation within the entire Austrian monarchy."@en ,
                                                "Ustrój terytoriualny oparty o komitaty (megye) i powiaty (processus, reambulatio, węg. szolgabírói járás) ukształtował się w średniowieczu, od XI wieku, i mimo wielu prób reform administracyjnych obowiązuje zasadniczo po dzień dzisiejszy. Najważniejsze reformy miały miejsce w latach 1785-1790, 1849-1860 i były związane z próbą centralizacji administracyjnej w ramach monarchii austriackiej."@pl ;
                                   rdfs:label "Królestwo Węgier (1200-1918)"@pl ,
@@ -15539,13 +12551,13 @@ ontohgis:administrative_system_18 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_19
 ontohgis:administrative_system_19 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_9 ;
                                   ontohgis:endsDominationAt "1742-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1372-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1782-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "terytorium Śląska"^^xsd:string ;
+                                  ontohgis:hasScope "terytorium Śląska" ;
                                   ontohgis:individualHasExternalIdentifier 19 ;
                                   ontohgis:startsDominationAt "1372-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_9 ;
                                   rdfs:label "Silesia (1372-1782)"@en ,
                                              "Śląsk (1372-1782)"@pl ;
                                   rdfs:seeAlso ontohgis:document_165 ,
@@ -15564,13 +12576,13 @@ ontohgis:administrative_system_19 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_20
 ontohgis:administrative_system_20 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_11 ;
                                   ontohgis:endsDominationAt "1648-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1230-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1648-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "terytorium Księstwa Pomorskiego, obejmuje obecne obszary Pomorza Zachodniego"^^xsd:string ;
+                                  ontohgis:hasScope "terytorium Księstwa Pomorskiego, obejmuje obecne obszary Pomorza Zachodniego" ;
                                   ontohgis:individualHasExternalIdentifier 20 ;
                                   ontohgis:startsDominationAt "1250-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_11 ;
                                   rdfs:comment """\"Jako datę początkową przyjęto w przybliżeniu 1230 r., kiedy następuje likwidacja systemu grodów kasztelańskich i kasztelanii.
 W 1160 r. podział na dwie dzielnice: 1. Księstwo Szczecińskie rządzone przez Bogusława I, obejmowało południową część księstwa. W jego skład wchodziły okręgi: Szczecina, Gardźca, Bani, Cedyni, Pyrzyc, ziemia wkrzańska, Uznam, Rochów, Szczytno, Lesiany (Lassan), Groźwin, Wkryujście (Ueckermuende); 2. Księstwo Dymińskie rządzone przez Kazimierza I obejmowało pas nadbrzeża i zdobyte ziemie wieleckie. W jego skład wchodziły okręgi: Barda, Trzebudzic, Chockowa, Ostrożna (Wusterhusen), Łosic (Loitz); ziemie: bezrzecka (Beseritz), dołęska (Tolense), biezdziedzka (okolice Gnojna), stargardzka; okręgi grodowe: Dymina, Wolina, Kamienia, Trzebiatowa, Nowogardu i Stargardu nad Iną. Prawdopodobnie również Łobez i Resko. Kasztelania kołobrzeska i okręg Świdwina stanowiły współwłasność obu książąt. 
 W latach 1180-1214 zjednoczenie obu księstw. W 1181 r. Księstwo Pomorskie w bezpośredniej zależności lennej jako księstwo Rzeszy. 
@@ -15591,14 +12603,14 @@ W 1625 r. zjednoczenie w jedno Księstwo Pomorskie, zaś po pokoju westfalskim w
 ###  https://onto.kul.pl/ontohgis/administrative_system_21
 ontohgis:administrative_system_21 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_11 ;
                                   ontohgis:endsDominationAt "1713-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1540-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1713-12-31"^^xsd:date ;
-                                  ontohgis:hasLegalBasis "Hofordnung 1537, Kanzleiordnungen 1537, 1562, 1577; Geheime-Rats-Ordnung 13.12.1604"^^xsd:string ;
-                                  ontohgis:hasScope "terytorium Marchii Brandenburskiej, obejmuje obecne ziemie zachodniej Polski"^^xsd:string ;
+                                  ontohgis:hasLegalBasis "Hofordnung 1537, Kanzleiordnungen 1537, 1562, 1577; Geheime-Rats-Ordnung 13.12.1604" ;
+                                  ontohgis:hasScope "terytorium Marchii Brandenburskiej, obejmuje obecne ziemie zachodniej Polski" ;
                                   ontohgis:individualHasExternalIdentifier 21 ;
                                   ontohgis:startsDominationAt "1550-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_11 ;
                                   rdfs:comment "W 1535 Nowa Marchia przeszła pod panowanie margrafa Jana i jako wydzielona prowincja uzyskała odrębną strukturę administracyjną (patrz. Nowa Marchia). Ponownie włączona w 1571 zachowała jednak swoją odrębność administracyjną. Po przejściu na luteranizm (1.11.1539) w roku następnym stany państwa brandenburskiego przejęły spłatę elektorskich długów i same utworzyły organ kontrolny i wykonawczy do sciągania danin i podatków."@pl ;
                                   rdfs:label "Marchia Brandenburska (1540-1713)"@pl ,
                                              "The Margraviate of Branderburg (1540-1713)"@en ;
@@ -15610,13 +12622,13 @@ ontohgis:administrative_system_21 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_22
 ontohgis:administrative_system_22 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_3 ;
                                   ontohgis:endsDominationAt "1790-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1443-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1790-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "terytorium Księstwa Siewierskiego, obejmuje obecnie okolice miast Siewierz, Czeladź i Koziegłowy"^^xsd:string ;
+                                  ontohgis:hasScope "terytorium Księstwa Siewierskiego, obejmuje obecnie okolice miast Siewierz, Czeladź i Koziegłowy" ;
                                   ontohgis:individualHasExternalIdentifier 22 ;
                                   ontohgis:startsDominationAt "1443-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_3 ;
                                   rdfs:label "Księstwo Siewierskie (1443-1790)"@pl ,
                                              "The Duchy of Siewierz (1443-1790)"@en ;
                                   rdfs:seeAlso ontohgis:document_175 ,
@@ -15627,14 +12639,14 @@ ontohgis:administrative_system_22 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_23
 ontohgis:administrative_system_23 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_11 ;
                                   ontohgis:endsDominationAt "1540-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1323-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1550-12-31"^^xsd:date ;
-                                  ontohgis:hasLegalBasis "Landbuch der Mark Brandenburg 1375 i następne decyzje margrafów"^^xsd:string ;
-                                  ontohgis:hasScope "terytorium Marchii Brandenburskiej, obejmuje obecne ziemie zachodniej Polski"^^xsd:string ;
+                                  ontohgis:hasLegalBasis "Landbuch der Mark Brandenburg 1375 i następne decyzje margrafów" ;
+                                  ontohgis:hasScope "terytorium Marchii Brandenburskiej, obejmuje obecne ziemie zachodniej Polski" ;
                                   ontohgis:individualHasExternalIdentifier 23 ;
                                   ontohgis:startsDominationAt "1350-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_11 ;
                                   rdfs:comment "In 1320, the dynasty of the house of Ascan had come to an end and the power moved to the house of Wittelsbach and Luxemburg. The emperor Luis IV Wittelsbach grants the Marach to his son Luis V the Brandenburger"@en ,
                                                "W 1320 r. wygasła dynastia askańczyków. Władzę w Marchii przejmują Wittelsbachowie i Luksemburgowie. Po wygaśnięciu dynastii Askańczyków cesarz Ludwik Wittelsbach nadaje marchię swemu synowi Ludwikowi"@pl ;
                                   rdfs:label "Marchia Brandenburska (1323-1540)"@pl ,
@@ -15647,13 +12659,13 @@ ontohgis:administrative_system_23 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_24
 ontohgis:administrative_system_24 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_3 ;
                                   ontohgis:endsDominationAt "1370-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1000-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1370-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "terytorium obecnej Polski"^^xsd:string ;
+                                  ontohgis:hasScope "terytorium obecnej Polski" ;
                                   ontohgis:individualHasExternalIdentifier 24 ;
                                   ontohgis:startsDominationAt "1000-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_3 ;
                                   rdfs:comment "Data umowna, koniec panowania Piastów, ostateczne przejście Śląska w ręce czeskie (1372), unia w Krewie (1385 r.), podział Rusi Halicko-Włodzimierskiej (1387)"@pl ,
                                                "The approximate date marks the end of the Piasts' rule, the final Chech rule in Sląsk (1372), Union of Krevo (1385), division of Kingdom of Valitia-Volhynia (1387)."@en ;
                                   rdfs:label "System średniowieczny (do XIV w.)"@pl .
@@ -15662,15 +12674,15 @@ ontohgis:administrative_system_24 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_25
 ontohgis:administrative_system_25 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_9 ;
                                   <http://www.cidoc-crm.org/cidoc-crm/P9i_forms_part_of> ontohgis:administrative_system_26 ;
                                   ontohgis:endsDominationAt "1466-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1233-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1525-12-31"^^xsd:date ;
-                                  ontohgis:hasLegalBasis "Przywilej chełmiński 1233, statuty zakonu, akt inkorporacji ziem pruskich z 6 marca 1454; traktat toruński z 1466; traktat krakowski z 1525"^^xsd:string ;
-                                  ontohgis:hasScope "terytorium państwa zakonnego, obejmuje obecne obszary północnej Polski (Pomorze, Warmia i Mazury)"^^xsd:string ;
+                                  ontohgis:hasLegalBasis "Przywilej chełmiński 1233, statuty zakonu, akt inkorporacji ziem pruskich z 6 marca 1454; traktat toruński z 1466; traktat krakowski z 1525" ;
+                                  ontohgis:hasScope "terytorium państwa zakonnego, obejmuje obecne obszary północnej Polski (Pomorze, Warmia i Mazury)" ;
                                   ontohgis:individualHasExternalIdentifier 25 ;
                                   ontohgis:startsDominationAt "1309-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_9 ;
                                   rdfs:comment "Częściowo, w sprawach związanych z działalnością zakonną, podległość Stolicy Apostolskiej"@pl ,
                                                "Plemiona pruskie nie wytworzyły państwowości i administracji terytorialnej przed XIII w.: W. Długokęcki, Prusy w starożytności i we wczesnym średniowieczu, [w:] M. Biskup, i in., Państwo zakonu krzyżackiego w Prusach. Władza i społeczeństwo, Warszawa 2008, s. 38-39, 43: \"Mniejsza niż plemię jednostka terytorialna nosiła nazwę territorium (Dusburg), a także terrula, districtus. W literaturze określa się ją też jako włość, mała ziemia lub używa pruskiej nazwy pulka. [...] Podstawową jednostkę osadniczą stanowiło pole (prus. lauks, łac. campus, niem. Feld). Tworzyło ono topograficzno-gospodarczą całość, bez wytyczonych granic linearnych [...] Obraz ustroju politycznego Estów i Prusów przekazany przez źródła IX-XIII w. wyraźnie wskazuje na rozdrobnienie polityczne i brak silnych ośrodków władzy publicznej. Zasadnicze znaczenie miały wiece różnych struktur terytorialnych (prus. wayde, waite). W XIII w. funkcjonowały wiece międzyplemienne, plemienne i na poziomie małej ziemi. Wzmianki o wiecach z XIII w. dotyczą przede wszystkim wieców wojennych [...]\". R. Czaja, i in. [w:] ibidem, s. 75-76: \"Przywilej chełmiński, będący formalnie dokumentem lokacyjnym Chełmna i Torunia, w rzeczywistości pełnił funkcję przywileju \"krajowego\". Niektóre bowiem przepisy w nim zawarte dotyczyły także rycerzy (np. te, które odnosiły się do statusu prawnego dóbr obciążonych służbą wojskową), postanowienia zaś odnoszące się do monety, wymiaru łana, zwolnień celnych, wolnego targu obejmowały wszystkich mieszkańców ziemi chełmińskiej. Prawo chełmińskie służyło wyodrębnieniu z władztwa księcia Konrada obszaru poddanego kontroli Zakonu: tam, gdzie były stosowane postanowienia przywileju, sięgała władza Krzyżaków\". 1309 - zajęcie Pomorza Gdańskiego, przeniesienie siedziby wielkiego mistrza zakonnego do Malborka (mimo że nie było jeszcze wtedy jasne czy Malbork zostanie stolicą państwa). 1466 - inkorporacja ziem pruskich do Korony przez króla Kazimierz Jagiellończyka doprowadziła do wybuchu wojny trzynastoletniej, na zakończenie której (pokojem toruńskim w 1466) Krzyżacy - korzystając z mediacji legata papieskiego - doprowadzili do swoistego kompromisu, w wyniku którego: Prusy Królewskie podlegały Koronie, Warmia stanowiła część Prus Królewskich, ale z dużą autonomią, Prusy zakonne stały się lennem Korony, nad którym władzę zwierzchnią sprawował Zakon."@pl ;
                                   rdfs:label "Państwo Krzyżackie (1226-1525)"@pl ,
@@ -15694,7 +12706,7 @@ ontohgis:administrative_system_26 rdf:type owl:NamedIndividual ,
                                   ontohgis:endsDominationAt "1939-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1000-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1939-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "terytorium Polski"^^xsd:string ;
+                                  ontohgis:hasScope "terytorium Polski" ;
                                   ontohgis:individualHasExternalIdentifier 26 ;
                                   ontohgis:startsDominationAt "1000-01-01"^^xsd:date ;
                                   rdfs:label "Kościół katolicki ob. łacińskiego"@pl ,
@@ -15726,8 +12738,8 @@ ontohgis:administrative_system_27 rdf:type owl:NamedIndividual ,
                                   ontohgis:endsDominationAt "1939-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1596-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1939-12-31"^^xsd:date ;
-                                  ontohgis:hasLegalBasis "1596, akt unii brzeskiej; 1720, synod w Zamościu "^^xsd:string ;
-                                  ontohgis:hasScope "terytorium Polski, zwłaszcza wschodniej"^^xsd:string ;
+                                  ontohgis:hasLegalBasis "1596, akt unii brzeskiej; 1720, synod w Zamościu " ;
+                                  ontohgis:hasScope "terytorium Polski, zwłaszcza wschodniej" ;
                                   ontohgis:individualHasExternalIdentifier 27 ;
                                   ontohgis:startsDominationAt "1596-01-01"^^xsd:date ;
                                   rdfs:label "Greek Catholic Church"@en ,
@@ -15761,7 +12773,7 @@ ontohgis:administrative_system_28 rdf:type owl:NamedIndividual ,
                                   ontohgis:endsDominationAt "1939-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1000-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1939-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "terytorium Polski, zwłaszcza wschodniej"^^xsd:string ;
+                                  ontohgis:hasScope "terytorium Polski, zwłaszcza wschodniej" ;
                                   ontohgis:individualHasExternalIdentifier 28 ;
                                   ontohgis:startsDominationAt "1000-01-01"^^xsd:date ;
                                   rdfs:label "Kościół prawosławny"@pl ,
@@ -15791,7 +12803,7 @@ ontohgis:administrative_system_29 rdf:type owl:NamedIndividual ,
                                   ontohgis:endsDominationAt "1772-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1565-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1795-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "Wielkopolska i Litwa, luteranie w Małopolsce i w Prusach Królewskich nie wytworzyli własnej struktury organizacyjnej"^^xsd:string ;
+                                  ontohgis:hasScope "Wielkopolska i Litwa, luteranie w Małopolsce i w Prusach Królewskich nie wytworzyli własnej struktury organizacyjnej" ;
                                   ontohgis:individualHasExternalIdentifier 29 ;
                                   ontohgis:startsDominationAt "1565-01-01"^^xsd:date ;
                                   rdfs:label "Evangelical Augsburg Church in the Polish-Lithuanian Commonwealth"@en ,
@@ -15812,14 +12824,14 @@ ontohgis:administrative_system_29 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_3
 ontohgis:administrative_system_3 rdf:type owl:NamedIndividual ,
                                           ontohgis:object_21 ;
+                                 dct:creator ontohgis:person_6 ;
                                  ontohgis:endsDominationAt "2016-12-21"^^xsd:date ;
                                  ontohgis:hasBeginning "1999-01-01"^^xsd:date ;
                                  ontohgis:hasEnd "2016-12-31"^^xsd:date ;
-                                 ontohgis:hasLegalBasis "Ustawa z dnia 24 lipca 1998 r. o wprowadzeniu zasadniczego trójstopniowego podziału terytorialnego państwa (Dz.U. z 1998 r. Nr 96, poz. 603)"^^xsd:string ;
-                                 ontohgis:hasScope "terytorium III RP"^^xsd:string ;
+                                 ontohgis:hasLegalBasis "Ustawa z dnia 24 lipca 1998 r. o wprowadzeniu zasadniczego trójstopniowego podziału terytorialnego państwa (Dz.U. z 1998 r. Nr 96, poz. 603)" ;
+                                 ontohgis:hasScope "terytorium III RP" ;
                                  ontohgis:individualHasExternalIdentifier 3 ;
                                  ontohgis:startsDominationAt "1999-01-01"^^xsd:date ;
-                                 dct:creator ontohgis:person_6 ;
                                  rdfs:comment "This administration system is introduced for the auxiliary purposes, has no historical value and is currently used."@en ,
                                               "Wprowadzenie tego systemu ma rolę pomocniczą, nie ma on charakteru historycznego i jest współcześnie obowiązujący"@pl ;
                                  rdfs:label "Rzeczpospolita Polska (1999-2016)"@pl ,
@@ -15844,7 +12856,7 @@ ontohgis:administrative_system_30 rdf:type owl:NamedIndividual ,
                                   ontohgis:endsDominationAt "1645-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1560-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1645-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "Wielkopolska"^^xsd:string ;
+                                  ontohgis:hasScope "Wielkopolska" ;
                                   ontohgis:individualHasExternalIdentifier 30 ;
                                   ontohgis:startsDominationAt "1560-01-01"^^xsd:date ;
                                   rdfs:label "Jednota Braci Czeskich w Polsce"@pl ,
@@ -15871,7 +12883,7 @@ ontohgis:administrative_system_31 rdf:type owl:NamedIndividual ,
                                   ontohgis:endsDominationAt "1795-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1560-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1795-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "Małopolska i Wielkie Księstwo Litewskie"^^xsd:string ;
+                                  ontohgis:hasScope "Małopolska i Wielkie Księstwo Litewskie" ;
                                   ontohgis:individualHasExternalIdentifier 31 ;
                                   ontohgis:startsDominationAt "1560-01-01"^^xsd:date ;
                                   rdfs:label "Calvinist Church in the Polish-Lithuanian Commonwealth"@en ,
@@ -15900,7 +12912,7 @@ ontohgis:administrative_system_32 rdf:type owl:NamedIndividual ,
                                   ontohgis:endsDominationAt "1808-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1525-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1817-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "Prusy, Pomorze, Śląsk"^^xsd:string ;
+                                  ontohgis:hasScope "Prusy, Pomorze, Śląsk" ;
                                   ontohgis:individualHasExternalIdentifier 32 ;
                                   ontohgis:startsDominationAt "1587-01-01"^^xsd:date ;
                                   rdfs:comment "Pominięte zostały dość dynamiczne zmiany dotyczące rozwoju struktur luterańskich na ziemiach polskich w latach 1772-1828 (w tym na obszarze Księstwa Warszawskiego), związane z włączaniem ich do systemu państw zaborczych (zob. A. Rhode). Reforma Steina, czyli patenty królewskie z 16 i 26 grudnia 1808 wprowadzały kontrole państwa nad strukturami kościołów ewangelickich. Zniesiono luterańskie Oberkonsistorium i Konsistorien w prowincjach, oraz reformierte Kirchendirktorium."@pl ,
@@ -15928,7 +12940,7 @@ ontohgis:administrative_system_33 rdf:type owl:NamedIndividual ,
                                   ontohgis:endsDominationAt "1808-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1713-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1817-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "Prusy, Pomorze, Śląsk"^^xsd:string ;
+                                  ontohgis:hasScope "Prusy, Pomorze, Śląsk" ;
                                   ontohgis:individualHasExternalIdentifier 33 ;
                                   ontohgis:startsDominationAt "1713-01-01"^^xsd:date ;
                                   rdfs:comment """Pominięte zostały dość dynamiczne zmiany dotyczące rozwoju struktur luterańskich na ziemiach polskich w latach 1772-1828 (w tym na obszarze Księstwa Warszawskiego), związane z włączaniem ich do systemu państw zaborczych. 
@@ -15957,7 +12969,7 @@ ontohgis:administrative_system_34 rdf:type owl:NamedIndividual ,
                                   ontohgis:endsDominationAt "1939-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1808-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1939-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "Prusy"^^xsd:string ;
+                                  ontohgis:hasScope "Prusy" ;
                                   ontohgis:individualHasExternalIdentifier 34 ;
                                   ontohgis:startsDominationAt "1821-01-01"^^xsd:date ;
                                   rdfs:comment "Reforma Steina, czyli patenty królewskie z 16 i 26 grudnia 1808 wprowadzały kontrole państwa nad strukturami kościołów ewangelickich. Zniesiono luterańskie Oberkonsistorium i Konsistorien w prowincjach, oraz reformierte Kirchendirktorium. W ich miejsce powołano Wydział Wyznań (Kultussektion) w ministerstwie spraw wewnętrznych jako najwyższy organ administracji kościelnej. W 1817 roku wydział ten przeniesiono do ministerstwa wyznań. Na poziomie nowo utworzonych rejencji powstają wydziały szkolne i kościelne, które administrują sprawami kościelnymi w następstwie dawnych konsystorzy prowincjonalnych. W 1815 roku powrócono do konsystorzy prowincjonalnych, które były jednak organami administracji państwowej. Od 1828 roku dla każdej prowincji był Generalsuperintendent, któremu przypadała władza podobna do biskupiej, ale nie miał tytułu biskupa."@pl ;
@@ -15989,7 +13001,7 @@ ontohgis:administrative_system_35 rdf:type owl:NamedIndividual ,
                                   ontohgis:endsDominationAt "1849-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1828-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1849-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "Królestwo Polskie"^^xsd:string ;
+                                  ontohgis:hasScope "Królestwo Polskie" ;
                                   ontohgis:individualHasExternalIdentifier 35 ;
                                   ontohgis:startsDominationAt "1828-01-01"^^xsd:date ;
                                   rdfs:comment "Pominięte zostały dość dynamiczne zmiany dotyczące rozwoju struktur luterańskich na ziemiach polskich w latach 1772-1828 (w tym na obszarze Księstwa Warszawskiego), związane z włączaniem ich do systemu państw zaborczych oraz tendencjami unijnymi (próby powołania wspólnego konsystorza dla luteran i reformowanych)."@pl ;
@@ -16011,8 +13023,8 @@ ontohgis:administrative_system_36 rdf:type owl:NamedIndividual ,
                                   ontohgis:endsDominationAt "1936-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1849-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1939-12-31"^^xsd:date ;
-                                  ontohgis:hasLegalBasis "Ustawa z 1849 r.; 25 listopada 1936, dekret Prezydenta RP: \"co spowodowały zmiany w tytulaturze i nazewnictwie poszczególnych zwierzchników i ich jednostek kościelnych\" (Kłaczkow, s. 42), trudno więc to uznać za zmianę ustroju kościoła ewangelickiego."^^xsd:string ;
-                                  ontohgis:hasScope "Królestwo Polskie, II Rzeczpospolita"^^xsd:string ;
+                                  ontohgis:hasLegalBasis "Ustawa z 1849 r.; 25 listopada 1936, dekret Prezydenta RP: \"co spowodowały zmiany w tytulaturze i nazewnictwie poszczególnych zwierzchników i ich jednostek kościelnych\" (Kłaczkow, s. 42), trudno więc to uznać za zmianę ustroju kościoła ewangelickiego." ;
+                                  ontohgis:hasScope "Królestwo Polskie, II Rzeczpospolita" ;
                                   ontohgis:individualHasExternalIdentifier 36 ;
                                   ontohgis:startsDominationAt "1849-01-01"^^xsd:date ;
                                   rdfs:comment "pominięty został wąski skrawek na wschodzie należący do Rosji (konsystorz kurlandzki i petersburski); tamtejsze struktury Kościoła luterańskiego oparte były na przepisach rosyjskich z 1832 r. ale niewiele różniły się od tych obowiązujących z Królestwie od 1849 r.; jedna z różnic polegała na tym, że w Rosji były dwa typy konsystorzy: szereg prowincjonalnych i jeden generalny w Petersburgu"@pl ;
@@ -16037,7 +13049,7 @@ ontohgis:administrative_system_37 rdf:type owl:NamedIndividual ,
                                   ontohgis:endsDominationAt "1936-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1849-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1939-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "Królestwo Polskie, II Rzeczpospolita"^^xsd:string ;
+                                  ontohgis:hasScope "Królestwo Polskie, II Rzeczpospolita" ;
                                   ontohgis:individualHasExternalIdentifier 37 ;
                                   ontohgis:startsDominationAt "1849-01-01"^^xsd:date ;
                                   rdfs:label "Evangelical Reformed Church in Poland 1849-1939"@en ,
@@ -16060,8 +13072,8 @@ ontohgis:administrative_system_38 rdf:type owl:NamedIndividual ,
                                   ontohgis:endsDominationAt "1918-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1781-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1918-12-31"^^xsd:date ;
-                                  ontohgis:hasLegalBasis "Od 1861 r. powołany oficjalnie "^^xsd:string ;
-                                  ontohgis:hasScope "Galicja"^^xsd:string ;
+                                  ontohgis:hasLegalBasis "Od 1861 r. powołany oficjalnie " ;
+                                  ontohgis:hasScope "Galicja" ;
                                   ontohgis:individualHasExternalIdentifier 38 ;
                                   ontohgis:startsDominationAt "1781-01-01"^^xsd:date ;
                                   rdfs:label "Kościół ewangelicki w Galicji 1781-1918"@pl .
@@ -16074,7 +13086,7 @@ ontohgis:administrative_system_39 rdf:type owl:NamedIndividual ,
                                   ontohgis:endsDominationAt "1764-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1623-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1764-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "terytorium obecnej Polski"^^xsd:string ;
+                                  ontohgis:hasScope "terytorium obecnej Polski" ;
                                   ontohgis:individualHasExternalIdentifier 39 ;
                                   ontohgis:startsDominationAt "1623-01-01"^^xsd:date ;
                                   rdfs:label "Żydzi w Rzeczypospolitej Obojga Narodów"@pl .
@@ -16083,14 +13095,14 @@ ontohgis:administrative_system_39 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_4
 ontohgis:administrative_system_4 rdf:type owl:NamedIndividual ,
                                           ontohgis:object_21 ;
+                                 dct:creator ontohgis:person_11 ;
                                  ontohgis:endsDominationAt "1945-12-31"^^xsd:date ;
                                  ontohgis:hasBeginning "1920-01-01"^^xsd:date ;
                                  ontohgis:hasEnd "1945-12-31"^^xsd:date ;
-                                 ontohgis:hasLegalBasis "Verordnung wegen verbesserter Einrichtung der Provinzial- Polizei- und Finanzbehörden vom 26. Dezember 1808 (GS S. 481); Städteordnung 1808, 1831, 1853; Verordnung wegen verbesserter Einrichtung der Provinzial-Behörden vom 30. April 1815 (GS S. 85); Gesetz über Verpflichtung zur Armenpflege vom 31. Dez. 1842; Kreisordnung für die östlichen 6 Provinzen vom 13. Dez. 1872."^^xsd:string ;
-                                 ontohgis:hasScope "terytorium Wolnego Państwa Prus, obejmuje obecne ziemie zachodniej i północnej Polski"^^xsd:string ;
+                                 ontohgis:hasLegalBasis "Verordnung wegen verbesserter Einrichtung der Provinzial- Polizei- und Finanzbehörden vom 26. Dezember 1808 (GS S. 481); Städteordnung 1808, 1831, 1853; Verordnung wegen verbesserter Einrichtung der Provinzial-Behörden vom 30. April 1815 (GS S. 85); Gesetz über Verpflichtung zur Armenpflege vom 31. Dez. 1842; Kreisordnung für die östlichen 6 Provinzen vom 13. Dez. 1872." ;
+                                 ontohgis:hasScope "terytorium Wolnego Państwa Prus, obejmuje obecne ziemie zachodniej i północnej Polski" ;
                                  ontohgis:individualHasExternalIdentifier 4 ;
                                  ontohgis:startsDominationAt "1920-01-01"^^xsd:date ;
-                                 dct:creator ontohgis:person_11 ;
                                  rdfs:comment """\"Verordnung wegen verbesserter Einrichtung der Provinzial- Polizei- und Finanzbehörden vom 26. Dezember 1808 (GS S. 481).
 Städteordnung 1808, 1831, 1853.
 Verordnung wegen verbesserter Einrichtung der Provinzial-Behörden vom 30. April 1815 (GS S. 85).
@@ -16113,13 +13125,13 @@ Kreisordnung für die östlichen 6 Provinzen vom 13. Dez. 1872.\""""@de ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_40
 ontohgis:administrative_system_40 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_6 ;
                                   ontohgis:endsDominationAt "1569-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1385-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1569-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "terytorium Wielkiego Księstwa Litewskiego, przede wszystkich teren historycznego Podlasia i Suwalszczyzny"^^xsd:string ;
+                                  ontohgis:hasScope "terytorium Wielkiego Księstwa Litewskiego, przede wszystkich teren historycznego Podlasia i Suwalszczyzny" ;
                                   ontohgis:individualHasExternalIdentifier 40 ;
                                   ontohgis:startsDominationAt "1385-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_6 ;
                                   rdfs:comment "The typology and taxonomy of territorial units in Lithuanian land in the Middle Ages was inconsistent and provoked heated discussion among historians. The terms are often interchangable and fluid, e.g. land, wolost. For instance, until the second half of the 15th c. the baillifs (pl. Starosta) od Drohiczyn and Biels lands were called \"wojewoda\", while after the 15th c. the governors in Poldlachia were called \"Starosta\". Only after the 16th c. a relatively stable administrative system was established. It included: voividships and districts (województwa, powiaty). Broadly speaking, the voidoships replaced the principalities and lands, while districts replaced the vicegerencies/bailiwicks and wolosts."@en ,
                                                "Typologia i nazewnictwo jednostek terytorialnych ziem litewskich w średniowieczu były niekonsekwentne i są przedmiotem dyskusji wśród historyków. Występuję duża zmienność oraz wymienność określeń ich typów: np. ziemia, wołość. Np. do II połowy wieku XV starostowie związani z ziemią drohicką i bielską nazywani byli wojewodami, zaś od połowy XV w. namiestnicy na Podlasiu określani byli mianem starostów. Dopiero w XVI w. ukształtował się względnie stabilny terytorialny system administracyjny oparty o podział na województwa oraz powiaty. Ujmując rzecz bardzo generalnie województwa zastąpiły dawne księstwa i ziemie, zaś powiaty – dawne namiestnictwa-starostwa i wołości."@pl ;
                                   rdfs:label "The Grand Duchy of Lithuania"@en ,
@@ -16142,13 +13154,13 @@ ontohgis:administrative_system_40 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_41
 ontohgis:administrative_system_41 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_6 ;
                                   ontohgis:endsDominationAt "1866-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1849-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1866-12-31"^^xsd:date ;
                                   ontohgis:hasLegalBasis "1849-1850: reforma ustrojowa (kraj koronny, namiestnictwa, wprowadzenie powiatów); 1855-1856: reforma administracyjna (zniesienie kompetencji dominiów i magistratów na rzecz ustroju gminnego i powiatów)" ;
                                   ontohgis:hasScope "terytorium Galicji" ;
                                   ontohgis:startsDominationAt "1855-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_6 ;
                                   rdfs:label "Królestwo Galicji i Lodomerii (1849-1866)"@pl ,
                                              "the Kingdom of Galicia and Lodomeria (1849-1866)"@en ;
                                   rdfs:seeAlso ontohgis:document_182 ,
@@ -16163,14 +13175,14 @@ ontohgis:administrative_system_41 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_42
 ontohgis:administrative_system_42 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_5 ;
                                   ontohgis:endsDominationAt "1814-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1807-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1814-12-31"^^xsd:date ;
-                                  ontohgis:hasLegalBasis "Dziennik Praw [Księstwa Warszawskiego], t. 1, s. XXXIV"^^xsd:string ;
-                                  ontohgis:hasScope "terytorium Księstwa Warszawskiego"^^xsd:string ;
+                                  ontohgis:hasLegalBasis "Dziennik Praw [Księstwa Warszawskiego], t. 1, s. XXXIV" ;
+                                  ontohgis:hasScope "terytorium Księstwa Warszawskiego" ;
                                   ontohgis:individualHasExternalIdentifier 42 ;
                                   ontohgis:startsDominationAt "1807-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_5 ;
                                   rdfs:comment "Chronologia obowiązywania systemu administracyjnego ma charakter generalny. Obejmuje również okres okupacji wojennej przez Rosję (1812-1816)"@pl ,
                                                "The administrative system's chronology is of general nature. It also includes the period of Russian occupation (1812-1816)."@en ;
                                   rdfs:label "Księstwo Warszawskie (1807-1815)"@pl ,
@@ -16186,14 +13198,14 @@ ontohgis:administrative_system_42 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_43
 ontohgis:administrative_system_43 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_5 ;
                                   ontohgis:endsDominationAt "1837-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1815-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1842-12-31"^^xsd:date ;
-                                  ontohgis:hasLegalBasis "Dekret Namiestnika Królestwa Polskiego gen. Józefa Zajączka z dn. 16 stycznia 1816 r. (Dziennik Praw, T. 1, s. 115)"^^xsd:string ;
-                                  ontohgis:hasScope "terytorium Królestwa Polskiego"^^xsd:string ;
+                                  ontohgis:hasLegalBasis "Dekret Namiestnika Królestwa Polskiego gen. Józefa Zajączka z dn. 16 stycznia 1816 r. (Dziennik Praw, T. 1, s. 115)" ;
+                                  ontohgis:hasScope "terytorium Królestwa Polskiego" ;
                                   ontohgis:individualHasExternalIdentifier 43 ;
                                   ontohgis:startsDominationAt "1815-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_5 ;
                                   rdfs:label "Kingdom of Poland (1815-1837)"@en ,
                                              "Królestwo Polskie (1815-1836)"@pl ;
                                   rdfs:seeAlso ontohgis:document_164 ,
@@ -16205,14 +13217,14 @@ ontohgis:administrative_system_43 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_44
 ontohgis:administrative_system_44 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_3 ;
                                   ontohgis:endsDominationAt "1568-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1370-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1568-12-31"^^xsd:date ;
-                                  ontohgis:hasLegalBasis "reformy ustrojowe XIV w.; statuty wiślicko-piotrowskie (1356-1362 r.)"^^xsd:string ;
-                                  ontohgis:hasScope "terytorium Królestwa Polskiego"^^xsd:string ;
+                                  ontohgis:hasLegalBasis "reformy ustrojowe XIV w.; statuty wiślicko-piotrowskie (1356-1362 r.)" ;
+                                  ontohgis:hasScope "terytorium Królestwa Polskiego" ;
                                   ontohgis:individualHasExternalIdentifier 44 ;
                                   ontohgis:startsDominationAt "1370-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_3 ;
                                   rdfs:label "Królestwo Polskie (1370-1568)"@pl ,
                                              "The Kingdom of Poland (1370-1568)"@en ;
                                   rdfs:seeAlso ontohgis:document_157 ,
@@ -16228,13 +13240,13 @@ ontohgis:administrative_system_44 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_45
 ontohgis:administrative_system_45 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_9 ;
                                   ontohgis:endsDominationAt "1701-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1525-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1701-12-31"^^xsd:date ;
-                                  ontohgis:hasScope "terytorium Prus Książęcych"^^xsd:string ;
+                                  ontohgis:hasScope "terytorium Prus Książęcych" ;
                                   ontohgis:individualHasExternalIdentifier 45 ;
                                   ontohgis:startsDominationAt "1525-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_9 ;
                                   rdfs:comment "Plemiona pruskie nie wytworzyły państwowości i administracji terytorialnej przed XIII w.: W. Długokęcki, Prusy w starożytności i we wczesnym średniowieczu, [w:] M. Biskup, i in., Państwo zakonu krzyżackiego w Prusach. Władza i społeczeństwo, Warszawa 2008, s. 38-39, 43: \"Mniejsza niż plemię jednostka terytorialna nosiła nazwę territorium (Dusburg), a także terrula, districtus. W literaturze określa się ją też jako włość, mała ziemia lub używa pruskiej nazwy pulka. [...] Podstawową jednostkę osadniczą stanowiło pole (prus. lauks, łac. campus, niem. Feld). Tworzyło ono topograficzno-gospodarczą całość, bez wytyczonych granic linearnych [...] Obraz ustroju politycznego Estów i Prusów przekazany przez źródła IX-XIII w. wyraźnie wskazuje na rozdrobnienie polityczne i brak silnych ośrodków władzy publicznej. Zasadnicze znaczenie miały wiece różnych struktur terytorialnych (prus. wayde, waite). W XIII w. funkcjonowały wiece międzyplemienne, plemienne i na poziomie małej ziemi. Wzmianki o wiecach z XIII w. dotyczą przede wszystkim wieców wojennych [...]\". R. Czaja, i in. [w:] ibidem, s. 75-76: \"Przywilej chełmiński, będący formalnie dokumentem lokacyjnym Chełmna i Torunia, w rzeczywistości pełnił funkcję przywileju \"krajowego\". Niektóre bowiem przepisy w nim zawarte dotyczyły także rycerzy (np. te, które odnosiły się do statusu prawnego dóbr obciążonych służbą wojskową), postanowienia zaś odnoszące się do monety, wymiaru łana, zwolnień celnych, wolnego targu obejmowały wszystkich mieszkańców ziemi chełmińskiej. Prawo chełmińskie służyło wyodrębnieniu z władztwa księcia Konrada obszaru poddanego kontroli Zakonu: tam, gdzie były stosowane postanowienia przywileju, sięgała władza Krzyżaków\". 1309 - zajęcie Pomorza Gdańskiego, przeniesienie siedziby wielkiego mistrza zakonnego do Malborka (mimo że nie było jeszcze wtedy jasne czy Malbork zostanie stolicą państwa). 1466 - inkorporacja ziem pruskich do Korony przez króla Kazimierz Jagiellończyka doprowadziła do wybuchu wojny trzynastoletniej, na zakończenie której (pokojem toruńskim w 1466) Krzyżacy - korzystając z mediacji legata papieskiego - doprowadzili do swoistego kompromisu, w wyniku którego: Prusy Królewskie podlegały Koronie, Warmia stanowiła część Prus Królewskich, ale z dużą autonomią, Prusy zakonne stały się lennem Korony, nad którym władzę zwierzchnią sprawował Zakon."@pl ;
                                   rdfs:label "Prusy Książęce (1525-1701)"@pl ,
                                              "The Duchy of Prussia (1525-1701)"@en ;
@@ -16259,8 +13271,8 @@ ontohgis:administrative_system_46 rdf:type owl:NamedIndividual ,
                                   ontohgis:endsDominationAt "1939-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1632-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1939-12-31"^^xsd:date ;
-                                  ontohgis:hasLegalBasis "1632, unia kościoła ormiańskiego z Rzymem"^^xsd:string ;
-                                  ontohgis:hasScope "terytorium Polski, zwłaszcza wschodniej"^^xsd:string ;
+                                  ontohgis:hasLegalBasis "1632, unia kościoła ormiańskiego z Rzymem" ;
+                                  ontohgis:hasScope "terytorium Polski, zwłaszcza wschodniej" ;
                                   ontohgis:individualHasExternalIdentifier 46 ;
                                   ontohgis:startsDominationAt "1632-01-01"^^xsd:date ;
                                   rdfs:label "Kościół katolicki ob. ormiańskiego"@pl .
@@ -16269,14 +13281,14 @@ ontohgis:administrative_system_46 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_47
 ontohgis:administrative_system_47 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_5 ;
                                   ontohgis:endsDominationAt "1918-12-31"^^xsd:date ;
                                   ontohgis:hasBeginning "1867-01-01"^^xsd:date ;
                                   ontohgis:hasEnd "1918-12-31"^^xsd:date ;
-                                  ontohgis:hasLegalBasis "Ukaz carski z 13.01.1867 (Dziennik Praw Królestwa Polskiego), nr 66, Warszawa 1866, s. 115-243."^^xsd:string ;
-                                  ontohgis:hasScope "terytorium Królestwa Polskiego"^^xsd:string ;
+                                  ontohgis:hasLegalBasis "Ukaz carski z 13.01.1867 (Dziennik Praw Królestwa Polskiego), nr 66, Warszawa 1866, s. 115-243." ;
+                                  ontohgis:hasScope "terytorium Królestwa Polskiego" ;
                                   ontohgis:individualHasExternalIdentifier 47 ;
                                   ontohgis:startsDominationAt "1867-01-01"^^xsd:date ;
-                                  dct:creator ontohgis:person_5 ;
                                   rdfs:label "Congress Poland (1867-1918)"@en ,
                                              "Królestwo Polskie (1867-1918)"@pl ;
                                   rdfs:seeAlso ontohgis:document_164 ,
@@ -16288,10 +13300,10 @@ ontohgis:administrative_system_47 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_48
 ontohgis:administrative_system_48 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
-                                  ontohgis:hasBeginning "1996-01-01"^^xsd:date ;
-                                  ontohgis:hasScope "terytorium Słowacji"^^xsd:string ;
-                                  ontohgis:individualHasExternalIdentifier 48 ;
                                   dct:creator ontohgis:person_6 ;
+                                  ontohgis:hasBeginning "1996-01-01"^^xsd:date ;
+                                  ontohgis:hasScope "terytorium Słowacji" ;
+                                  ontohgis:individualHasExternalIdentifier 48 ;
                                   rdfs:label "Republika Słowacka (1996-2020)"@pl ,
                                              "Slovak Republic (1996-2020)"@en ,
                                              "Slovenská republika (1996-2020)"@sk ;
@@ -16305,13 +13317,13 @@ ontohgis:administrative_system_48 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_49
 ontohgis:administrative_system_49 rdf:type owl:NamedIndividual ,
                                            ontohgis:object_21 ;
+                                  dct:creator ontohgis:person_6 ;
                                   ontohgis:endsDominationAt "1806-08-06"^^xsd:date ;
                                   ontohgis:hasBeginning "0800-12-25"^^xsd:date ;
                                   ontohgis:hasEnd "1806-08-06"^^xsd:date ;
                                   ontohgis:hasScope "terytorium wielokrotnie zmieniało swój zasięg, obejmowało głównie kraje Europy Środkowej i Wschodniej, w przeważającej części zamieszkiwane przez ludność posługującą się językiem niemieckim"@pl ;
                                   ontohgis:individualHasExternalIdentifier 49 ;
                                   ontohgis:startsDominationAt "0962-02-02"^^xsd:date ;
-                                  dct:creator ontohgis:person_6 ;
                                   rdfs:label "Holy Roman Empire (962-1806)"@en ,
                                              "Święte Cesarstwo Rzymskie (962-1806)"@pl ;
                                   rdfs:seeAlso <https://www.wikidata.org/wiki/Q12548> .
@@ -16320,13 +13332,13 @@ ontohgis:administrative_system_49 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_5
 ontohgis:administrative_system_5 rdf:type owl:NamedIndividual ,
                                           ontohgis:object_21 ;
+                                 dct:creator ontohgis:person_11 ;
                                  ontohgis:endsDominationAt "1939-12-31"^^xsd:date ;
                                  ontohgis:hasBeginning "1920-01-01"^^xsd:date ;
                                  ontohgis:hasEnd "1939-12-31"^^xsd:date ;
-                                 ontohgis:hasScope "terytorium Wolnego Miasta Gdańska"^^xsd:string ;
+                                 ontohgis:hasScope "terytorium Wolnego Miasta Gdańska" ;
                                  ontohgis:individualHasExternalIdentifier 5 ;
                                  ontohgis:startsDominationAt "1920-01-01"^^xsd:date ;
-                                 dct:creator ontohgis:person_11 ;
                                  rdfs:label "The Free City of Danzig (1920-1939)"@en ,
                                             "Wolne Miasto Gdańsk (1920-1939)"@pl ;
                                  rdfs:seeAlso ontohgis:document_85 ,
@@ -16355,13 +13367,13 @@ ontohgis:administrative_system_50 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_6
 ontohgis:administrative_system_6 rdf:type owl:NamedIndividual ,
                                           ontohgis:object_21 ;
+                                 dct:creator ontohgis:person_4 ;
                                  ontohgis:endsDominationAt "1945-12-31"^^xsd:date ;
                                  ontohgis:hasBeginning "1919-01-01"^^xsd:date ;
                                  ontohgis:hasEnd "1945-12-31"^^xsd:date ;
-                                 ontohgis:hasScope "terytorium Wolnego Państwa Saksonia, obejmuje część Łużyc leżących obecnie w Polsce (Bogatynia)"^^xsd:string ;
+                                 ontohgis:hasScope "terytorium Wolnego Państwa Saksonia, obejmuje część Łużyc leżących obecnie w Polsce (Bogatynia)" ;
                                  ontohgis:individualHasExternalIdentifier 6 ;
                                  ontohgis:startsDominationAt "1919-01-01"^^xsd:date ;
-                                 dct:creator ontohgis:person_4 ;
                                  rdfs:comment """1920-1933 Wolne Państwo Saksonia jako państwo członkowskie Republiki Związkowej.
 1933-1945  Wolne Państwo Saksonia jako państwo członkowskie III Rzeszy."""@pl ;
                                  rdfs:label "Freistaat Sachsen (1919-1945)"@de ,
@@ -16373,15 +13385,15 @@ ontohgis:administrative_system_6 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_7
 ontohgis:administrative_system_7 rdf:type owl:NamedIndividual ,
                                           ontohgis:object_21 ;
+                                 dct:creator ontohgis:person_11 ;
                                  <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ontohgis:administrative_system_49 ;
                                  ontohgis:endsDominationAt "1945-12-31"^^xsd:date ;
                                  ontohgis:hasBeginning "1806-01-01"^^xsd:date ;
                                  ontohgis:hasEnd "1919-12-31"^^xsd:date ;
-                                 ontohgis:hasLegalBasis "Verordnung wegen verbesserter Einrichtung der Provinzial- Polizei- und Finanzbehörden vom 26. Dezember 1808 (GS S. 481); Städteordnung 1808, 1831, 1853; Verordnung wegen verbesserter Einrichtung der Provinzial-Behörden vom 30. April 1815 (GS S. 85); Gesetz über Verpflichtung zur Armenpflege vom 31. Dez. 1842; Kreisordnung für die östlichen 6 Provinzen vom 13. Dez. 1872."^^xsd:string ;
-                                 ontohgis:hasScope "terytorium Królestwa Prus, obejmuje obecne ziemie zachodniej i północnej Polski"^^xsd:string ;
+                                 ontohgis:hasLegalBasis "Verordnung wegen verbesserter Einrichtung der Provinzial- Polizei- und Finanzbehörden vom 26. Dezember 1808 (GS S. 481); Städteordnung 1808, 1831, 1853; Verordnung wegen verbesserter Einrichtung der Provinzial-Behörden vom 30. April 1815 (GS S. 85); Gesetz über Verpflichtung zur Armenpflege vom 31. Dez. 1842; Kreisordnung für die östlichen 6 Provinzen vom 13. Dez. 1872." ;
+                                 ontohgis:hasScope "terytorium Królestwa Prus, obejmuje obecne ziemie zachodniej i północnej Polski" ;
                                  ontohgis:individualHasExternalIdentifier 7 ;
                                  ontohgis:startsDominationAt "1815-01-01"^^xsd:date ;
-                                 dct:creator ontohgis:person_11 ;
                                  rdfs:comment """\"Verordnung wegen verbesserter Einrichtung der Provinzial- Polizei- und Finanzbehörden vom 26. Dezember 1808 (GS S. 481).
 Städteordnung 1808, 1831, 1853.
 Verordnung wegen verbesserter Einrichtung der Provinzial-Behörden vom 30. April 1815 (GS S. 85).
@@ -16401,14 +13413,14 @@ Kreisordnung für die östlichen 6 Provinzen vom 13. Dez. 1872.\""""@de ;
 ###  https://onto.kul.pl/ontohgis/administrative_system_8
 ontohgis:administrative_system_8 rdf:type owl:NamedIndividual ,
                                           ontohgis:object_21 ;
+                                 dct:creator ontohgis:person_6 ;
                                  ontohgis:endsDominationAt "1917-12-31"^^xsd:date ;
                                  ontohgis:hasBeginning "1775-01-01"^^xsd:date ;
                                  ontohgis:hasEnd "1917-12-31"^^xsd:date ;
-                                 ontohgis:hasLegalBasis "Dekret Piotra I z dnia 18 grudnia 1708 r.; ukaz Piotra I z dnia 29 maja 1719 r.; dekret Katarzyny II z 7 listopada 1775 r.; dekret Pawa I z 12 grudnia 1796 r.; 1861: reforma uwłaszczeniowa i wprowadzenie gmin"^^xsd:string ;
-                                 ontohgis:hasScope "terytorium Cesarstwa Rosyjskiego, obejmuje część obecnego Podlasia (Białowieża)"^^xsd:string ;
+                                 ontohgis:hasLegalBasis "Dekret Piotra I z dnia 18 grudnia 1708 r.; ukaz Piotra I z dnia 29 maja 1719 r.; dekret Katarzyny II z 7 listopada 1775 r.; dekret Pawa I z 12 grudnia 1796 r.; 1861: reforma uwłaszczeniowa i wprowadzenie gmin" ;
+                                 ontohgis:hasScope "terytorium Cesarstwa Rosyjskiego, obejmuje część obecnego Podlasia (Białowieża)" ;
                                  ontohgis:individualHasExternalIdentifier 8 ;
                                  ontohgis:startsDominationAt "1796-01-01"^^xsd:date ;
-                                 dct:creator ontohgis:person_6 ;
                                  rdfs:comment "Dekret Piotra I z dnia 18 grudnia 1708 r.; ukaz Piotra I z dnia 29 maja 1719 r.; dekret Katarzyny II z 7 listopada 1775 r.; dekret Pawa I z 12 grudnia 1796 r.; 1861: reforma uwłaszczeniowa i wprowadzenie gmin"@pl ,
                                               "The foundation of the administrative divisions were established by Peter the Great's  decree on 18th od December 1708. First, the governorates (gubernjas) were not divided into districts (uyezds). in 1710-1713 they were divided into dolas ( Ru. доля, Ger. Landratsamt). Another reform, so called the second reform of Peter the Great, following a decree of 29th of May 1719, waived the dolas, while the governorates were divided into provinces and consequently districts. In 1727, the districts were abolished, while governorates and provinces were divided into districts (uyezds). On the 7th of November 1775, Catherine the Great decreed an administrative division reform dividing the state into governorates-vicegerencies-circles operating as governorates. The units were divided into districts (uyezds). Some vast governorates were divided into circes (oblasti), which comprised an intermediary level between a vicegerency and district. The decree by Pawel I Romanov, on 12th of December 1796 abolished vicegerencies."@en ,
                                               "Zasadniczy system podziału na gubernie został zapoczątkowany dekretem Piotra I z 18 grudnia 1708 r. W pierwszym okresie gubernie nie dzieliły się na powiaty (ujezdy). W latach 1710-1713 zostały podzielone na dole landrackie (доля). Kolejna reforma, tzw. druga reforma Piotra I, na podstawie ukazu z 29 maja 1719 roku, zniosła dole landrackie, gubernie zostały podzielone na prowincje, zaś prowincje na dystrykty. W 1727 roku zostały zniesione dystrykty, a gubernie i prowincje podzielone na powiaty (ujezdy). 7 listopada 1775 r. Katarzyna II wydała dekret o reformie administracyjnej państwa wprowadzając system podziału na gubernie-namiestnictwa-obwody na prawach guberni. W ramach tych jednostek funkcjonowały powiaty (ujezdy). Niektóre rozległe namiestnictwa dzielone były na zwykłe obwody (obłasti), które tworzyły szczebel pośredni między namiestnictwem (lub gubernią) i powiatem (ujezdem). Ukaz Pawła I z 12 grudnia 1796 r. zamienił namiestnictwa, pozostawiając gubernie i obwody na prawach guberni."@pl ;
@@ -16428,13 +13440,13 @@ ontohgis:administrative_system_8 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/administrative_system_9
 ontohgis:administrative_system_9 rdf:type owl:NamedIndividual ,
                                           ontohgis:object_21 ;
+                                 dct:creator ontohgis:person_9 ;
                                  ontohgis:endsDominationAt "1918-12-31"^^xsd:date ;
                                  ontohgis:hasBeginning "1849-01-01"^^xsd:date ;
                                  ontohgis:hasEnd "1918-12-31"^^xsd:date ;
-                                 ontohgis:hasScope "terytorium kraju koronnego Śląsk Austriacki, obejmuje obecną ziemię cieszyńską"^^xsd:string ;
+                                 ontohgis:hasScope "terytorium kraju koronnego Śląsk Austriacki, obejmuje obecną ziemię cieszyńską" ;
                                  ontohgis:individualHasExternalIdentifier 9 ;
                                  ontohgis:startsDominationAt "1849-01-01"^^xsd:date ;
-                                 dct:creator ontohgis:person_9 ;
                                  rdfs:label "Księstwo Górnego i Dolnego Śląska (1849-1918)"@pl ,
                                             "The Duchy of Upper and Lower Silesia (1849-1918)"@en ;
                                  rdfs:seeAlso ontohgis:document_172 ,
@@ -16494,8 +13506,8 @@ ontohgis:document_102 rdf:type owl:NamedIndividual ,
 ontohgis:document_103 rdf:type owl:NamedIndividual ,
                                <http://www.cidoc-crm.org/cidoc-crm/E31_Document> ;
                       dc:creator "Sitarz, M." ;
-                      dc:date "1973-2014" ,
-                              "Encyklopedia katolicka, t. 14, Lublin 1973-2014, s. 1324–1326"@pl ;
+                      dc:date "Encyklopedia katolicka, t. 14, Lublin 1973-2014, s. 1324–1326"@pl ,
+                              "1973-2014" ;
                       dc:title "Parafia"@pl ;
                       rdfs:label "Sitarz, Parafia"@pl .
 
@@ -16559,7 +13571,7 @@ ontohgis:document_109 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/document_11
 ontohgis:document_11 rdf:type owl:NamedIndividual ,
                               <http://www.cidoc-crm.org/cidoc-crm/E31_Document> ;
-                     <http://purl.org/dc/terms/date> "1962-1970"@pl ;
+                     dct:date "1962-1970"@pl ;
                      rdfs:label "Wielka encyklopedia powszechna PWN"@pl .
 
 
@@ -16664,16 +13676,16 @@ ontohgis:document_119 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/document_12
 ontohgis:document_12 rdf:type owl:NamedIndividual ,
                               <http://www.cidoc-crm.org/cidoc-crm/E31_Document> ;
-                     <http://purl.org/dc/terms/creator> "Irsigler, Franz" ;
-                     <http://purl.org/dc/terms/date> 2001 ;
-                     <http://purl.org/dc/terms/identifier> "Goslar und die Stadtgeschichte. Forschungen und Perspektiven 1399–1999, hg. v. Carl-Hans Hauptmeyer/Jürgen Rund, Bielefeld 2001, s. 57–74"@de ;
-                     <http://purl.org/dc/terms/title> "Die Stadt im Mittelalter. Aktuelle Forschungstendenzen"@de ;
+                     dct:creator "Irsigler, Franz" ;
+                     dct:date 2001 ;
+                     dct:identifier "Goslar und die Stadtgeschichte. Forschungen und Perspektiven 1399–1999, hg. v. Carl-Hans Hauptmeyer/Jürgen Rund, Bielefeld 2001, s. 57–74"@de ;
+                     dct:title "Die Stadt im Mittelalter. Aktuelle Forschungstendenzen"@de ;
                      rdfs:label "Irsigler, Die Stadt im Mittelalter"@pl ;
                      <http://www.w3.org/2004/02/skos/core#prefLabel> "Irsigler, Franz: Die Stadt im Mittelalter"@de .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:document_12 ;
-   owl:annotatedProperty <http://purl.org/dc/terms/identifier> ;
+   owl:annotatedProperty dct:identifier ;
    owl:annotatedTarget "Goslar und die Stadtgeschichte. Forschungen und Perspektiven 1399–1999, hg. v. Carl-Hans Hauptmeyer/Jürgen Rund, Bielefeld 2001, s. 57–74"@de ;
    rdfs:isDefinedBy <http://www.uni-muenster.de/Staedtegeschichte/portal/einfuehrung/Definitionen.html>
  ] .
@@ -16779,9 +13791,9 @@ ontohgis:document_129 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/document_13
 ontohgis:document_13 rdf:type owl:NamedIndividual ,
                               <http://www.cidoc-crm.org/cidoc-crm/E31_Document> ;
-                     <http://purl.org/dc/terms/creator> "Marciniak-Kajzer, Anna" ;
-                     <http://purl.org/dc/terms/date> 2011 ;
-                     <http://purl.org/dc/terms/title> "Średniowieczny dwór rycerski w Polsce"@pl ;
+                     dct:creator "Marciniak-Kajzer, Anna" ;
+                     dct:date 2011 ;
+                     dct:title "Średniowieczny dwór rycerski w Polsce"@pl ;
                      rdfs:label "Marciniak-Kajzer, Średniowieczny dwór rycerski w Polsce"@pl .
 
 
@@ -17549,8 +14561,8 @@ ontohgis:document_4 rdf:type owl:NamedIndividual ,
                              <http://www.cidoc-crm.org/cidoc-crm/E31_Document> ;
                     dct:creator ontohgis:person_20 ;
                     dc:title "Słownik języka polskiego"@pl ;
-                    <http://purl.org/dc/terms/date> "1958–1969" ;
-                    <http://purl.org/dc/terms/identifier> <http://doroszewski.pwn.pl/> ;
+                    dct:date "1958–1969" ;
+                    dct:identifier <http://doroszewski.pwn.pl/> ;
                     rdfs:label "Słownik języka polskiego (Doroszewski)"@pl .
 
 
@@ -17653,10 +14665,10 @@ ontohgis:document_49 rdf:type owl:NamedIndividual ,
 ontohgis:document_5 rdf:type owl:NamedIndividual ,
                              <http://www.cidoc-crm.org/cidoc-crm/E31_Document> ;
                     dc:title "Słownik języka  polskiego"@pl ;
-                    <http://purl.org/dc/terms/creator> "Karłowicz, Jan" ,
-                                                       "Kryński, Adam" ,
-                                                       "Niedźwiedzki, Władysław" ;
-                    <http://purl.org/dc/terms/date> "1900-1927" ;
+                    dct:creator "Karłowicz, Jan" ,
+                                "Kryński, Adam" ,
+                                "Niedźwiedzki, Władysław" ;
+                    dct:date "1900-1927" ;
                     rdfs:label "Słownik  warszawski"@pl ;
                     rdfs:seeAlso <http://ebuw.uw.edu.pl/publication/254> .
 
@@ -17760,7 +14772,7 @@ ontohgis:document_59 rdf:type owl:NamedIndividual ,
 ontohgis:document_6 rdf:type owl:NamedIndividual ,
                              <http://www.cidoc-crm.org/cidoc-crm/E31_Document> ;
                     dc:creator "Urbańczyk, Stanisław" ;
-                    <http://purl.org/dc/terms/date> "1953–2002" ;
+                    dct:date "1953–2002" ;
                     rdfs:label "Słownik staropolski"@pl ;
                     rdfs:seeAlso <https://pjs.ijp.pan.pl/sstp.html> .
 
@@ -17856,7 +14868,7 @@ ontohgis:document_69 rdf:type owl:NamedIndividual ,
 ontohgis:document_7 rdf:type owl:NamedIndividual ,
                              <http://www.cidoc-crm.org/cidoc-crm/E31_Document> ;
                     dc:title "Encyklopedia Katolicka"@pl ;
-                    <http://purl.org/dc/terms/date> "1973-2014" ;
+                    dct:date "1973-2014" ;
                     rdfs:label "Encyklopedia Katolicka"@pl ;
                     rdfs:seeAlso <http://www.kul.pl/encyklopedia-katolicka,art_9929.html> .
 
@@ -17960,9 +14972,9 @@ ontohgis:document_79 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/document_8
 ontohgis:document_8 rdf:type owl:NamedIndividual ,
                              <http://www.cidoc-crm.org/cidoc-crm/E31_Document> ;
-                    <http://purl.org/dc/terms/creator> "Tkocz, Jan" ;
-                    <http://purl.org/dc/terms/date> "1998"@pl ;
-                    <http://purl.org/dc/terms/title> "Organizacja przestrzenna wsi w Polsce"@pl ;
+                    dct:creator "Tkocz, Jan" ;
+                    dct:date "1998"@pl ;
+                    dct:title "Organizacja przestrzenna wsi w Polsce"@pl ;
                     rdfs:label "Tkocz, Organizacja przestrzenna wsi"@pl .
 
 
@@ -18075,9 +15087,9 @@ ontohgis:document_89 rdf:type owl:NamedIndividual ,
 ###  https://onto.kul.pl/ontohgis/document_9
 ontohgis:document_9 rdf:type owl:NamedIndividual ,
                              <http://www.cidoc-crm.org/cidoc-crm/E31_Document> ;
-                    <http://purl.org/dc/terms/creator> "Minister Spraw Wewnętrznych i Administracji"@pl ;
-                    <http://purl.org/dc/terms/date> 2011 ;
-                    <http://purl.org/dc/terms/title> "Rozporządzenie Ministra Spraw Wewnętrznych i Administracji z dnia 17 listopada 2011 r. w sprawie bazy danych obiektów topograficznych oraz bazy danych obiektów ogólnogeograficznych, a także standardowych opracowań kartograficznych"@pl ;
+                    dct:creator "Minister Spraw Wewnętrznych i Administracji"@pl ;
+                    dct:date 2011 ;
+                    dct:title "Rozporządzenie Ministra Spraw Wewnętrznych i Administracji z dnia 17 listopada 2011 r. w sprawie bazy danych obiektów topograficznych oraz bazy danych obiektów ogólnogeograficznych, a także standardowych opracowań kartograficznych"@pl ;
                     rdfs:label "Rozporządzenie BDOT10k"@pl ;
                     rdfs:seeAlso <http://prawo.sejm.gov.pl/isap.nsf/DocDetails.xsp?id=WDU20112791642> .
 
@@ -18701,403 +15713,3939 @@ ontohgis:person_9 rdf:type owl:NamedIndividual ,
                   foaf:mbox "wieslawa.duzy@gmail.com" .
 
 
+###  https://onto.kul.pl/ontohgis/settlement_type_1
+ontohgis:settlement_type_1 rdf:type owl:NamedIndividual ;
+                           dct:creator ontohgis:person_2 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_10
+ontohgis:settlement_type_10 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_4 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_100
+ontohgis:settlement_type_100 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_6 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_103
+ontohgis:settlement_type_103 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_6 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_106
+ontohgis:settlement_type_106 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_3 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_11
+ontohgis:settlement_type_11 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_4 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_110
+ontohgis:settlement_type_110 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_3 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_112
+ontohgis:settlement_type_112 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_113
+ontohgis:settlement_type_113 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_2 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_114
+ontohgis:settlement_type_114 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_2 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_115
+ontohgis:settlement_type_115 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_5 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_117
+ontohgis:settlement_type_117 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_5 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_118
+ontohgis:settlement_type_118 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_5 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_119
+ontohgis:settlement_type_119 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_5 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_12
+ontohgis:settlement_type_12 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_4 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_120
+ontohgis:settlement_type_120 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_6 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_121
+ontohgis:settlement_type_121 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_6 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_122
+ontohgis:settlement_type_122 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_6 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_123
+ontohgis:settlement_type_123 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_6 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_124
+ontohgis:settlement_type_124 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_3 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_125
+ontohgis:settlement_type_125 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_3 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_126
+ontohgis:settlement_type_126 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_3 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_127
+ontohgis:settlement_type_127 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_3 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_128
+ontohgis:settlement_type_128 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_3 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_129
+ontohgis:settlement_type_129 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_5 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_130
+ontohgis:settlement_type_130 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_5 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_131
+ontohgis:settlement_type_131 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_5 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_132
+ontohgis:settlement_type_132 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_6 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_133
+ontohgis:settlement_type_133 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_6 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_134
+ontohgis:settlement_type_134 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_6 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_135
+ontohgis:settlement_type_135 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_4 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_136
+ontohgis:settlement_type_136 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_4 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_137
+ontohgis:settlement_type_137 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_4 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_138
+ontohgis:settlement_type_138 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_4 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_139
+ontohgis:settlement_type_139 rdf:type owl:NamedIndividual ;
+                             dct:creator ontohgis:person_6 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_17
+ontohgis:settlement_type_17 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_5 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_18
+ontohgis:settlement_type_18 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_4 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_19
+ontohgis:settlement_type_19 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_6 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_2
+ontohgis:settlement_type_2 rdf:type owl:NamedIndividual ;
+                           dct:creator ontohgis:person_3 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_20
+ontohgis:settlement_type_20 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_7 ,
+                                        ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_21
+ontohgis:settlement_type_21 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_4 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_23
+ontohgis:settlement_type_23 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_5 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_25
+ontohgis:settlement_type_25 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_5 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_27
+ontohgis:settlement_type_27 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_5 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_28
+ontohgis:settlement_type_28 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_2 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_3
+ontohgis:settlement_type_3 rdf:type owl:NamedIndividual ;
+                           dct:creator ontohgis:person_2 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_33
+ontohgis:settlement_type_33 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_7 ,
+                                        ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_34
+ontohgis:settlement_type_34 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_7 ,
+                                        ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_35
+ontohgis:settlement_type_35 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_7 ,
+                                        ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_36
+ontohgis:settlement_type_36 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_5 ,
+                                        ontohgis:person_7 ,
+                                        ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_37
+ontohgis:settlement_type_37 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_2 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_38
+ontohgis:settlement_type_38 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_7 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_41
+ontohgis:settlement_type_41 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_6 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_43
+ontohgis:settlement_type_43 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_2 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_44
+ontohgis:settlement_type_44 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_3 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_45
+ontohgis:settlement_type_45 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_5 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_47
+ontohgis:settlement_type_47 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_6 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_48
+ontohgis:settlement_type_48 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_5 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_50
+ontohgis:settlement_type_50 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_6 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_51
+ontohgis:settlement_type_51 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_6 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_52
+ontohgis:settlement_type_52 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_2 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_53
+ontohgis:settlement_type_53 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_5 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_54
+ontohgis:settlement_type_54 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_6 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_56
+ontohgis:settlement_type_56 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_3 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_60
+ontohgis:settlement_type_60 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_7 ,
+                                        ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_61
+ontohgis:settlement_type_61 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_7 ,
+                                        ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_62
+ontohgis:settlement_type_62 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_7 ,
+                                        ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_63
+ontohgis:settlement_type_63 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_7 ,
+                                        ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_64
+ontohgis:settlement_type_64 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_7 ,
+                                        ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_65
+ontohgis:settlement_type_65 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_7 ,
+                                        ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_66
+ontohgis:settlement_type_66 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_7 ,
+                                        ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_68
+ontohgis:settlement_type_68 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_7 ,
+                                        ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_69
+ontohgis:settlement_type_69 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_7 ,
+                                        ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_7
+ontohgis:settlement_type_7 rdf:type owl:NamedIndividual ;
+                           dct:creator ontohgis:person_3 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_70
+ontohgis:settlement_type_70 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_7 ,
+                                        ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_71
+ontohgis:settlement_type_71 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_7 ,
+                                        ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_72
+ontohgis:settlement_type_72 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_7 ,
+                                        ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_73
+ontohgis:settlement_type_73 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_74
+ontohgis:settlement_type_74 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_75
+ontohgis:settlement_type_75 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_8 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_76
+ontohgis:settlement_type_76 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_5 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_8
+ontohgis:settlement_type_8 rdf:type owl:NamedIndividual ;
+                           dct:creator ontohgis:person_3 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_80
+ontohgis:settlement_type_80 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_3 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_82
+ontohgis:settlement_type_82 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_5 .
+
+
+###  https://onto.kul.pl/ontohgis/settlement_type_99
+ontohgis:settlement_type_99 rdf:type owl:NamedIndividual ;
+                            dct:creator ontohgis:person_3 .
+
+
 #################################################################
 #    Annotations
 #################################################################
 
-dc: <http://purl.org/dc/terms/publisher> <http://purl.org/dc/aboutdcmi#DCMI> ;
-    <http://purl.org/dc/terms/title> "Dublin Core Metadata Element Set, Version 1.1"@en ;
-    <http://purl.org/dc/terms/modified> "2012-06-14"^^xsd:date .
-
-
-<http://purl.org/dc/terms/Box> <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                               rdfs:comment "The set of regions in space defined by their geographic coordinates according to the DCMI Box Encoding Scheme."@en ;
-                               rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                               rdfs:seeAlso <http://dublincore.org/documents/dcmi-box/> ;
-                               <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                               rdfs:label "DCMI Box"@en ;
-                               <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#Box-003> .
-
-
-<http://purl.org/dc/terms/ISO3166> <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                   rdfs:comment "The set of codes listed in ISO 3166-1 for the representation of names of countries."@en ;
-                                   <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#ISO3166-004> ;
-                                   rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                   <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                   rdfs:label "ISO 3166"@en ;
-                                   rdfs:seeAlso <http://www.iso.org/iso/en/prods-services/iso3166ma/02iso-3166-code-lists/list-en1.html> .
-
-
-<http://purl.org/dc/terms/ISO639-2> rdfs:seeAlso <http://lcweb.loc.gov/standards/iso639-2/langhome.html> ;
-                                    <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                    <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                    rdfs:comment "The three-letter alphabetic codes listed in ISO639-2 for the representation of names of languages."@en ;
-                                    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                    rdfs:label "ISO 639-2"@en ;
-                                    <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#ISO639-2-003> .
-
-
-<http://purl.org/dc/terms/ISO639-3> rdfs:comment "The set of three-letter codes listed in ISO 639-3 for the representation of names of languages."@en ;
-                                    rdfs:label "ISO 639-3"@en ;
-                                    <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#ISO639-3-001> ;
-                                    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                    <http://purl.org/dc/terms/issued> "2008-01-14"^^xsd:date ;
-                                    rdfs:seeAlso <http://www.sil.org/iso639-3/> .
-
-
-<http://purl.org/dc/terms/Period> rdfs:comment "The set of time intervals defined by their limits according to the DCMI Period Encoding Scheme."@en ;
-                                  <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                  rdfs:seeAlso <http://dublincore.org/documents/dcmi-period/> ;
-                                  <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                  rdfs:label "DCMI Period"@en ;
-                                  rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                  <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#Period-003> .
-
-
-<http://purl.org/dc/terms/Point> rdfs:comment "The set of points in space defined by their geographic coordinates according to the DCMI Point Encoding Scheme."@en ;
-                                 rdfs:label "DCMI Point"@en ;
-                                 <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                 <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                 <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#Point-003> ;
-                                 rdfs:seeAlso <http://dublincore.org/documents/dcmi-point/> ;
-                                 rdfs:isDefinedBy <http://purl.org/dc/terms/> .
-
-
-<http://purl.org/dc/terms/RFC1766> rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                   <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                   <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                   rdfs:seeAlso <http://www.ietf.org/rfc/rfc1766.txt> ;
-                                   rdfs:comment "The set of tags, constructed according to RFC 1766, for the identification of languages."@en ;
-                                   <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#RFC1766-003> ;
-                                   rdfs:label "RFC 1766"@en .
-
-
-<http://purl.org/dc/terms/RFC3066> <http://purl.org/dc/terms/issued> "2002-07-13"^^xsd:date ;
-                                   rdfs:label "RFC 3066"@en ;
-                                   rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                   <http://purl.org/dc/terms/description> "RFC 3066 has been obsoleted by RFC 4646."@en ;
-                                   rdfs:comment "The set of tags constructed according to RFC 3066 for the identification of languages."@en ;
-                                   <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                   rdfs:seeAlso <http://www.ietf.org/rfc/rfc3066.txt> ;
-                                   <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#RFC3066-002> .
-
-
-<http://purl.org/dc/terms/RFC4646> <http://purl.org/dc/terms/description> "RFC 4646 obsoletes RFC 3066."@en ;
-                                   <http://purl.org/dc/terms/issued> "2008-01-14"^^xsd:date ;
-                                   <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#RFC4646-001> ;
-                                   rdfs:seeAlso <http://www.ietf.org/rfc/rfc4646.txt> ;
-                                   rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                   rdfs:label "RFC 4646"@en ;
-                                   rdfs:comment "The set of tags constructed according to RFC 4646 for the identification of languages."@en .
-
-
-<http://purl.org/dc/terms/RFC5646> <http://purl.org/dc/terms/issued> "2010-10-11"^^xsd:date ;
-                                   rdfs:seeAlso <http://www.ietf.org/rfc/rfc5646.txt> ;
-                                   <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#RFC5646-001> ;
-                                   rdfs:comment "The set of tags constructed according to RFC 5646 for the identification of languages."@en ;
-                                   rdfs:label "RFC 5646"@en ;
-                                   <http://purl.org/dc/terms/description> "RFC 5646 obsoletes RFC 4646."@en ;
-                                   rdfs:isDefinedBy <http://purl.org/dc/terms/> .
-
-
-<http://purl.org/dc/terms/URI> rdfs:comment "The set of identifiers constructed according to the generic syntax for Uniform Resource Identifiers as specified by the Internet Engineering Task Force."@en ;
-                               rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                               <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                               rdfs:seeAlso <http://www.ietf.org/rfc/rfc3986.txt> ;
-                               <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#URI-003> ;
-                               rdfs:label "URI"@en ;
-                               <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date .
-
-
-<http://purl.org/dc/terms/W3CDTF> rdfs:label "W3C-DTF"@en ;
-                                  rdfs:comment "The set of dates and times constructed according to the W3C Date and Time Formats Specification."@en ;
-                                  <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#W3CDTF-003> ;
-                                  rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                  <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                  <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                  rdfs:seeAlso <http://www.w3.org/TR/NOTE-datetime> .
-
-
-<http://purl.org/dc/terms/abstract> rdfs:label "Abstract"@en ;
-                                    <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                    <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#abstract-003> ;
-                                    <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                    rdfs:comment "A summary of the resource."@en .
-
-
-<http://purl.org/dc/terms/alternative> rdfs:comment "An alternative name for the resource."@en ;
-                                       rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                       <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#alternative-003> ;
-                                       <http://purl.org/dc/terms/modified> "2010-10-11"^^xsd:date ;
-                                       <http://purl.org/dc/terms/description> "The distinction between titles and alternative titles is application-specific."@en ;
-                                       <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                       rdfs:label "Alternative Title"@en .
-
-
-<http://purl.org/dc/terms/available> rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                     rdfs:label "Date Available"@en ;
-                                     rdfs:comment "Date (often a range) that the resource became or will become available."@en ;
-                                     <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#available-003> ;
-                                     <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                     <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date .
-
-
-<http://purl.org/dc/terms/bibliographicCitation> <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                                 <http://purl.org/dc/terms/description> "Recommended practice is to include sufficient bibliographic detail to identify the resource as unambiguously as possible."@en ;
-                                                 rdfs:label "Bibliographic Citation"@en ;
-                                                 <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#bibliographicCitation-002> ;
-                                                 rdfs:comment "A bibliographic reference for the resource."@en ;
-                                                 rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                                 <http://purl.org/dc/terms/issued> "2003-02-15"^^xsd:date .
-
-
-<http://purl.org/dc/terms/contributor> <http://purl.org/dc/terms/modified> "2010-10-11"^^xsd:date ;
-                                       rdfs:comment "An entity responsible for making contributions to the resource."@en ;
-                                       rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                       <http://purl.org/dc/terms/description> "Examples of a Contributor include a person, an organization, or a service."@en ;
-                                       <http://purl.org/dc/terms/issued> "2008-01-14"^^xsd:date ;
-                                       <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#contributorT-001> ;
-                                       rdfs:label "Contributor"@en .
-
-
-<http://purl.org/dc/terms/created> rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                   rdfs:comment "Date of creation of the resource."@en ;
-                                   <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#created-003> ;
-                                   rdfs:label "Date Created"@en ;
-                                   <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                   <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date .
-
-
-<http://purl.org/dc/terms/creator> rdfs:comment "An entity primarily responsible for making the resource."@en ;
-                                   <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#creatorT-002> ;
-                                   rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                   <http://purl.org/dc/terms/modified> "2010-10-11"^^xsd:date ;
-                                   <http://purl.org/dc/terms/issued> "2008-01-14"^^xsd:date ;
-                                   rdfs:label "Creator"@en ;
-                                   <http://purl.org/dc/terms/description> "Examples of a Creator include a person, an organization, or a service."@en .
-
-
-<http://purl.org/dc/terms/date> rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                rdfs:comment "A point or period of time associated with an event in the lifecycle of the resource."@en ;
-                                <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#dateT-001> ;
-                                <http://purl.org/dc/terms/description> "Date may be used to express temporal information at any level of granularity.  Recommended best practice is to use an encoding scheme, such as the W3CDTF profile of ISO 8601 [W3CDTF]."@en ;
-                                rdfs:label "Date"@en ;
-                                <http://purl.org/dc/terms/issued> "2008-01-14"^^xsd:date ;
-                                <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date .
-
-
-<http://purl.org/dc/terms/dateAccepted> <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                        <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#dateAccepted-002> ;
-                                        <http://purl.org/dc/terms/issued> "2002-07-13"^^xsd:date ;
-                                        <http://purl.org/dc/terms/description> "Examples of resources to which a Date Accepted may be relevant are a thesis (accepted by a university department) or an article (accepted by a journal)."@en ;
-                                        rdfs:comment "Date of acceptance of the resource."@en ;
-                                        rdfs:label "Date Accepted"@en ;
-                                        rdfs:isDefinedBy <http://purl.org/dc/terms/> .
-
-
-<http://purl.org/dc/terms/dateCopyrighted> rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                           rdfs:label "Date Copyrighted"@en ;
-                                           rdfs:comment "Date of copyright."@en ;
-                                           <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                           <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#dateCopyrighted-002> ;
-                                           <http://purl.org/dc/terms/issued> "2002-07-13"^^xsd:date .
-
-
-<http://purl.org/dc/terms/dateSubmitted> <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                         rdfs:comment "Date of submission of the resource."@en ;
-                                         <http://purl.org/dc/terms/description> "Examples of resources to which a Date Submitted may be relevant are a thesis (submitted to a university department) or an article (submitted to a journal)."@en ;
-                                         <http://purl.org/dc/terms/issued> "2002-07-13"^^xsd:date ;
-                                         <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#dateSubmitted-002> ;
-                                         rdfs:label "Date Submitted"@en ;
-                                         rdfs:isDefinedBy <http://purl.org/dc/terms/> .
-
-
-<http://purl.org/dc/terms/description> <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                       rdfs:label "Description"@en ;
-                                       rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                       <http://purl.org/dc/terms/issued> "2008-01-14"^^xsd:date ;
-                                       rdfs:comment "An account of the resource."@en ;
-                                       <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#descriptionT-001> ;
-                                       <http://purl.org/dc/terms/description> "Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource."@en .
-
-
-<http://purl.org/dc/terms/hasFormat> <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en ;
-                                     rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                     <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#hasFormat-003> ;
-                                     <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                     rdfs:label "Has Format"@en ;
-                                     <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                     rdfs:comment "A related resource that is substantially the same as the pre-existing described resource, but in another format."@en .
-
-
-<http://purl.org/dc/terms/hasPart> rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                   <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en ;
-                                   <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                   rdfs:label "Has Part"@en ;
-                                   <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                   rdfs:comment "A related resource that is included either physically or logically in the described resource."@en ;
-                                   <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#hasPart-003> .
-
-
-<http://purl.org/dc/terms/hasVersion> <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#hasVersion-003> ;
-                                      rdfs:comment "A related resource that is a version, edition, or adaptation of the described resource."@en ;
-                                      rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                      <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en ;
-                                      rdfs:label "Has Version"@en ;
-                                      <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                      <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date .
-
-
-<http://purl.org/dc/terms/identifier> <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#identifierT-001> ;
-                                      rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                      <http://purl.org/dc/terms/description> "Recommended best practice is to identify the resource by means of a string conforming to a formal identification system. "@en ;
-                                      <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                      rdfs:comment "An unambiguous reference to the resource within a given context."@en ;
-                                      rdfs:label "Identifier"@en ;
-                                      <http://purl.org/dc/terms/issued> "2008-01-14"^^xsd:date .
-
-
-<http://purl.org/dc/terms/isFormatOf> <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#isFormatOf-003> ;
-                                      <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                      rdfs:comment "A related resource that is substantially the same as the described resource, but in another format."@en ;
-                                      <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                      <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en ;
-                                      rdfs:label "Is Format Of"@en ;
-                                      rdfs:isDefinedBy <http://purl.org/dc/terms/> .
-
-
-<http://purl.org/dc/terms/isPartOf> <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                    rdfs:label "Is Part Of"@en ;
-                                    <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#isPartOf-003> ;
-                                    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en ;
-                                    <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                    rdfs:comment "A related resource in which the described resource is physically or logically included."@en .
-
-
-<http://purl.org/dc/terms/isReferencedBy> rdfs:label "Is Referenced By"@en ;
-                                          rdfs:comment "A related resource that references, cites, or otherwise points to the described resource."@en ;
-                                          <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                          <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en ;
-                                          rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                          <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                          <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#isReferencedBy-003> .
-
-
-<http://purl.org/dc/terms/isReplacedBy> rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                        rdfs:label "Is Replaced By"@en ;
-                                        <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                        rdfs:comment "A related resource that supplants, displaces, or supersedes the described resource."@en ;
-                                        <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                        <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en ;
-                                        <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#isReplacedBy-003> .
-
-
-<http://purl.org/dc/terms/isRequiredBy> rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                        <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en ;
-                                        <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                        rdfs:label "Is Required By"@en ;
-                                        <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#isRequiredBy-003> ;
-                                        <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                        rdfs:comment "A related resource that requires the described resource to support its function, delivery, or coherence."@en .
-
-
-<http://purl.org/dc/terms/isVersionOf> rdfs:label "Is Version Of"@en ;
-                                       rdfs:comment "A related resource of which the described resource is a version, edition, or adaptation."@en ;
-                                       rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                       <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                       <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en ;
-                                       <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#isVersionOf-003> ;
-                                       <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                       <http://purl.org/dc/terms/description> "Changes in version imply substantive changes in content rather than differences in format."@en .
-
-
-<http://purl.org/dc/terms/issued> <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                  rdfs:comment "Date of formal issuance (e.g., publication) of the resource."@en ;
-                                  rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                  <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#issued-003> ;
-                                  <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                  rdfs:label "Date Issued"@en .
-
-
-<http://purl.org/dc/terms/modified> rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                    rdfs:label "Date Modified"@en ;
-                                    <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#modified-003> ;
-                                    <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                    rdfs:comment "Date on which the resource was changed."@en ;
-                                    <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date .
-
-
-<http://purl.org/dc/terms/references> rdfs:label "References"@en ;
-                                      rdfs:comment "A related resource that is referenced, cited, or otherwise pointed to by the described resource."@en ;
-                                      <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                      <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                      <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#references-003> ;
-                                      <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en ;
-                                      rdfs:isDefinedBy <http://purl.org/dc/terms/> .
-
-
-<http://purl.org/dc/terms/relation> <http://purl.org/dc/terms/issued> "2008-01-14"^^xsd:date ;
-                                    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en ;
-                                    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                    <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#relationT-001> ;
-                                    <http://purl.org/dc/terms/description> "Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system. "@en ;
-                                    rdfs:label "Relation"@en ;
-                                    rdfs:comment "A related resource."@en ;
-                                    <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date .
-
-
-<http://purl.org/dc/terms/replaces> <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en ;
-                                    <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                    <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                    rdfs:label "Replaces"@en ;
-                                    <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#replaces-003> ;
-                                    rdfs:comment "A related resource that is supplanted, displaced, or superseded by the described resource."@en ;
-                                    rdfs:isDefinedBy <http://purl.org/dc/terms/> .
-
-
-<http://purl.org/dc/terms/requires> <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#requires-003> ;
-                                    <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                    rdfs:label "Requires"@en ;
-                                    rdfs:comment "A related resource that is required by the described resource to support its function, delivery, or coherence."@en ;
-                                    rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                    <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en ;
-                                    <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date .
-
-
-<http://purl.org/dc/terms/source> rdfs:label "Source"@en ;
-                                  <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en ;
-                                  <http://purl.org/dc/terms/issued> "2008-01-14"^^xsd:date ;
-                                  rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                  <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                  <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#sourceT-001> ;
-                                  rdfs:comment "A related resource from which the described resource is derived."@en ;
-                                  <http://purl.org/dc/terms/description> "The described resource may be derived from the related resource in whole or in part. Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system."@en .
-
-
-<http://purl.org/dc/terms/tableOfContents> rdfs:comment "A list of subunits of the resource."@en ;
-                                           <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                           rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                           rdfs:label "Table Of Contents"@en ;
-                                           <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                           <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#tableOfContents-003> .
-
-
-<http://purl.org/dc/terms/title> rdfs:label "Title"@en ;
-                                 rdfs:comment "A name given to the resource."@en ;
-                                 <http://purl.org/dc/terms/issued> "2008-01-14"^^xsd:date ;
-                                 <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#titleT-002> ;
-                                 rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                 <http://purl.org/dc/terms/modified> "2010-10-11"^^xsd:date .
-
-
-<http://purl.org/dc/terms/valid> rdfs:comment "Date (often a range) of validity of a resource."@en ;
-                                 <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-                                 <http://purl.org/dc/terms/issued> "2000-07-11"^^xsd:date ;
-                                 rdfs:label "Date Valid"@en ;
-                                 rdfs:isDefinedBy <http://purl.org/dc/terms/> ;
-                                 <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#valid-003> .
-
-
-###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi
+dc: dct:modified "2012-06-14"^^xsd:date ;
+    dct:publisher <http://purl.org/dc/aboutdcmi#DCMI> ;
+    dct:title "Dublin Core Metadata Element Set, Version 1.1"@en .
+
+
+dct:Box dct:hasVersion <http://dublincore.org/usage/terms/history/#Box-003> ;
+        dct:issued "2000-07-11"^^xsd:date ;
+        dct:modified "2008-01-14"^^xsd:date ;
+        rdfs:comment "The set of regions in space defined by their geographic coordinates according to the DCMI Box Encoding Scheme."@en ;
+        rdfs:isDefinedBy dct: ;
+        rdfs:label "DCMI Box"@en ;
+        rdfs:seeAlso <http://dublincore.org/documents/dcmi-box/> .
+
+
+dct:ISO3166 dct:hasVersion <http://dublincore.org/usage/terms/history/#ISO3166-004> ;
+            dct:issued "2000-07-11"^^xsd:date ;
+            dct:modified "2008-01-14"^^xsd:date ;
+            rdfs:comment "The set of codes listed in ISO 3166-1 for the representation of names of countries."@en ;
+            rdfs:isDefinedBy dct: ;
+            rdfs:label "ISO 3166"@en ;
+            rdfs:seeAlso <http://www.iso.org/iso/en/prods-services/iso3166ma/02iso-3166-code-lists/list-en1.html> .
+
+
+dct:ISO639-2 dct:hasVersion <http://dublincore.org/usage/terms/history/#ISO639-2-003> ;
+             dct:issued "2000-07-11"^^xsd:date ;
+             dct:modified "2008-01-14"^^xsd:date ;
+             rdfs:comment "The three-letter alphabetic codes listed in ISO639-2 for the representation of names of languages."@en ;
+             rdfs:isDefinedBy dct: ;
+             rdfs:label "ISO 639-2"@en ;
+             rdfs:seeAlso <http://lcweb.loc.gov/standards/iso639-2/langhome.html> .
+
+
+dct:ISO639-3 dct:hasVersion <http://dublincore.org/usage/terms/history/#ISO639-3-001> ;
+             dct:issued "2008-01-14"^^xsd:date ;
+             rdfs:comment "The set of three-letter codes listed in ISO 639-3 for the representation of names of languages."@en ;
+             rdfs:isDefinedBy dct: ;
+             rdfs:label "ISO 639-3"@en ;
+             rdfs:seeAlso <http://www.sil.org/iso639-3/> .
+
+
+dct:Period dct:hasVersion <http://dublincore.org/usage/terms/history/#Period-003> ;
+           dct:issued "2000-07-11"^^xsd:date ;
+           dct:modified "2008-01-14"^^xsd:date ;
+           rdfs:comment "The set of time intervals defined by their limits according to the DCMI Period Encoding Scheme."@en ;
+           rdfs:isDefinedBy dct: ;
+           rdfs:label "DCMI Period"@en ;
+           rdfs:seeAlso <http://dublincore.org/documents/dcmi-period/> .
+
+
+dct:Point dct:hasVersion <http://dublincore.org/usage/terms/history/#Point-003> ;
+          dct:issued "2000-07-11"^^xsd:date ;
+          dct:modified "2008-01-14"^^xsd:date ;
+          rdfs:comment "The set of points in space defined by their geographic coordinates according to the DCMI Point Encoding Scheme."@en ;
+          rdfs:isDefinedBy dct: ;
+          rdfs:label "DCMI Point"@en ;
+          rdfs:seeAlso <http://dublincore.org/documents/dcmi-point/> .
+
+
+dct:RFC1766 dct:hasVersion <http://dublincore.org/usage/terms/history/#RFC1766-003> ;
+            dct:issued "2000-07-11"^^xsd:date ;
+            dct:modified "2008-01-14"^^xsd:date ;
+            rdfs:comment "The set of tags, constructed according to RFC 1766, for the identification of languages."@en ;
+            rdfs:isDefinedBy dct: ;
+            rdfs:label "RFC 1766"@en ;
+            rdfs:seeAlso <http://www.ietf.org/rfc/rfc1766.txt> .
+
+
+dct:RFC3066 dct:description "RFC 3066 has been obsoleted by RFC 4646."@en ;
+            dct:hasVersion <http://dublincore.org/usage/terms/history/#RFC3066-002> ;
+            dct:issued "2002-07-13"^^xsd:date ;
+            dct:modified "2008-01-14"^^xsd:date ;
+            rdfs:comment "The set of tags constructed according to RFC 3066 for the identification of languages."@en ;
+            rdfs:isDefinedBy dct: ;
+            rdfs:label "RFC 3066"@en ;
+            rdfs:seeAlso <http://www.ietf.org/rfc/rfc3066.txt> .
+
+
+dct:RFC4646 dct:description "RFC 4646 obsoletes RFC 3066."@en ;
+            dct:hasVersion <http://dublincore.org/usage/terms/history/#RFC4646-001> ;
+            dct:issued "2008-01-14"^^xsd:date ;
+            rdfs:comment "The set of tags constructed according to RFC 4646 for the identification of languages."@en ;
+            rdfs:isDefinedBy dct: ;
+            rdfs:label "RFC 4646"@en ;
+            rdfs:seeAlso <http://www.ietf.org/rfc/rfc4646.txt> .
+
+
+dct:RFC5646 dct:description "RFC 5646 obsoletes RFC 4646."@en ;
+            dct:hasVersion <http://dublincore.org/usage/terms/history/#RFC5646-001> ;
+            dct:issued "2010-10-11"^^xsd:date ;
+            rdfs:comment "The set of tags constructed according to RFC 5646 for the identification of languages."@en ;
+            rdfs:isDefinedBy dct: ;
+            rdfs:label "RFC 5646"@en ;
+            rdfs:seeAlso <http://www.ietf.org/rfc/rfc5646.txt> .
+
+
+dct:URI dct:hasVersion <http://dublincore.org/usage/terms/history/#URI-003> ;
+        dct:issued "2000-07-11"^^xsd:date ;
+        dct:modified "2008-01-14"^^xsd:date ;
+        rdfs:comment "The set of identifiers constructed according to the generic syntax for Uniform Resource Identifiers as specified by the Internet Engineering Task Force."@en ;
+        rdfs:isDefinedBy dct: ;
+        rdfs:label "URI"@en ;
+        rdfs:seeAlso <http://www.ietf.org/rfc/rfc3986.txt> .
+
+
+dct:W3CDTF dct:hasVersion <http://dublincore.org/usage/terms/history/#W3CDTF-003> ;
+           dct:issued "2000-07-11"^^xsd:date ;
+           dct:modified "2008-01-14"^^xsd:date ;
+           rdfs:comment "The set of dates and times constructed according to the W3C Date and Time Formats Specification."@en ;
+           rdfs:isDefinedBy dct: ;
+           rdfs:label "W3C-DTF"@en ;
+           rdfs:seeAlso <http://www.w3.org/TR/NOTE-datetime> .
+
+
+dct:abstract dct:hasVersion <http://dublincore.org/usage/terms/history/#abstract-003> ;
+             dct:issued "2000-07-11"^^xsd:date ;
+             dct:modified "2008-01-14"^^xsd:date ;
+             rdfs:comment "A summary of the resource."@en ;
+             rdfs:isDefinedBy dct: ;
+             rdfs:label "Abstract"@en .
+
+
+dct:alternative dct:description "The distinction between titles and alternative titles is application-specific."@en ;
+                dct:hasVersion <http://dublincore.org/usage/terms/history/#alternative-003> ;
+                dct:issued "2000-07-11"^^xsd:date ;
+                dct:modified "2010-10-11"^^xsd:date ;
+                rdfs:comment "An alternative name for the resource."@en ;
+                rdfs:isDefinedBy dct: ;
+                rdfs:label "Alternative Title"@en .
+
+
+dct:available dct:hasVersion <http://dublincore.org/usage/terms/history/#available-003> ;
+              dct:issued "2000-07-11"^^xsd:date ;
+              dct:modified "2008-01-14"^^xsd:date ;
+              rdfs:comment "Date (often a range) that the resource became or will become available."@en ;
+              rdfs:isDefinedBy dct: ;
+              rdfs:label "Date Available"@en .
+
+
+dct:bibliographicCitation dct:description "Recommended practice is to include sufficient bibliographic detail to identify the resource as unambiguously as possible."@en ;
+                          dct:hasVersion <http://dublincore.org/usage/terms/history/#bibliographicCitation-002> ;
+                          dct:issued "2003-02-15"^^xsd:date ;
+                          dct:modified "2008-01-14"^^xsd:date ;
+                          rdfs:comment "A bibliographic reference for the resource."@en ;
+                          rdfs:isDefinedBy dct: ;
+                          rdfs:label "Bibliographic Citation"@en .
+
+
+dct:contributor dct:description "Examples of a Contributor include a person, an organization, or a service."@en ;
+                dct:hasVersion <http://dublincore.org/usage/terms/history/#contributorT-001> ;
+                dct:issued "2008-01-14"^^xsd:date ;
+                dct:modified "2010-10-11"^^xsd:date ;
+                rdfs:comment "An entity responsible for making contributions to the resource."@en ;
+                rdfs:isDefinedBy dct: ;
+                rdfs:label "Contributor"@en .
+
+
+dct:created dct:hasVersion <http://dublincore.org/usage/terms/history/#created-003> ;
+            dct:issued "2000-07-11"^^xsd:date ;
+            dct:modified "2008-01-14"^^xsd:date ;
+            rdfs:comment "Date of creation of the resource."@en ;
+            rdfs:isDefinedBy dct: ;
+            rdfs:label "Date Created"@en .
+
+
+dct:creator dct:description "Examples of a Creator include a person, an organization, or a service."@en ;
+            dct:hasVersion <http://dublincore.org/usage/terms/history/#creatorT-002> ;
+            dct:issued "2008-01-14"^^xsd:date ;
+            dct:modified "2010-10-11"^^xsd:date ;
+            rdfs:comment "An entity primarily responsible for making the resource."@en ;
+            rdfs:isDefinedBy dct: ;
+            rdfs:label "Creator"@en .
+
+
+dct:date dct:description "Date may be used to express temporal information at any level of granularity.  Recommended best practice is to use an encoding scheme, such as the W3CDTF profile of ISO 8601 [W3CDTF]."@en ;
+         dct:hasVersion <http://dublincore.org/usage/terms/history/#dateT-001> ;
+         dct:issued "2008-01-14"^^xsd:date ;
+         dct:modified "2008-01-14"^^xsd:date ;
+         rdfs:comment "A point or period of time associated with an event in the lifecycle of the resource."@en ;
+         rdfs:isDefinedBy dct: ;
+         rdfs:label "Date"@en .
+
+
+dct:dateAccepted dct:description "Examples of resources to which a Date Accepted may be relevant are a thesis (accepted by a university department) or an article (accepted by a journal)."@en ;
+                 dct:hasVersion <http://dublincore.org/usage/terms/history/#dateAccepted-002> ;
+                 dct:issued "2002-07-13"^^xsd:date ;
+                 dct:modified "2008-01-14"^^xsd:date ;
+                 rdfs:comment "Date of acceptance of the resource."@en ;
+                 rdfs:isDefinedBy dct: ;
+                 rdfs:label "Date Accepted"@en .
+
+
+dct:dateCopyrighted dct:hasVersion <http://dublincore.org/usage/terms/history/#dateCopyrighted-002> ;
+                    dct:issued "2002-07-13"^^xsd:date ;
+                    dct:modified "2008-01-14"^^xsd:date ;
+                    rdfs:comment "Date of copyright."@en ;
+                    rdfs:isDefinedBy dct: ;
+                    rdfs:label "Date Copyrighted"@en .
+
+
+dct:dateSubmitted dct:description "Examples of resources to which a Date Submitted may be relevant are a thesis (submitted to a university department) or an article (submitted to a journal)."@en ;
+                  dct:hasVersion <http://dublincore.org/usage/terms/history/#dateSubmitted-002> ;
+                  dct:issued "2002-07-13"^^xsd:date ;
+                  dct:modified "2008-01-14"^^xsd:date ;
+                  rdfs:comment "Date of submission of the resource."@en ;
+                  rdfs:isDefinedBy dct: ;
+                  rdfs:label "Date Submitted"@en .
+
+
+dct:description dct:description "Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource."@en ;
+                dct:hasVersion <http://dublincore.org/usage/terms/history/#descriptionT-001> ;
+                dct:issued "2008-01-14"^^xsd:date ;
+                dct:modified "2008-01-14"^^xsd:date ;
+                rdfs:comment "An account of the resource."@en ;
+                rdfs:isDefinedBy dct: ;
+                rdfs:label "Description"@en .
+
+
+dct:hasFormat dct:hasVersion <http://dublincore.org/usage/terms/history/#hasFormat-003> ;
+              dct:issued "2000-07-11"^^xsd:date ;
+              dct:modified "2008-01-14"^^xsd:date ;
+              rdfs:comment "A related resource that is substantially the same as the pre-existing described resource, but in another format."@en ;
+              rdfs:isDefinedBy dct: ;
+              rdfs:label "Has Format"@en ;
+              <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+
+dct:hasPart dct:hasVersion <http://dublincore.org/usage/terms/history/#hasPart-003> ;
+            dct:issued "2000-07-11"^^xsd:date ;
+            dct:modified "2008-01-14"^^xsd:date ;
+            rdfs:comment "A related resource that is included either physically or logically in the described resource."@en ;
+            rdfs:isDefinedBy dct: ;
+            rdfs:label "Has Part"@en ;
+            <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+
+dct:hasVersion dct:hasVersion <http://dublincore.org/usage/terms/history/#hasVersion-003> ;
+               dct:issued "2000-07-11"^^xsd:date ;
+               dct:modified "2008-01-14"^^xsd:date ;
+               rdfs:comment "A related resource that is a version, edition, or adaptation of the described resource."@en ;
+               rdfs:isDefinedBy dct: ;
+               rdfs:label "Has Version"@en ;
+               <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+
+dct:identifier dct:description "Recommended best practice is to identify the resource by means of a string conforming to a formal identification system. "@en ;
+               dct:hasVersion <http://dublincore.org/usage/terms/history/#identifierT-001> ;
+               dct:issued "2008-01-14"^^xsd:date ;
+               dct:modified "2008-01-14"^^xsd:date ;
+               rdfs:comment "An unambiguous reference to the resource within a given context."@en ;
+               rdfs:isDefinedBy dct: ;
+               rdfs:label "Identifier"@en .
+
+
+dct:isFormatOf dct:hasVersion <http://dublincore.org/usage/terms/history/#isFormatOf-003> ;
+               dct:issued "2000-07-11"^^xsd:date ;
+               dct:modified "2008-01-14"^^xsd:date ;
+               rdfs:comment "A related resource that is substantially the same as the described resource, but in another format."@en ;
+               rdfs:isDefinedBy dct: ;
+               rdfs:label "Is Format Of"@en ;
+               <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+
+dct:isPartOf dct:hasVersion <http://dublincore.org/usage/terms/history/#isPartOf-003> ;
+             dct:issued "2000-07-11"^^xsd:date ;
+             dct:modified "2008-01-14"^^xsd:date ;
+             rdfs:comment "A related resource in which the described resource is physically or logically included."@en ;
+             rdfs:isDefinedBy dct: ;
+             rdfs:label "Is Part Of"@en ;
+             <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+
+dct:isReferencedBy dct:hasVersion <http://dublincore.org/usage/terms/history/#isReferencedBy-003> ;
+                   dct:issued "2000-07-11"^^xsd:date ;
+                   dct:modified "2008-01-14"^^xsd:date ;
+                   rdfs:comment "A related resource that references, cites, or otherwise points to the described resource."@en ;
+                   rdfs:isDefinedBy dct: ;
+                   rdfs:label "Is Referenced By"@en ;
+                   <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+
+dct:isReplacedBy dct:hasVersion <http://dublincore.org/usage/terms/history/#isReplacedBy-003> ;
+                 dct:issued "2000-07-11"^^xsd:date ;
+                 dct:modified "2008-01-14"^^xsd:date ;
+                 rdfs:comment "A related resource that supplants, displaces, or supersedes the described resource."@en ;
+                 rdfs:isDefinedBy dct: ;
+                 rdfs:label "Is Replaced By"@en ;
+                 <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+
+dct:isRequiredBy dct:hasVersion <http://dublincore.org/usage/terms/history/#isRequiredBy-003> ;
+                 dct:issued "2000-07-11"^^xsd:date ;
+                 dct:modified "2008-01-14"^^xsd:date ;
+                 rdfs:comment "A related resource that requires the described resource to support its function, delivery, or coherence."@en ;
+                 rdfs:isDefinedBy dct: ;
+                 rdfs:label "Is Required By"@en ;
+                 <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+
+dct:isVersionOf dct:description "Changes in version imply substantive changes in content rather than differences in format."@en ;
+                dct:hasVersion <http://dublincore.org/usage/terms/history/#isVersionOf-003> ;
+                dct:issued "2000-07-11"^^xsd:date ;
+                dct:modified "2008-01-14"^^xsd:date ;
+                rdfs:comment "A related resource of which the described resource is a version, edition, or adaptation."@en ;
+                rdfs:isDefinedBy dct: ;
+                rdfs:label "Is Version Of"@en ;
+                <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+
+dct:issued dct:hasVersion <http://dublincore.org/usage/terms/history/#issued-003> ;
+           dct:issued "2000-07-11"^^xsd:date ;
+           dct:modified "2008-01-14"^^xsd:date ;
+           rdfs:comment "Date of formal issuance (e.g., publication) of the resource."@en ;
+           rdfs:isDefinedBy dct: ;
+           rdfs:label "Date Issued"@en .
+
+
+dct:modified dct:hasVersion <http://dublincore.org/usage/terms/history/#modified-003> ;
+             dct:issued "2000-07-11"^^xsd:date ;
+             dct:modified "2008-01-14"^^xsd:date ;
+             rdfs:comment "Date on which the resource was changed."@en ;
+             rdfs:isDefinedBy dct: ;
+             rdfs:label "Date Modified"@en .
+
+
+dct:references dct:hasVersion <http://dublincore.org/usage/terms/history/#references-003> ;
+               dct:issued "2000-07-11"^^xsd:date ;
+               dct:modified "2008-01-14"^^xsd:date ;
+               rdfs:comment "A related resource that is referenced, cited, or otherwise pointed to by the described resource."@en ;
+               rdfs:isDefinedBy dct: ;
+               rdfs:label "References"@en ;
+               <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+
+dct:relation dct:description "Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system. "@en ;
+             dct:hasVersion <http://dublincore.org/usage/terms/history/#relationT-001> ;
+             dct:issued "2008-01-14"^^xsd:date ;
+             dct:modified "2008-01-14"^^xsd:date ;
+             rdfs:comment "A related resource."@en ;
+             rdfs:isDefinedBy dct: ;
+             rdfs:label "Relation"@en ;
+             <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+
+dct:replaces dct:hasVersion <http://dublincore.org/usage/terms/history/#replaces-003> ;
+             dct:issued "2000-07-11"^^xsd:date ;
+             dct:modified "2008-01-14"^^xsd:date ;
+             rdfs:comment "A related resource that is supplanted, displaced, or superseded by the described resource."@en ;
+             rdfs:isDefinedBy dct: ;
+             rdfs:label "Replaces"@en ;
+             <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+
+dct:requires dct:hasVersion <http://dublincore.org/usage/terms/history/#requires-003> ;
+             dct:issued "2000-07-11"^^xsd:date ;
+             dct:modified "2008-01-14"^^xsd:date ;
+             rdfs:comment "A related resource that is required by the described resource to support its function, delivery, or coherence."@en ;
+             rdfs:isDefinedBy dct: ;
+             rdfs:label "Requires"@en ;
+             <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+
+dct:source dct:description "The described resource may be derived from the related resource in whole or in part. Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system."@en ;
+           dct:hasVersion <http://dublincore.org/usage/terms/history/#sourceT-001> ;
+           dct:issued "2008-01-14"^^xsd:date ;
+           dct:modified "2008-01-14"^^xsd:date ;
+           rdfs:comment "A related resource from which the described resource is derived."@en ;
+           rdfs:isDefinedBy dct: ;
+           rdfs:label "Source"@en ;
+           <http://www.w3.org/2004/02/skos/core#note> "This term is intended to be used with non-literal values as defined in the DCMI Abstract Model (http://dublincore.org/documents/abstract-model/).  As of December 2007, the DCMI Usage Board is seeking a way to express this intention with a formal range declaration."@en .
+
+
+dct:tableOfContents dct:hasVersion <http://dublincore.org/usage/terms/history/#tableOfContents-003> ;
+                    dct:issued "2000-07-11"^^xsd:date ;
+                    dct:modified "2008-01-14"^^xsd:date ;
+                    rdfs:comment "A list of subunits of the resource."@en ;
+                    rdfs:isDefinedBy dct: ;
+                    rdfs:label "Table Of Contents"@en .
+
+
+dct:title dct:hasVersion <http://dublincore.org/usage/terms/history/#titleT-002> ;
+          dct:issued "2008-01-14"^^xsd:date ;
+          dct:modified "2010-10-11"^^xsd:date ;
+          rdfs:comment "A name given to the resource."@en ;
+          rdfs:isDefinedBy dct: ;
+          rdfs:label "Title"@en .
+
+
+dct:valid dct:hasVersion <http://dublincore.org/usage/terms/history/#valid-003> ;
+          dct:issued "2000-07-11"^^xsd:date ;
+          dct:modified "2008-01-14"^^xsd:date ;
+          rdfs:comment "Date (often a range) of validity of a resource."@en ;
+          rdfs:isDefinedBy dct: ;
+          rdfs:label "Date Valid"@en .
+
+
+ontohgis:hasLanguageVerificator rdfs:label "translation was verified by"@en ,
+                                           "weryfikacja tłumaczenia deskrypcji przez"@pl .
+
+
+ontohgis:hasOntologicalVerificator rdfs:label "deskrypcja została ontologicznie zweryfikowana przez"@pl ,
+                                              "was ontologically verified by"@en .
+
+
+ontohgis:hasTranslator rdfs:label "deskrypcja została przetłumaczona przez"@pl ,
+                                  "was translated by"@en .
+
+
+ontohgis:settlement_type_1 rdfs:comment "A castle could be an independent settlement unit or an object within some other unit."@en ,
+                                        "Zamek mógł być jednostką osadniczą lub obiektem w obrębie innej jednostki."@pl ;
+                           rdfs:isDefinedBy "A castle (a locality) is a locality comprising a castle (building) unless it is a part of another locality."@en ,
+                                            "Zamek (miejscowość) jest to miejscowość obejmująca zamek (obiekt), gdy nie jest on częścią innej miejscowości."@pl ;
+                           rdfs:label "castle"@en ,
+                                      "zamek"@pl ;
+                           rdfs:seeAlso <http://gov.genealogy.net/types.owl#111> ,
+                                        <http://linkedgeodata.org/page/ontology/Castle> ;
+                           <http://www.w3.org/2004/02/skos/core#altLabel> "Burg"@de ,
+                                                                          "Schloß"@de ,
+                                                                          "castellum"@la ,
+                                                                          "castrum"@la ;
+                           <http://www.w3.org/2004/02/skos/core#hiddenLabel> "arx"@la ,
+                                                                             "forteca"@pl ,
+                                                                             "gród"@pl ,
+                                                                             "pałac"@pl ,
+                                                                             "twierdza"@pl ;
+                           <http://www.w3.org/2004/02/skos/core#prefLabel> "castle"@en ,
+                                                                           "zamek"@pl ;
+                           ontohgis:hasExternalIdentifier "1" ;
+                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                           ontohgis:hasTranslator ontohgis:person_9 .
+
+
+ontohgis:settlement_type_10 rdfs:comment "A brewery might be a separate locality (rarely, before the WW II), both individual and a part of a cluster of localities sharing the same name, however most often it has been an integral part of a city or a town and has not been distinguished."@en ,
+                                         "Browar może być odrębną miejscowością (rzadko, przed II wojną światową), zarówno samodzielną jak i częścią grupy miejscowości o tej samej nazwie, ale najczęściej znajduje się w obrębie miast i nie jest wyróżniony."@pl ;
+                            rdfs:isDefinedBy "Brewery (locality) is a settlement, where a brewery (a factory) plays the most important role."@en ,
+                                             "Browar (miejscowość) jest to osada, w której główna rolę pełni browar (obiekt)."@pl ;
+                            rdfs:label "brewery"@en ,
+                                       "browar"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Bierbrauerei"@de ,
+                                                                              "Brauerei"@de ,
+                                                                              "Brauhaus"@de ,
+                                                                              "braxatorium"@la ,
+                                                                              "mielcuch"@pl ,
+                                                                              "piwowarnia"@pl ,
+                                                                              "warzelnia"@pl ,
+                                                                              "пивоварня"@ru ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "brewery"@en ,
+                                                                            "browar"@pl ;
+                            ontohgis:hasExternalIdentifier "10" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
+
+
+ontohgis:settlement_type_100 rdfs:comment "As a separate building, chapel could be a separate settlement unit in the past (rarely in the early modern era), but most often it is part of the village as a building."@en ,
+                                          "Kaplica jako odrębny budynek mogła być w przeszłości odrębną jednostką osadniczą (rzadko, spotyka się w okresie staropolskim), najczęściej jednak wchodzi w skład miejscowości jako budowla."@pl ;
+                             rdfs:isDefinedBy "Chapel is a locality, where the main role is played by a chapel (sacral building)."@en ,
+                                              "Kaplica jest to miejscowość, w której główną rolę pełni kaplica jako obiekt sakralny."@pl ;
+                             rdfs:label "chapel"@en ,
+                                        "kaplica"@pl ;
+                             rdfs:seeAlso <http://gov.genealogy.net/types.owl#245> ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "capella"@la ,
+                                                                            "die Kapelle"@de ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "aedes"@la ,
+                                                                               "aedicula sacrarium"@la ,
+                                                                               "augurale"@la ,
+                                                                               "auguratorium"@la ,
+                                                                               "delubrum"@la ,
+                                                                               "fanulum"@la ,
+                                                                               "fanum"@la ,
+                                                                               "kościół"@pl ,
+                                                                               "lararium"@la ,
+                                                                               "oratorium"@la ,
+                                                                               "sacellum"@la ,
+                                                                               "świątynia"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "chapel"@en ,
+                                                                             "kaplica"@pl ;
+                             ontohgis:hasExternalIdentifier "100" ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_103 rdfs:comment "A church could be a separate settlement in the past (rarely, one can note its existence during and early modern era), however usually it, understood as a building, constituted a part of a locality."@en ,
+                                          "Kościół mógł być w przeszłości odrębną jednostką osadniczą (rzadko, spotyka się w okresie staropolskim), najczęściej jednak wchodzi w skład miejscowości jako budowla."@pl ;
+                             rdfs:isDefinedBy "Church is a locality, where the main role is played by the church (sacral building)."@en ,
+                                              "Kościół jest to miejscowość, w której główną rolę pełni kościół jako obiekt sakralny."@pl ;
+                             rdfs:label "church"@en ,
+                                        "kościół"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "ecclesia"@la ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "aedes"@la ,
+                                                                               "cerkiew"@pl ,
+                                                                               "die Kirche"@de ,
+                                                                               "domus Dei"@la ,
+                                                                               "fanum"@la ,
+                                                                               "kaplica"@pl ,
+                                                                               "templum"@la ,
+                                                                               "świątynia"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "church"@en ,
+                                                                             "kościół"@pl ;
+                             ontohgis:hasExternalIdentifier "103" ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 ,
+                                                    ontohgis:person_9 .
+
+
+ontohgis:settlement_type_106 rdfs:comment "Although the category exists on maps - e.g. the Topographical Map of the Kingdom of Poland from 1843 - it is very rare. On the Map, one can notice the peculiar spelling of this category: \"romunek\"."@en ,
+                                          "Kategoria występuje na mapach – np. Kwatermistrzostwie, to jednak jest to kategoria bardzo rzadka."@pl ;
+                             rdfs:isDefinedBy "\"Rumunek\" is an outlying settlement, situated in a cleared forest area (usually) or near the forest."@en ,
+                                              "Rumunek to odosobniona osada, położona w miejscu po wykarczowanym lesie (najczęściej) lub pod lasem."@pl ;
+                             rdfs:label "\"rumunek\""@en ,
+                                        "rumunek"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "pustkowie (pl)" ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "kolonia"@pl ,
+                                                                               "przysiółek"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "\"rumunek\""@en ,
+                                                                             "rumunek"@pl ;
+                             ontohgis:hasExternalIdentifier "106" ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
+
+
+ontohgis:settlement_type_11 rdfs:comment "A brickyard might be a separate locality, both individual and a part of a cluster of localities sharing the same name. It may also be an integral part of a bigger locality."@en ,
+                                         "Cegielnia może być odrębną miejscowością, zarówno samodzielną jak i częścią grupy miejscowości o tej samej nazwie, może też znajdować się w obrębie większej miejscowości."@pl ;
+                            rdfs:isDefinedBy "Brickyard (locality) is a settlement, where a brickyard (a building and a factory) plays the most important role."@en ,
+                                             "Cegielnia (miejscowość) jest to osada, w której główną rolę odrywa cegielnia (obiekt)."@pl ;
+                            rdfs:label "brickyard"@en ,
+                                       "cegielnia"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Ziegelei"@de ,
+                                                                              "Ziegelscheune"@de ,
+                                                                              "cegielnica"@pl ,
+                                                                              "кирпичный завод"@ru ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "brickyard"@en ,
+                                                                            "cegielnia"@pl ;
+                            ontohgis:hasExternalIdentifier "11" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
+
+
+ontohgis:settlement_type_110 rdfs:comment "O odrębności wójtostwa decyduje kryterium nazewnicze, które jest efektem jego statusu prawnego."@pl ,
+                                          "Vogt-owned-settlement is distinguished on the basis of its name, which results from its legal status."@en ;
+                             rdfs:isDefinedBy "Vogt-owned-settlement is the area of land owned by the vogt (ger Schultheiß) which is either a separate locality or a separate part of another locality."@en ,
+                                              "Wójtostwo to obszar zajmowany przez ziemię należącą do sołtysa (wójta), będący osobną miejscowością lub wydzieloną częścią miejscowości."@pl ;
+                             rdfs:label "vogt-owned-settlement"@en ,
+                                        "wójtostwo"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "die Vogtei"@de ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "grunt"@pl ,
+                                                                               "majątek"@pl ,
+                                                                               "posiadłość"@pl ,
+                                                                               "sołectwo"@pl ,
+                                                                               "zagroda"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "vogt-owned-settlement"@en ,
+                                                                             "wójtostwo"@pl ;
+                             ontohgis:hasExternalIdentifier "110" ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 ,
+                                                    ontohgis:person_9 .
+
+
+ontohgis:settlement_type_112 rdfs:comment "Część przysiółka jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Części przysiółków to 6 obiektów: 3 w woj. małopolskim, po 1 w woj. mazowieckim, kujawsko-pomorskim i wielkopolskim."@pl ,
+                                          "Part of a hamlet is a separate settlement unit, a kind of locality, it always has a particular name. There are 6 parts of the hamlets according to National Register of Geographic Names (pl \"Państwowy Rejestr Nazwy Geograficznych\"): 3 in Małopolskie voivodship, 1 in Mazowieckie , Kuyawsko-Pomorskie, and Wielkopolskie voivodships."@en ;
+                             rdfs:isDefinedBy "Część przysiółka jest to miejscowość stanowiąca integralną część miejscowości podstawowej przysiółka, jest wydzielona administracyjnie, ale należy do jednostki nadrzędnej."@pl ,
+                                              "Part of a hamlet is an integral part of the main locality a hamlet; it is administratively separated, but belongs to the superior locality."@en ;
+                             rdfs:label "część przysiółka"@pl ,
+                                        "part of a hamlet"@en ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "część przysiółka"@pl ,
+                                                                             "part of a hamlet"@en ;
+                             ontohgis:hasExternalIdentifier 112 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_113 rdfs:comment "At least untill the 13th century, a gord was a central and usually the only element of a city or town indicated in written historical sources, which is why these may be considered as identical for this period; after location, the gord became one of many facilities in a city or a town, usually situated on peripheries, sometimes converted into a castle."@en ,
+                                          "Gords are characteristic mostly for the High Middle Ages, when documents were written in Latin, despite the fact that Latin does not know a proper notion for this kind of settlement unit. Expressions with a different, relatively similar, meaning had been used to describe the gord, i.e. a city (lat civitas), or a castle (lat arx, castrum). In younger historical German sources “gród” was called Burg, the expression meaning both a gord and a castle. Researchers consider “gord” as an endemic and specifically Slavic phenomenon."@en ,
+                                          "Grody są charakterystyczne przede wszystkim dla pełnego średniowiecza, gdy językiem źródeł była łacina - a w niej nie wykształcił się w ogóle termin odpowiadający tej jednostce osadniczej. Określano ją więc za pomocą pojęć o odmiennym, względnie podobnym znaczeniu, jak miasto (civitas), zamek (arx, castrum). Z kolei w późniejszych źródłach niemieckich odpowiadał mu termin Burg, oznaczający zarówno gród, jak również zamek. W literaturze przedmiotu gród jest traktowany jako zjawisko specyficznie słowiańskie."@pl ,
+                                          "Przynamniej do XIII w. gród stanowił centralną i zwykle jedyną uchwytną źródłowo część miasta, więc dla tego okresu może być z nim utożsamiany; po lokacji stawał się jednym z obiektów w mieście, zwykle peryferyjnym, niejednokrotnie zamienianym w zamek."@pl ;
+                             rdfs:isDefinedBy "Gord is a medieval or – in eastern territories – early modern settlement with revetments and stockades."@en ,
+                                              "Średniowieczna lub, na terenach wschodnich, wczesnonowożytna osada z obwarowaniami drewniano-ziemnymi."@pl ;
+                             rdfs:label "gord"@en ,
+                                        "gród"@pl ;
+                             rdfs:seeAlso <http://dbpedia.org/page/Gord_(archaeology)> ,
+                                          <https://www.wikidata.org/wiki/Q88598> ,
+                                          "t. 2, s. 168 (hasło \"Grodzisko\"): \"Grody to obiekty sztucznie ogrodzone w celach obronnych. Pojęcie to obejmuje wszelkiego rodzaju miejsca obronne, jak wsie, miasta, ośrodki administracyjne, wojskowe i inne schronienia przygotowane do obrony. W średniowieczu grodami nazywano też miasta\"."@pl ,
+                                          "t. 2, s. 637: \"pierwotnie osada obronna, ogrodzona palisadą lub obwałowana\""@pl ,
+                                          "t. 6, s. 22: \"miejsce obronne w znaczeniu późniejszym tyle co \"zamek\", \"miasto\"\""@pl ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Burg"@de ,
+                                                                               "arx"@la ,
+                                                                               "castrum"@la ,
+                                                                               "civitas"@la ,
+                                                                               "gorod"@ru ,
+                                                                               "grodzisko"@pl ,
+                                                                               "zamek"@pl ,
+                                                                               "grodzisko (pol, zamek (pl), Burg (de), gorod (ru), civitas (lat), arx (lat), castrum (lat)" ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "gord"@en ,
+                                                                             "gród"@pl ;
+                             ontohgis:hasExternalIdentifier "113" ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_113 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 2, s. 168 (hasło \"Grodzisko\"): \"Grody to obiekty sztucznie ogrodzone w celach obronnych. Pojęcie to obejmuje wszelkiego rodzaju miejsca obronne, jak wsie, miasta, ośrodki administracyjne, wojskowe i inne schronienia przygotowane do obrony. W średniowieczu grodami nazywano też miasta\"."@pl ;
+   rdfs:isDefinedBy ontohgis:document_139
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_113 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 2, s. 637: \"pierwotnie osada obronna, ogrodzona palisadą lub obwałowana\""@pl ;
+   rdfs:isDefinedBy ontohgis:document_138
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_113 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 6, s. 22: \"miejsce obronne w znaczeniu późniejszym tyle co \"zamek\", \"miasto\"\""@pl ;
+   rdfs:isDefinedBy ontohgis:document_140
+ ] .
+
+
+ontohgis:settlement_type_114 rdfs:comment "Chronologically, a castle with its functions was preceded by a gord (non-brick, without buildings having both defensive and residential functions), while its successor was a palace (with defensive functions reduced), and a fortress (is was not necessarily a densely built-up structure, and there was no buildings with both defensive and residential functions). During the Early Modern era, military functions of castles were diminishing, but they continued to be residences. Newly established ones in their form imitated defensive buildings and due to this feature were called castles."@en ,
+                                          "Chronologicznie funkcjonalnym poprzednikiem zamku był gród (niemurowany i bez budynków łączących funkcje obronne i rezydencjonalne), a następcą pałac (bez funkcji obronnych) i twierdza (nie musiała być założeniem zwartym i bez budynków łączących funkcje obronne i rezydencjonalne). W epoce nowożytnej i później zamki w coraz mniejszym stopniu pełniły funkcje militarne, ale zachowywały ciągłość funkcji rezydencjonalnych lub, nowopowstałe, w architekturze naśladowały budowle obronne i z tego względu były nazywane zamkami."@pl ;
+                             rdfs:isDefinedBy "Castle is a brick, densely built-up, closed, usually complex structure, within which at least some buildings have both defensive and residential functions; built in the Middle Ages or later but then in a form referring to that period."@en ,
+                                              "Murowane, zwarte, zamknięte, zwykle wieloczłonowe założenie, w którym przynajmniej część budynków pełni funkcje zarazem obronne i rezydencjonalne; powstałe w średniowieczu lub nawiązujące formą do tej epoki."@pl ;
+                             rdfs:label "castle"@en ,
+                                        "zamek - obiekt"@pl ;
+                             rdfs:seeAlso <http://dbpedia.org/ontology/Castle> ,
+                                          <http://linkedgeodata.org/page/ontology/Castle> ,
+                                          <http://vocab.getty.edu/aat/300006891> ,
+                                          <https://www.wikidata.org/wiki/Q23413> ,
+                                          "miejsce obronne, twierdza"@pl ,
+                                          "od średniowiecza do w. XVII obronna siedziba pana feudalnego, ośrodek władzy; w XVII w. i później królewska, książęca lub magnacka rezydencja miejska lub pozamiejska"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "Burg"@de ,
+                                                                            "Schloss"@de ,
+                                                                            "castellum"@la ,
+                                                                            "castrum"@la ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "arx"@la ,
+                                                                               "forteca"@pl ,
+                                                                               "gród"@pl ,
+                                                                               "pałac"@pl ,
+                                                                               "twierdza"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "castle"@en ,
+                                                                             "zamek"@pl ;
+                             ontohgis:hasExternalIdentifier "114"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_114 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "miejsce obronne, twierdza"@pl ;
+   rdfs:isDefinedBy ontohgis:document_2
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_114 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "od średniowiecza do w. XVII obronna siedziba pana feudalnego, ośrodek władzy; w XVII w. i później królewska, książęca lub magnacka rezydencja miejska lub pozamiejska"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+
+ontohgis:settlement_type_115 rdfs:comment "Port morski określa funkcję, jako pełni miejscowość, np. Gdynia jest miastem portowym (określenie z Bystrzyckiego), ale „port” (niekoniecznie morski) również może być miejscowością (patrz: Koeniglicher Hafen k. Torunia). Niektóre portowe miasta niemieckie zawierają „port” (niem. „-hafen”) w nazwie własnej (np. Osternothafen dziś: Chorzelin, id prng: 178058)."@pl ,
+                                          "Sea harbour defines the function of the locality, e.g. Gdynia is a \"harbour city\" (in Bystrzycki's register), but the \"harbour\" (not necessarily at sea) may also be a locality (see: Koeniglicher Hafen near Toruń). Some harbours in Germany contain a \"harbour\" (German \"-hafen\") suffix in their own name (e.g. Osternothafen today: Chorzelin, id :: prng 178058)."@en ;
+                             rdfs:isDefinedBy "Port morski to przybrzeżny obszar wodny wraz z infrastrukturą przeznaczony dla obsługi statków."@pl ,
+                                              "Sea harbour is an area consisting of coastal waters together with artificial structures designed for the ship service."@en ;
+                             rdfs:label "port morski - obiekt"@pl ,
+                                        "sea harbour"@en ;
+                             rdfs:seeAlso <http://dbpedia.org/ontology/Port> ,
+                                          <https://www.wikidata.org/wiki/Q15310171> ,
+                                          "przybrzeżny obszar wodny, odpowiednio pogłębiony, osłonięty przed wiatrem i falą, przeznaczony dla postoju statków, wyposażony w specjalne urządzenia służące do ich załadowywania, wyładowywania, zaopatrzenia i naprawy; miasto  nabrzeżne, w którym jest także miejsce postoju statków."@pl ,
+                                          "t. 2, cz. 2. s. 929: część można między ziemią zamknięta, do którey okręty wchodzą o od burzy morskiey bezpieczeństwo znayduią"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "port morski"@pl ,
+                                                                             "sea harbour"@en ;
+                             ontohgis:hasExternalIdentifier "115"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 ,
+                                                    ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_115 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "przybrzeżny obszar wodny, odpowiednio pogłębiony, osłonięty przed wiatrem i falą, przeznaczony dla postoju statków, wyposażony w specjalne urządzenia służące do ich załadowywania, wyładowywania, zaopatrzenia i naprawy; miasto  nabrzeżne, w którym jest także miejsce postoju statków."@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_115 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 2, cz. 2. s. 929: część można między ziemią zamknięta, do którey okręty wchodzą o od burzy morskiey bezpieczeństwo znayduią"@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+
+ontohgis:settlement_type_117 rdfs:comment "Although tourist shelter is nowadays classified as a kind of village (PRNG, DBTO10k), it seems that the tourist shelters were not considered localites in the period of our interest. This is due to the lack of this category in Bystrzycki's register, as well as the way of presentation on the maps: without the particular name, only symbol and explanatory abbreviation. Conceptually, this category is similar to shepherd's huts and inns (see: example)."@en ,
+                                          "Mimo że dziś figuruje jako rodzaj miejscowości (PRNG, BDOT10k), wydaje się, że schronisko turystyczne nie było w interesującym nas okresie uznawane za miejscowość. Świadczy o tym brak wyróżnienia tej kategorii w spisie Bystrzyckiego, jak również sposób prezentacji na mapach: bez nazwy własnej, jedynie sygnatura i skrótem objaśniającym. Pojęciowo kategoria zbliżona do szałasów pasterskich i karczem (patrz przykład)."@pl ;
+                             rdfs:isDefinedBy "Schronisko turystyczne to budynek na szlaku turystycznym służący jako miejsce odpoczynku i noclegu dla turystów."@pl ,
+                                              "Tourist shelter is a building on the tourist trail that serves as a place of rest and accommodation for tourists."@en ;
+                             rdfs:label "schronisko turystyczne - obiekt"@pl ,
+                                        "tourist shelter"@en ;
+                             rdfs:seeAlso <http://dbpedia.org/page/Mountain_hut> ,
+                                          <https://pzgik.geoportal.gov.pl/ontologies/prng/schroniskoTurystyczne> ,
+                                          <https://www.wikidata.org/wiki/Q182676> ,
+                                          "1] miejsce, gdzie można się schronić, czuć bezpiecznie, schronienie; [2] budynek położony na szlaku turystycznym z dala od osiedli ludzkich, służący jako miejsce odpoczynku i noclegu dla turystów (podróżnych); [3] przytułek, zakład dla bezdomnych, starców"@pl ,
+                                          "budynek na szlaku turystycznym służący jako miejsce odpoczynku i noclegu dla turystów (kategorie: budynki, budowle i urządzenia; kompleksu użytkowania terenu, miejscowości)"@pl ,
+                                          "t. 5, s. 201 – mieysce do schronienia"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "karczma"@pl ,
+                                                                               "schronisko"@pl ,
+                                                                               "schronisko górskie"@pl ,
+                                                                               "stacja turystyczna"@pl ,
+                                                                               "szałas"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "schronisko turystyczne"@pl ,
+                                                                             "tourist shelter"@en ;
+                             ontohgis:hasExternalIdentifier "117"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_117 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "1] miejsce, gdzie można się schronić, czuć bezpiecznie, schronienie; [2] budynek położony na szlaku turystycznym z dala od osiedli ludzkich, służący jako miejsce odpoczynku i noclegu dla turystów (podróżnych); [3] przytułek, zakład dla bezdomnych, starców"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_117 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "budynek na szlaku turystycznym służący jako miejsce odpoczynku i noclegu dla turystów (kategorie: budynki, budowle i urządzenia; kompleksu użytkowania terenu, miejscowości)"@pl ;
+   rdfs:comment ontohgis:document_9
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_117 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 5, s. 201 – mieysce do schronienia"@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+
+ontohgis:settlement_type_118 rdfs:comment "Functional distinctivness - clearly defined (passenger services).Morphological distinctiveness - on the maps, mostly as a non-scale symbols and an explanatory annotation.Spatial distinctivness - depending on the location of the railway line with the respect of locality, stations are either at a distance (often they have a given name, such as a town and the number of houses) or in the area of the locality (without a proper name, only a symbol and an explanatory annotation).Railway station can be part of a locality (Czekanów) or a separate locality (Chrośnica), then spatially distinct. If the station is located far away from the locality, then on the MGI maps it can be supplemeted by information about number of houses, not just the explanatory annotation (pol \"st.\"). The name of the station is never a proper name name but only the name of the main locality."@en ,
+                                          "Odrębność funkcjonalna – jasno określona (obsługa podróżnych).Odrębność morfologiczna – najczęściej na mapach jako znak nieskalowy i podpis objaśniający.Odrębność przestrzenna – w zależności od położenia linii kolejowej względem miejscowości stacje znajdują się albo w oddaleniu (wtedy często mają podaną nazwę, taką jak miejscowość oraz liczbę domów) lub na obszarze miejscowości (bez nazwy; tylko sygnatura i skrót objaśniający).Stacja kolejowa może być częścią miejscowości (Czekanów) albo osobną miejscowością (Chrośnica) wyodrębnioną przestrzennie. Jeżeli stacja leży w oddaleniu od głównej miejscowości (wówczas na mapie WIG ma podaną liczbę domów, a nie tylko skrót objaśniający „st.”). Nazwa stacji nigdy nie jest nazwą własną, a jedynie nazwą głównej miejscowości."@pl ;
+                             rdfs:isDefinedBy "Stacja kolejowa to obszar, gdzie rozmieszczone są budowle związane z obsługą pasażerów kolei naziemnych."@pl ,
+                                              "The railway station is an area where facilities related to the service of ground railway passengers are located."@en ;
+                             rdfs:label "railway station"@en ,
+                                        "stacja kolejowa - obiekt"@pl ;
+                             rdfs:seeAlso "#BDOT10k, s. 154 – Obszar, na którym rozmieszczone są budowle (budynek stacyjny, magazyny, przechowalnia bagażu, perony, parkingi itp.), związane z obsługą pasażerów kolei naziemnych i przeładunkiem towarów (klasa obiektów: kompleks komunikacyjny)"@pl ,
+                                          "miejsce, gdzie zatrzymują się pociągi"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "Haltestation (de)" ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "przystanek kolejowy (pl), dworzec kolejowy (pl)" ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "railway station"@en ,
+                                                                             "stacja kolejowa"@pl ;
+                             ontohgis:hasExternalIdentifier "118"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_118 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "miejsce, gdzie zatrzymują się pociągi"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+
+ontohgis:settlement_type_119 rdfs:comment "Functional distinctivness - clearly defined (passenger services).Morphological distinctiveness - most often on topographic maps as a non-scale symbol or an explanatory annotation, usually without a proper name (only an abbreviation).Spatial distinctivness - depending on the location of the railway line with respect to the locality, the stops are either located at a distance (then they often have a proper name, the same as a locality) or within the area of the locality (no particular name, only symbol or an explanatory annotation). A railway station should rather not be treated as a locality, unless in exceptional cases, when all the constitutive conditions of localities are met."@en ,
+                                          "Odrębność funkcjonalna – jasno określona (obsługa podróżnych).Odrębność morfologiczna – najczęściej na mapach jako znak nieskalowy obszaru przystanku i podpis objaśniający, przeważnie bez nazwy własnej (jedynie skrót).Odrębność przestrzenna – w zależności od położenia linii kolejowej względem miejscowości przystanki znajdują się albo w oddaleniu (wtedy często mają podaną nazwę, taką jak miejscowość) lub na obszarze miejscowości (bez nazwy; tylko sygnatura i skrót objaśniający). Przystanek kolejowy raczej nie powinien być traktowany jako miejscowość, chyba że w wyjątkowych przypadkach, gdy spełnione są wszystkie warunki konstytutywne miejscowości."@pl ;
+                             rdfs:isDefinedBy "A train stop is a stopping place for trains enabling travelers to enter or leave the train."@en ,
+                                              "Przystanek kolejowy to miejsce zatrzymywania się pociągów umożliwiające podróżnym wejście lub opuszczenie pociągu."@pl ;
+                             rdfs:label "przystanek kolejowy - obiekt"@pl ,
+                                        "train stop"@en ;
+                             rdfs:seeAlso "#BDOT10k, s. 166 – miejsce zatrzymywania się pociągów, umożliwiające podróżnym wejście lub opuszczenie pociągu (klasa obiektów: obiekt związany z komunikacją)"@pl ,
+                                          "mała stacja kolejowa przeznaczona tylko dla ruchu pasażerskiego"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "Haltepunkt (de)" ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Stacja kolejowa (pl), dworzec kolejowy (pl)" ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "przystanek kolejowy"@pl ,
+                                                                             "train stop"@en ;
+                             ontohgis:hasExternalIdentifier "119"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_119 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "mała stacja kolejowa przeznaczona tylko dla ruchu pasażerskiego"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+
+ontohgis:settlement_type_12 rdfs:comment "It is very unusual to classify a sugar factory or refinery as a separate locality, most often it is a part of a locality."@en ,
+                                         "W niezwykle rzadkich przypadkach cukrownia może być odrębną miejscowością, zazwyczaj jest częścią miejscowości."@pl ;
+                            rdfs:isDefinedBy "Cukrownia (miejscowość) jest to osada, w której główną rolę odgrywa cukrownia (obiekt)."@pl ,
+                                             "Sugar rafinery (a locality) is a settlement with a sugar factory or refinery (a factory) as the most important element."@en ;
+                            rdfs:label "cukrownia"@pl ,
+                                       "sugar factory"@en ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "die Zuckerfabrik"@de ,
+                                                                              "die Zuckersiederei"@de ,
+                                                                              "Сахарный завод"@ru ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "cukrownia"@pl ,
+                                                                            "sugar factory"@en ;
+                            ontohgis:hasExternalIdentifier "12" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
+
+
+ontohgis:settlement_type_120 rdfs:comment "A church could be a separate unit (from adjacent settlements) distinguished by a particular name and morphology."@en ,
+                                          "W analizowanych przypadkach kościół mógł stanowić odrębną (od sąsiadujących) nazewniczo i morfologicznie jednostkę osadniczą."@pl ;
+                             rdfs:isDefinedBy "A church (in architecture) is a building used by a religious community to meet and listen to the Word of God, for preaching, private prayers or to celebrate rituals."@en ,
+                                              "Kościół (w kontekście architektonicznym) jest to budynek, gdzie wspólnota religijna gromadzi się na słuchanie słowa Bożego, wspólną lub prywatną modlitwę oraz celebrację sakramentów."@pl ;
+                             rdfs:label "church"@en ,
+                                        "kościół - obiekt"@pl ;
+                             rdfs:seeAlso <http://linkedgeodata.org/ontology/BuildingChurch> ,
+                                          <http://plwordnet.pwr.wroc.pl/wordnet/3210a0be-28e9-11eb-8b1d-fb60577b06bc> ,
+                                          <https://dbpedia.org/ontology/Church> ,
+                                          <https://www.wikidata.org/wiki/Q16970> ,
+                                          "2. «budynek, miejsce modlitwy chrześcijan»"@pl ,
+                                          "t. 11, s. 57-68: II. Budowla sakralna; 1. Świątynia chrześcijańska, zwłaszcza katolicka; templum--; aedes, fanum--; ecclesia--; aedes sacra--; sacrum--; domus, sedes sacra--; delubrum, dominicum, domus Dei, martyrium, sacrarium ritus Christiani--. 3. Świątynia mahometańska; meczet--. 4. Świątynia pogańska, delubrum--; aedes, oraculum, templum--; templum idolorum--; idolium--; domus--; aedes sacra, fanum, penetralia, sessimonium deorum--. 6. n-loc [nazwa miejsca] : -- »Czerwony Kościoł«"@pl ,
+                                          "t. 3, s. 360-362: 1. Świątynia (nie tylko chrześcijańska), dom boży, templum, aedes sacra--. 2. swoista jednostka prawna związana z określonym kościołem (parafia, diecezja itd.), corpus paroeciae vel dioecesis (ad certam quandam ecclesiam pertinens)."@pl ,
+                                          "t. 9, kol. 1025: budynek poświęcony (dedykacja lub benedykcja) w obrzędzie liturg. przez biskupa, gdzie wspólnota ochrzczonych (—> Kościół) gromadzi się na słuchanie słowa Bożego, wspólną i prywatną modlitwę oraz celebrację sakramentów, zwł. Eucharystii; miejsce przechowywania Najśw. Sakramentu, a także pochówku(—> krypta, —> konfesja); k. był określany także jako domus ecclesiae, domus orationis, Kyriakon, domus Dei, Dominicum; w kat. obrządkach wsch. nazywany jest —> cerkwią."@pl ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "ecclesia (lat), templum (lat), fanum (lat), aedes (lat), domus Dei (lat), kaplica (pl), cerkiew (pl), świątynia (pl), die Kirche (de)" ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "church"@en ,
+                                                                             "kościół"@pl ;
+                             ontohgis:hasExternalIdentifier "120"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_120 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "2. «budynek, miejsce modlitwy chrześcijan»"@pl ;
+   rdfs:isDefinedBy ontohgis:document_3 ,
+                    <https://sjp.pwn.pl/sjp/kosciol;2474550.html>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_120 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 11, s. 57-68: II. Budowla sakralna; 1. Świątynia chrześcijańska, zwłaszcza katolicka; templum--; aedes, fanum--; ecclesia--; aedes sacra--; sacrum--; domus, sedes sacra--; delubrum, dominicum, domus Dei, martyrium, sacrarium ritus Christiani--. 3. Świątynia mahometańska; meczet--. 4. Świątynia pogańska, delubrum--; aedes, oraculum, templum--; templum idolorum--; idolium--; domus--; aedes sacra, fanum, penetralia, sessimonium deorum--. 6. n-loc [nazwa miejsca] : -- »Czerwony Kościoł«"@pl ;
+   rdfs:isDefinedBy ontohgis:document_2
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_120 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 3, s. 360-362: 1. Świątynia (nie tylko chrześcijańska), dom boży, templum, aedes sacra--. 2. swoista jednostka prawna związana z określonym kościołem (parafia, diecezja itd.), corpus paroeciae vel dioecesis (ad certam quandam ecclesiam pertinens)."@pl ;
+   rdfs:isDefinedBy ontohgis:document_6
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_120 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 9, kol. 1025: budynek poświęcony (dedykacja lub benedykcja) w obrzędzie liturg. przez biskupa, gdzie wspólnota ochrzczonych (—> Kościół) gromadzi się na słuchanie słowa Bożego, wspólną i prywatną modlitwę oraz celebrację sakramentów, zwł. Eucharystii; miejsce przechowywania Najśw. Sakramentu, a także pochówku(—> krypta, —> konfesja); k. był określany także jako domus ecclesiae, domus orationis, Kyriakon, domus Dei, Dominicum; w kat. obrządkach wsch. nazywany jest —> cerkwią."@pl ;
+   rdfs:isDefinedBy ontohgis:document_7
+ ] .
+
+
+ontohgis:settlement_type_121 rdfs:comment "In each analysed case, a rectory being a separate settlement, lays in a vicinity of a village, or a town/city with the same name. In cartographical sources, one can find it presented separately, with its proper name, an abbreviation of a category (i.e. pol “pleb.”, which is “rect.”), and distinguished by its morphology. A rectory differs slightly from the house of a provost, but we leave this difference aside."@en ,
+                                          "We wszystkich analizowanych przypadkach jeżeli plebania jest odrębną miejscowością, to znajduje się w pobliżu wsi, miasta lub osady o tej samej nazwie. W ujęciu kartograficznym wyodrębniona przez nazwę własną, skrót kategorii (np. pleb.) oraz morfologicznie. Plebania różni się nieco od probostwa, gdyż pleban nie jest tożsamy z proboszczem, ale różnicę tę pomijamy."@pl ;
+                             rdfs:isDefinedBy "A rectory is a house or a group of buildings organised for a home for a provost supervising other priests living with him together with other people responsible for its maintenance."@en ,
+                                              "Plebania jest to dom lub zespół zabudowań przeznaczony do mieszkania dla plebana, podległych mu księży i innych osób zajmujących się jego obsługą."@pl ;
+                             rdfs:label "plebania - obiekt"@pl ,
+                                        "rectory"@en ;
+                             rdfs:seeAlso <http://dbpedia.org/page/Clergy_house> ,
+                                          <http://vocab.getty.edu/aat/300005639> ,
+                                          <https://www.wikidata.org/wiki/Q607241> ,
+                                          "dom należący do parafii, przeznaczony na mieszkanie dla proboszcza"@pl ,
+                                          "t. 2, cz. 2, s. 732: Pleban -- Plebania, -ii, ż., urząd plebański abo beneficjum --; Dochód plebański, ut dobra --; plebaniia, dom plebański, die Pfarrwohnung, die Pfarre. J ksiądz widzimy, plebaniią rzadki Buduie, że kto inszy weźmie po nim spadki. Pot. Pocz. 475 (Slo. fara; Hg. plebania; Cro. plebania; Vd. faroush; Ross. приходъ (cf. przychód)."@pl ,
+                                          "t. 24, s. 326: 1. Domostwo plebana -- ; flaminia -- ; parochia, plebanatus -- ; curionis domus, curionium --; 2. Terytorium będące pod opieką plebana; także urząd i dochody z niego; parochia --; plebanatus --; curionatus, curionium -- ; 2a. Wierni należący do parafii --. Synonimy: probostwo, parafija."@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "Pfarrwohnung"@de ,
+                                                                            "curionis domus"@la ,
+                                                                            "dom plebański"@pl ,
+                                                                            "pastorówka"@pl ,
+                                                                            "plebanatus"@la ,
+                                                                            "popówka"@pl ,
+                                                                            "probostwo"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Pfarre"@de ,
+                                                                               "curionatus"@la ,
+                                                                               "curionium"@la ,
+                                                                               "parafia"@pl ,
+                                                                               "parochia"@la ,
+                                                                               "wikariatka"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "plebania"@pl ,
+                                                                             "rectory"@en ;
+                             ontohgis:hasExternalIdentifier "121"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_121 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "dom należący do parafii, przeznaczony na mieszkanie dla proboszcza"@pl ;
+   rdfs:isDefinedBy ontohgis:document_3
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_121 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 2, cz. 2, s. 732: Pleban -- Plebania, -ii, ż., urząd plebański abo beneficjum --; Dochód plebański, ut dobra --; plebaniia, dom plebański, die Pfarrwohnung, die Pfarre. J ksiądz widzimy, plebaniią rzadki Buduie, że kto inszy weźmie po nim spadki. Pot. Pocz. 475 (Slo. fara; Hg. plebania; Cro. plebania; Vd. faroush; Ross. приходъ (cf. przychód)."@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_121 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 24, s. 326: 1. Domostwo plebana -- ; flaminia -- ; parochia, plebanatus -- ; curionis domus, curionium --; 2. Terytorium będące pod opieką plebana; także urząd i dochody z niego; parochia --; plebanatus --; curionatus, curionium -- ; 2a. Wierni należący do parafii --. Synonimy: probostwo, parafija."@pl ;
+   rdfs:isDefinedBy ontohgis:document_2
+ ] .
+
+
+ontohgis:settlement_type_122 rdfs:comment "Kryterium wyróżniającym kościół od kaplicy jest wielkość oraz znaczenie instytucjonalne. Kościół ma charakter świątyni głównej dla wspólnoty wiernych, natomiast kaplica ma znaczenie pomocnicze. Niewielkie wspólnoty wiernych mogły funkcjonować przy kaplicy, kiedy z różnych powodów (brak środków, ograniczenia prawne) nie mogły wybudować lub utrzymać kościoła."@pl ,
+                                          "The criterion that distinguishes the church from the chapel is its size and institutional significance. The church serves as a main temple for the community, while the chapel's role is rather auxiliary. Small communities could use a chapel, when for various reasons (lack of resources, legal restrictions) they could not build or afford a church."@en ;
+                             rdfs:isDefinedBy "Chapel is a separate building (small church) or a separate room with an altar in a church or another building, devoted to religious worship (prayer, worship)."@en ,
+                                              "Kaplica jest to odrębny budynek (mały kościół) lub oddzielne pomieszczenie z ołtarzem w kościele lub innym budynku, przeznaczone do sprawowania kultu religijnego (modlitwy, nabożeństwa)."@pl ;
+                             rdfs:label "chapel"@en ,
+                                        "kaplica - obiekt"@pl ;
+                             rdfs:seeAlso <http://linkedgeodata.org/ontology/BuildingChapel> ,
+                                          <http://plwordnet.pwr.wroc.pl/wordnet/31c75b34-28e9-11eb-89c7-03aa60bf5f82> ,
+                                          <https://www.wikidata.org/wiki/Q108325> ,
+                                          "1. «niewielka budowla sakralna», 2. «oddzielne pomieszczenie z ołtarzem do odprawiania nabożeństw»"@pl ,
+                                          "t. 1, cz 2, s. 955: miejsce bogu poświęcone, w którym obowiązki kościelne za zezwoleniem zwierzchności odprawować się mogą."@pl ,
+                                          "t. 10, s. 81: Mały kościół lub nieduże pomieszczenie z ołtarzem, przeznaczone do uprawiania kultu religijnego; też wydzielona część kościoła (wyraz przeniesiony również na świątynie i pomieszczenia służące innym kultom); sacellum --; aedicula --; sacrarium--; oratorium--; aedes, fanum--; aedis sacrae appendix, augurale, auguratorium, fanulum (s. hanulum), lararium, parvum delubrum"@pl ,
+                                          "t. 8, kol. 676: niewielka budowla kultowa (najczęściej z ołtarzem), wolno stojąca lub związana z większym kompleksem archit., także pomieszczenie, czyli oratorium, miejsce modlitwy liturg. i prywatnej, przeznaczone przez ordynariusza do sprawowanie wszystkich lub niektórych funkcji liturg. dla niewielkiej grupy wiernych, do którego za zgodą kompetentnego przełożonego mogą przychodzić także in. wierni."@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "capella (lat)" ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "kościół (pl), oratorium (pl), świątynia (pl), sacellum (łac), oratorium (lat), aedicula (lat), sacrarium (lat), aedes (lat), fanum (lat), augurale (lat), augurale (lat), auguratorium (lat), fanulum (lat), lararium (lat), delubrum (lat), die Kapelle (de)" ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "chapel"@en ,
+                                                                             "kaplica"@pl ;
+                             ontohgis:hasExternalIdentifier "122"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_122 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "1. «niewielka budowla sakralna», 2. «oddzielne pomieszczenie z ołtarzem do odprawiania nabożeństw»"@pl ;
+   rdfs:isDefinedBy ontohgis:document_3 ,
+                    <https://sjp.pwn.pl/szukaj/kaplica.html>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_122 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 1, cz 2, s. 955: miejsce bogu poświęcone, w którym obowiązki kościelne za zezwoleniem zwierzchności odprawować się mogą."@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_122 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 10, s. 81: Mały kościół lub nieduże pomieszczenie z ołtarzem, przeznaczone do uprawiania kultu religijnego; też wydzielona część kościoła (wyraz przeniesiony również na świątynie i pomieszczenia służące innym kultom); sacellum --; aedicula --; sacrarium--; oratorium--; aedes, fanum--; aedis sacrae appendix, augurale, auguratorium, fanulum (s. hanulum), lararium, parvum delubrum"@pl ;
+   rdfs:isDefinedBy ontohgis:document_2
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_122 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 8, kol. 676: niewielka budowla kultowa (najczęściej z ołtarzem), wolno stojąca lub związana z większym kompleksem archit., także pomieszczenie, czyli oratorium, miejsce modlitwy liturg. i prywatnej, przeznaczone przez ordynariusza do sprawowanie wszystkich lub niektórych funkcji liturg. dla niewielkiej grupy wiernych, do którego za zgodą kompetentnego przełożonego mogą przychodzić także in. wierni."@pl ;
+   rdfs:isDefinedBy ontohgis:document_7
+ ] .
+
+
+ontohgis:settlement_type_123 rdfs:comment "In most analysed cases, if the tar pitch was morphologically distinct, it had the same name as the neighbouring village or another locality. Occasionally it had its proper name."@en ,
+                                          "W większości analizowanych przypadków, jeżeli smolarnia była odrębna morfologicznie, to miała tę samą nazwę, co sąsiadująca wieś lub inna miejscowość. Sporadycznie cechowała ją odrębność nazewnicza."@pl ;
+                             rdfs:isDefinedBy "Obiekt lub zespół obiektów gospodarczych zlokalizowanych w lesie lub jego pobliżu, gdzie w procesie prażenia drewna pozyskiwano smołę i inne produkty np. terpentynę, węgiel drzewny."@pl ,
+                                              "Tar pitch is a facility or a complex of industrial facilities located in or near the forest, where tar was sourced in the process of wood roasting, along with other products, e.g. turpentine, charcoal."@en ;
+                             rdfs:label "smolarnia - obiekt"@pl ,
+                                        "tar pitch"@en ;
+                             rdfs:seeAlso "huta smolana, t. 3, s. 519:"@pl ,
+                                          "prymitywny zakład przemysłowy, gdzie wypraża się z drewna (tzw. karpowin) smołę i otrzymuje terpentynę, spirytus drzewny i inne chemikalia"@pl ,
+                                          "«dawny zakład, w którym się wyprażało z drewna smołę»"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "der Teerofen (de), smolanoi zawod (ru)" ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "terpentyniarnia (pl), osada leśna (pl), dziegciarnia (pl), huta (pl)" ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "smolarnia"@pl ,
+                                                                             "tar pitch"@en ;
+                             ontohgis:hasExternalIdentifier "123"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_123 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "huta smolana, t. 3, s. 519:"@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_123 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "prymitywny zakład przemysłowy, gdzie wypraża się z drewna (tzw. karpowin) smołę i otrzymuje terpentynę, spirytus drzewny i inne chemikalia"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4 ,
+                    <https://sjp.pwn.pl/doroszewski/smolarnia;5498496.html>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_123 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "«dawny zakład, w którym się wyprażało z drewna smołę»"@pl ;
+   rdfs:isDefinedBy ontohgis:document_3 ,
+                    <https://sjp.pwn.pl/sjp/smolarnia;2522097.html>
+ ] .
+
+
+ontohgis:settlement_type_124 rdfs:comment "Inns (localities) are distinguished on the old maps, which is mainly the result of their function. In the historiography, inns are distinguished from \"zajazd\" and \"gościniec\".The former usually served local customers - residents of the village or city, whereas the latter was supposed to serve supra-regional traffic. On the maps, inns are also distinguished by their proper names - e.g. Wygoda or Ostatni Grosz."@en ,
+                                          "Karczmy wyróżniane są na dawnej kartografii, co wynika głównie z pełnionej przez nie funkcji. Warto jednak pamiętać o tym, że w historiografii rozróżnia się pojęcie karczmy oraz zajazdu lub gościńca. Pierwszy obiekt zazwyczaj miał na celu obsługę lokalnych klientów – mieszkańców wsi lub miasta, drugi zaś miał obsługiwać ruch ponadregionalny. Na mapach karczmy wyróżniają także specyficzne nazwy – np. Wygoda lub Ostatni Grosz."@pl ;
+                             rdfs:isDefinedBy "Budynek służący celom gastronomiczno-hotelarskim, zlokalizowany na przedmieściach miast, obrzeżach wsi lub ważnych szlakach komunikacyjnych."@pl ,
+                                              "Inn is a building serving catering and accomodation purposes, located in the suburbs, outskirts of villages, or on important communication routes."@en ;
+                             rdfs:label "inn"@en ,
+                                        "karczma - obiekt"@pl ;
+                             rdfs:seeAlso <http://dbpedia.org/page/Inn> ,
+                                          <https://www.wikidata.org/wiki/Q32860419> ,
+                                          "t. 1, s. 296–298: ‘budynek, w którym warzono, sprzedawano, później głównie szynkowano piwo, miód pitny, od XVI w. gorzałkę; niektóre karczmy, zwłaszcza przy ważniejszych drogach i w miastach, dawały posiłki i obrok dla koni oraz zapewniały nocleg podróżnym (zwano je gościńcami); sprzedawano w nich różne wyroby, głównie spożywcze, rzadziej odzieżowe. Dostarczały też karczmy różnego rodzaju rozrywek, często z muzyką, były miejscem tańców i zabaw. Niekiedy w karczmach odbywał sesje sąd (zwłaszcza wiejski), załatwiano tu sprawy urzędowe podczas popasu dostojników czy pobytu miejscowych oficjalistów [...]’."@pl ,
+                                          "t. 10, s. 136: miejsce wyszynku alkoholu i spotkań okolicznej ludności, przede wszystkim chłopów, także gospoda, dom zajezdny; taberna"@pl ,
+                                          "t. 15, s. 403: ‘budynek służący jako dom zajezdny dla podróżnych, a także miejsce wyszynku oraz spotkań i zabaw miejscowej ludności, wznoszony na przedmieściach większych miast, na rynkach miasteczek, przy uczęszczanych traktach, we wsiach w pobliżu kościoła lub dworu’"@de ,
+                                          """t. 2, s. 264: 1. dom szynkowy (Star.), szynk, szynkownia, gospoda; do na wsi albo przy drodze dla popasu podróżnych, austerja, oberża, dom zajezdny, zajazd’, 
+[por. t. 3, s. 453 hasło: oberża ‘dom gościnny, gospoda, zajazd, karczma, austerja’ i 
+t. 8, s. 106 hasło zajazd, gdzie ‘dom zajezdny, gospoda, austerja, karczma, dom gościnny’]"""@pl ,
+                                          "t. 2, s. 318: dom szynkowy"@pl ,
+                                          "t. 3, s. 564: szynk na wsi, gospoda; dawniej również dom zajezdny, austeria, oberża"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "Gasthof"@de ,
+                                                                            "Krug"@de ,
+                                                                            "Wirthaus"@de ,
+                                                                            "gospoda"@pl ,
+                                                                            "taberna"@la ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "budynek"@pl ,
+                                                                               "gościniec"@pl ,
+                                                                               "gościnny dom"@pl ,
+                                                                               "oberża"@pl ,
+                                                                               "restauracja"@pl ,
+                                                                               "szynkowny dom"@pl ,
+                                                                               "zajazd"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "inn"@en ,
+                                                                             "karczma"@pl ;
+                             ontohgis:hasExternalIdentifier "124"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_124 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 1, s. 296–298: ‘budynek, w którym warzono, sprzedawano, później głównie szynkowano piwo, miód pitny, od XVI w. gorzałkę; niektóre karczmy, zwłaszcza przy ważniejszych drogach i w miastach, dawały posiłki i obrok dla koni oraz zapewniały nocleg podróżnym (zwano je gościńcami); sprzedawano w nich różne wyroby, głównie spożywcze, rzadziej odzieżowe. Dostarczały też karczmy różnego rodzaju rozrywek, często z muzyką, były miejscem tańców i zabaw. Niekiedy w karczmach odbywał sesje sąd (zwłaszcza wiejski), załatwiano tu sprawy urzędowe podczas popasu dostojników czy pobytu miejscowych oficjalistów [...]’."@pl ;
+   rdfs:isDefinedBy ontohgis:document_17
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_124 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 10, s. 136: miejsce wyszynku alkoholu i spotkań okolicznej ludności, przede wszystkim chłopów, także gospoda, dom zajezdny; taberna"@pl ;
+   rdfs:isDefinedBy ontohgis:document_2
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_124 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 15, s. 403: ‘budynek służący jako dom zajezdny dla podróżnych, a także miejsce wyszynku oraz spotkań i zabaw miejscowej ludności, wznoszony na przedmieściach większych miast, na rynkach miasteczek, przy uczęszczanych traktach, we wsiach w pobliżu kościoła lub dworu’"@de ;
+   rdfs:isDefinedBy ontohgis:document_137
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_124 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget """t. 2, s. 264: 1. dom szynkowy (Star.), szynk, szynkownia, gospoda; do na wsi albo przy drodze dla popasu podróżnych, austerja, oberża, dom zajezdny, zajazd’, 
+[por. t. 3, s. 453 hasło: oberża ‘dom gościnny, gospoda, zajazd, karczma, austerja’ i 
+t. 8, s. 106 hasło zajazd, gdzie ‘dom zajezdny, gospoda, austerja, karczma, dom gościnny’]"""@pl ;
+   rdfs:isDefinedBy ontohgis:document_5
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_124 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 2, s. 318: dom szynkowy"@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_124 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 3, s. 564: szynk na wsi, gospoda; dawniej również dom zajezdny, austeria, oberża"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+
+ontohgis:settlement_type_125 rdfs:isDefinedBy "Ironworks (locality) is a settlement, where the main role is played by an ironworks, an industrial facility."@en ,
+                                              "Osada kuźnicza jest to osada, w której główną rolę pełni kuźnica jako obiekt gospodarczy."@pl ;
+                             rdfs:label "ironworks"@en ,
+                                        "osada kuźnicza"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "Hammer (de), minera (lat), ruda (pl), Hütte (de), Ofen (de), Schmelze (de)" ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "kuźnica"@pl ,
+                                                                               "ruda"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "ironworks"@en ,
+                                                                             "osada kuźnicza"@pl ;
+                             ontohgis:hasExternalIdentifier "125"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
+
+
+ontohgis:settlement_type_126 rdfs:isDefinedBy "Ironworks is a cluster of manufacturing workshops, the main puprpose of which is to melt and manufacture iron."@en ,
+                                              "Zespół warsztatów przemysłowych, których głównym zadaniem jest przetop i obróbka żelaza."@pl ;
+                             rdfs:label "ironworks"@en ,
+                                        "kuźnica - obiekt"@pl ;
+                             rdfs:seeAlso "#Zientara B., Dzieje małopolskiego hutnictwa żelaznego, Warszaw 1954, s. 64‘zespół połączonych warsztatów – dymarki, młotów, kowalichy (piec kowalski i urządzenia służące do produkcji różnych przedmiotów z żelaza)’#Praktyczny słownik współczesnej polszczyzny, red. H. Zgłówkowa, t. 18, s. 369‘dawny typ zakładu hutniczego, w którym żelazo z rud wytapiano za pomocą dymarki i młota napędzanego kołem wodnym’ – dodatkowo inf., że „kuźnice zostały wyparte przez zakłady stosujące procesy wielkopiecowe”#Encyklopedia historii gospodarczej Polski do 1945 r., t. 1, red. A. Mączak:‘w XIII–XVIII w. zespół warsztatów zakładu hutniczego, składający się w zasadzie z dymarki, młota mechanicznego i pieca kowalskiego (kowalichy), niekiedy także ze stęp do drobienia rudy; wszystkie te warsztaty (czasem podwójne) poruszane były energią wodną, uzyskiwaną dzięki budowie zapór na niewielkich rzeczkach. Hamrem (hamernią) zwano wchodzący w skład każdej kuźnicy warsztat obróbki metali, którego głównym urządzeniem był młot mechaniczny z kowadłem; niekiedy jednak przez hamer rozumiano całą kuźnicę. Upowszechnione w Polsce od przełomu XIII/XIV w., stanowiły kuźnice do XVIII w. dominujący typ zakładu hutniczego, tworzącego jednocześnie odrębne przedsiębiorstwo prowadzone przez kuźnika [...]”. Autor hasła B. Zientara"@pl ,
+                                          "t. 11, s. 598: ‘zakład przetapiający i obrabiający żelazo’, ‘warsztat kowalski; miejsce, gdzie się kuje’"@pl ,
+                                          "t. 2, s. 561: utożsamia pojęcia kuźnia i kuźnica, podaje też termin bliskoznaczny kowalnia"@pl ,
+                                          "t. 2, s. 653: ‘zabudowanie mieszczące w sobie jedno albo kilka ognisk, miechy i młoty poruszane przez wodę, gdzie z surowizny przetopionej i oczyszczonej wykuwa się żelazo gotowe; fabryka topienia żelaza i urabiana go w sztaby"@pl ,
+                                          "t. 3, s. 1328: zakład przemysłowy, fabryka wyrobów z żelaza itp. metali; dawniej kuźnia"@pl ,
+                                          "t. 3, s.473–474: ‘warsztat wytopu i obróbki żelaza’"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "Hütte (de), huta (pl), hamer (pl), Hammer (de), minera (lat), hamernia (pl), amernia (pl), oficina ferraria (lat), ferrifonda (lat), ruda (pl)" ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "kuźnia (pl), fryszerka (pl), huta żelaza (pl), zakład przemysłowy (pl), mennica (pl)" ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "ironworks"@en ,
+                                                                             "kuźnica"@pl ;
+                             ontohgis:hasExternalIdentifier "126"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_126 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 11, s. 598: ‘zakład przetapiający i obrabiający żelazo’, ‘warsztat kowalski; miejsce, gdzie się kuje’"@pl ;
+   rdfs:isDefinedBy ontohgis:document_2
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_126 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 2, s. 561: utożsamia pojęcia kuźnia i kuźnica, podaje też termin bliskoznaczny kowalnia"@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_126 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 2, s. 653: ‘zabudowanie mieszczące w sobie jedno albo kilka ognisk, miechy i młoty poruszane przez wodę, gdzie z surowizny przetopionej i oczyszczonej wykuwa się żelazo gotowe; fabryka topienia żelaza i urabiana go w sztaby"@pl ;
+   rdfs:isDefinedBy ontohgis:document_5
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_126 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 3, s. 1328: zakład przemysłowy, fabryka wyrobów z żelaza itp. metali; dawniej kuźnia"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_126 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 3, s.473–474: ‘warsztat wytopu i obróbki żelaza’"@pl ;
+   rdfs:isDefinedBy ontohgis:document_6
+ ] .
+
+
+ontohgis:settlement_type_127 rdfs:comment "Glasswork settlement (ger Hütte) was considered a separate locality, which emerged as consequence of a process in which common names (i.e. huta) gained new meaning, associated with a particular locality. Glasswork settlements were temporary settlements, very often, these were very unstable. When all local resources became exhausted (i.e. woods, sand, limestone), these settlements were moved into a new place. The result was frequent disappearing of glasswork settlements."@en ,
+                                          "Odrębność osadnicza osady hutniczej (od ger Hütte) wynika przede wszystkim z procesu onimizacji, czyli przekształcania nazwy pospolitej (huta) w nazwę własną. Osady hutnicze były często osadami czasowymi, tzn. cechowały się dużą mobilnością. Po wyczerpaniu się pobliskich surowców (drewno, piasek, wapień) przenoszone były w inne miejsca. W związku z tym były to osady zanikające z krajobrazu osadniczego."@pl ;
+                             rdfs:isDefinedBy "Glassworks is a settlement in which the most importan role is played by a glassworks (considered as an factory building)."@en ,
+                                              "Osada hutnicza jest to osada, w której główną rolę pełni huta jako obiekt gospodarczy."@pl ;
+                             rdfs:label "glassworks"@en ,
+                                        "osada hutnicza"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "Hütte (de), Ofen (de), Schmelze (de), Hammer (de)" ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "kuźnica"@pl ,
+                                                                               "ruda"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "glassworks"@en ,
+                                                                             "osada hutnicza"@pl ;
+                             ontohgis:hasExternalIdentifier "127"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
+
+
+ontohgis:settlement_type_128 rdfs:comment "Legal status - ownership diveded between a land lord and a hereditary tenant or an annual tenant."@en ,
+                                          "Status prawny - własność podzielona między pana gruntowego a dzierżawcę dziedzicznego lub dzierżawcę rocznego."@pl ;
+                             rdfs:isDefinedBy "Glassworks is an industrial facility, where major production was glasswork, and later mainly casting and manufacturing metals, e.g. lead, zinc, iron."@en ,
+                                              "Zakład przemysłowy, którego głównym celem była produkcja szkła, a w późniejszym okresie wytop i przetwórstwo rud metali np. ołowiu, cynku, żelaza."@pl ;
+                             rdfs:label "glassworks"@en ,
+                                        "huta - obiekt"@pl ;
+                             rdfs:seeAlso "#J. Olczak, Późnośrednowieczne i nowożytne hutnictwo szkła w Polsce w perspektywie źródeł archeologicznych, „Archeologia Historia Polona”, t.1, 1995, s. 79-86#Wyrobisz A., Szkło w Polsce od XIV do XVII w., Warszawa 1968"@pl ,
+                                          "rozróżnia hutę i hutę szkła. Huta – ‘zakład metalurgiczny, w którym wytapia się metale z rud’, zaś Huta szkła – ‘zakład wytapiający szkło i wytwarzający produkty szklane’"@pl ,
+                                          "t. 2, s. 67: ‘zakład, gdzie robią szkło albo topią metale’"@pl ,
+                                          "zakład lub zespół zakładów przemysłowych produkujących metale z rud, szkło, siarkę i in.’, huty przerabiają nie tylko rudy na surówkę, lecz także surówkę na stal"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "Hütte (de), Ofen (de), Schmelze (de), Hammer (de)" ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "kuźnica (pl), ruda (pl)" ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "glassworks"@en ,
+                                                                             "huta"@pl ;
+                             ontohgis:hasExternalIdentifier "128"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_128 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "rozróżnia hutę i hutę szkła. Huta – ‘zakład metalurgiczny, w którym wytapia się metale z rud’, zaś Huta szkła – ‘zakład wytapiający szkło i wytwarzający produkty szklane’"@pl ;
+   rdfs:isDefinedBy ontohgis:document_3
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_128 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 2, s. 67: ‘zakład, gdzie robią szkło albo topią metale’"@pl ;
+   rdfs:isDefinedBy ontohgis:document_5
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_128 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "zakład lub zespół zakładów przemysłowych produkujących metale z rud, szkło, siarkę i in.’, huty przerabiają nie tylko rudy na surówkę, lecz także surówkę na stal"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+
+ontohgis:settlement_type_129 rdfs:comment "Morphological distinctiveness - usually clear (location in the forest), but there are lodges located in the immediate vicinity of some other localities. Naming distinctiveness - clear from the second half of the 19th c. (previously forester's lodges had no proper names, later not always). Functional distinctiveness - the forester's lodge plays a role in the economy and forest administration."@en ,
+                                          "Odrębność morfologiczna – przeważnie wyraźna (położenie w lesie), ale zdarzają się leśniczówki położone w bezpośrednim sąsiedztwie innych miejscowości. Odrębność nazewnicza – od drugiej połowy XIX wieku (wcześniej bez nazw; później nie zawsze). Odrębność funkcjonalna – leśniczówka pełni rolę związaną z gospodarką i administracją leśną."@pl ;
+                             rdfs:isDefinedBy "Forester's lodge is an area where there is a complex of buildings including a house in which a forester lives, which is the seat of the Forest District's authorities, located in a forest area. Apart from forest management, forester's lodge performs residential functions. Forester's lodge is a locality as long as it has a proper name and is not in the vicinity of another locality."@en ,
+                                              "Leśniczówka (obiekt) to obszar, na którym znajduje się zespół zabudowań obejmujący dom, w którym mieszka leśniczy, stanowiący siedzibę leśnictwa, znajdujący się na terenie leśnym, pełniący oprócz mieszkalnych funkcje związane z gospodarką leśną. Leśniczówka jest miejscowością o ile posiada nazwę własną i nie znajduje się w bezpośrednim sąsiedztwie innej miejscowości."@pl ;
+                             rdfs:label "forester's lodge"@en ,
+                                        "leśniczówka - obiekt"@pl ;
+                             rdfs:seeAlso <http://gov.genealogy.net/types.owl#102> ,
+                                          <http://vocab.getty.edu/aat/300250342> ,
+                                          <https://www.wikidata.org/wiki/Q1425352> ,
+                                          "Dom, zagroda w lesie stanowiąca mieszkanie; mieszkanie leśniczego (zarządca obszaru leśnego stanowiącego leśnictwo) wraz z zabudowaniami gospodarskimi"@pl ,
+                                          "Pojedyncza zagroda służąca leśniczemu i będąca jednocześnie siedzibą leśnictwa"@pl ,
+                                          "t. 2, s. 721: domek w lesie, mieszkanie, zagroda leśniczego a. leśnika"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "Jägerhaus"@de ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Forestrey"@de ,
+                                                                               "Forst Amt"@de ,
+                                                                               "Hegerhaus"@de ,
+                                                                               "gajówka"@pl ,
+                                                                               "nadleśnictwo"@pl ,
+                                                                               "osada leśna"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "forester's lodge"@en ,
+                                                                             "leśniczówka"@pl ;
+                             ontohgis:hasExternalIdentifier "129"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_129 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "Dom, zagroda w lesie stanowiąca mieszkanie; mieszkanie leśniczego (zarządca obszaru leśnego stanowiącego leśnictwo) wraz z zabudowaniami gospodarskimi"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_129 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "Pojedyncza zagroda służąca leśniczemu i będąca jednocześnie siedzibą leśnictwa"@pl ;
+   rdfs:isDefinedBy ontohgis:document_9
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_129 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 2, s. 721: domek w lesie, mieszkanie, zagroda leśniczego a. leśnika"@pl ;
+   rdfs:isDefinedBy ontohgis:document_5
+ ] .
+
+
+ontohgis:settlement_type_130 rdfs:comment "Morphological distinctiveness - usually clear (location in the forest), but there are lodges located in the immediate vicinity of some other localities.Naming distinctiveness - clear from the second half of the 19th century (previously forester's lodges had no proper names, later not always).Functional distinctiveness - the forester's lodge plays a role in the economy and forest administration."@en ,
+                                          "Odrębność morfologiczna – przeważnie wyraźna (położenie w lesie), ale zdarzają się gajówki położone w bezpośrednim sąsiedztwie innych miejscowości.Odrębność nazewnicza – od drugiej połowy XIX wieku (wcześniej bez nazw; później nie zawsze). Odrębność funkcjonalna – gajówka pełni rolę związaną z gospodarką leśną."@pl ;
+                             rdfs:isDefinedBy "Forest-guard's lodge is an area comprising a set of buildings including a house in which a forest-guard lives, located in a forest area, performing residential as well as forest management functions. Forest-guard's lodge is a locality as long as it has its own name and is not located in the immediate vicinity of another locality."@en ,
+                                              "Gajówka to obszar na którym znajduje się zespół zabudowań obejmujący dom, w którym mieszka gajowy, znajdujący się na terenie leśnym, pełniący oprócz mieszkalnych funkcje związane z gospodarką leśną. Gajówka jest miejscowością o ile posiada nazwę własną i nie znajduje się w bezpośrednim sąsiedztwie innej miejscowości."@pl ;
+                             rdfs:label "forest-guard's lodge"@en ,
+                                        "gajówka - obiekt"@pl ;
+                             rdfs:seeAlso <http://vocab.getty.edu/aat/300250342> ,
+                                          <https://www.wikidata.org/wiki/Q17087359> ,
+                                          "Budynek, w którym mieszka gajowy (pracownik nadleśnictwa chroniący przydzieloną mu część lasu przed szkodami)"@pl ,
+                                          "Pojedyncza zagroda, zazwyczaj położona w lesie, pełniąca funkcję mieszkania służbowego dla funkcjonariuszy pomocniczej służy leśnej podleśniczych lub gajowych"@pl ,
+                                          "t. 1, s. 793: chatka gajowego"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "Hegerhaus"@de ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Forestrey"@de ,
+                                                                               "Forst Amt"@de ,
+                                                                               "Jägerhaus"@de ,
+                                                                               "leśnictwo"@pl ,
+                                                                               "leśniczówka"@pl ,
+                                                                               "nadleśnictwo"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "forest-guard's lodge"@en ,
+                                                                             "gajówka"@pl ;
+                             ontohgis:hasExternalIdentifier "130"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_130 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "Budynek, w którym mieszka gajowy (pracownik nadleśnictwa chroniący przydzieloną mu część lasu przed szkodami)"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_130 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "Pojedyncza zagroda, zazwyczaj położona w lesie, pełniąca funkcję mieszkania służbowego dla funkcjonariuszy pomocniczej służy leśnej podleśniczych lub gajowych"@pl ;
+   rdfs:isDefinedBy ontohgis:document_9
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_130 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 1, s. 793: chatka gajowego"@pl ;
+   rdfs:isDefinedBy ontohgis:document_5
+ ] .
+
+
+ontohgis:settlement_type_131 rdfs:comment """Functional distinctivness - distinguished as a kind of locality in Bystrzycki's register, and on topographic maps as distinct symbol, sometimes with the proper name.
+Morphological and spatial distinctivness - usually a lightouse is a building (structure) within the area of the locality or in its vicinity. 
+If it has its a particular (proper) name, it can be treated as a separate locality (interpretation of maps is necessary, see: Rozewie). Otherwise it is either part of another locality or an object (building/structure) in it (see: Hel, Jastarnia)."""@en ,
+                                          "Odrębność funkcjonalna – wyróżniana jako rodzaj miejscowości u Bystrzyckiego, a na mapach topograficznych odrębnym znakiem, niekiedy z nazwą własną. Odrębność morfologiczna/przestrzenna – przeważnie jest obiektem na obszarze miejscowości lub w niewielkim od niej oddaleniu. Jeżeli posiada nazwę własną może być traktowana jako osobna miejscowość (konieczna interpretacja map; patrz: Rozewie). W przeciwnym razie jest albo częścią innej, większej miejscowości lub obiektem terenowym (budowlą) w niej (patrz: Hel, Jastarnia)."@pl ;
+                             rdfs:isDefinedBy "A lighthouse (a facility) is a building, usually a high tower with a beacon light to guide ships."@en ,
+                                              "Latarnia morska (obiekt) to budowla, najczęściej wysoka wieża służąca jako punkt orientacyjny dla statków."@pl ;
+                             rdfs:label "latarnia morska - obiekt"@pl ,
+                                        "lighthouse"@en ;
+                             rdfs:seeAlso <http://dbpedia.org/ontology/Lighthouse> ,
+                                          <http://linkedgeodata.org/ontology/Lighthouse> ,
+                                          <http://vocab.getty.edu/aat/300007741> ,
+                                          <https://www.wikidata.org/wiki/Q39715> ,
+                                          "wysoka, widoczna z morza wieża, służąca jako punkt orientacyjny dla statków"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "Leuchtturm"@de ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "latarnia morska"@pl ,
+                                                                             "lighthouse"@en ;
+                             ontohgis:hasExternalIdentifier "131"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 ,
+                                                    ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_131 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "wysoka, widoczna z morza wieża, służąca jako punkt orientacyjny dla statków"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+
+ontohgis:settlement_type_132 rdfs:comment "In the analysed cases, the monastery could have been a locality which was separate in terms of name and mophology from the neighbouring ones. The monastery could have been a beginning (a stem) of a larger locality, which would develop around it and transform into a monastery settlement, village, city etc."@en ,
+                                          "W analizowanych przypadkach klasztor mógł stanowić całkowicie odrębną (od sąsiadujących) nazewniczo i morfologicznie miejscowość. Klasztor mógł stanowić zalążek większej miejscowości, która rozwinęła się wokół niego i przekształciła się w osadę klasztorną, wieś, miasto etc."@pl ;
+                             rdfs:isDefinedBy "Klasztor jest to budynek lub zespół budynków przeznaczony do mieszkania dla zakonników lub zakonnic."@pl ,
+                                              "Monastery is a building or a group of buildings where monks and nuns live"@en ;
+                             rdfs:label "klasztor - obiekt"@pl ,
+                                        "monastery"@en ;
+                             rdfs:seeAlso <http://dbpedia.org/ontology/Monastery> ,
+                                          <http://gov.genealogy.net/types.owl#30> ,
+                                          <http://vocab.getty.edu/aat/300000641> ,
+                                          <https://www.wikidata.org/wiki/Q44613> ,
+                                          "1. budynek lub kompleks budynków stanowiących wspólne miejsce zamieszkiwania zakonnic lub zakonników; 2. wspólnota zakonna o określonej regule"@pl ,
+                                          "1. zgromadzenie zakonne; zakon--; 2. budynek lub kompleks budynków zamieszkiwanych przez zakonników (zakonnice) danej reguły"@pl ,
+                                          "t. 1, cz. 2, s. 1010: pomieszkanie zakonnicze"@pl ,
+                                          "t. 10, s. 337: 1. Odosobnione i wyodrębnione spośród innych osiedli ludzkich miejsce zamieszkania zakonników i zakonnic (pojmowane jako budynek lub jego mieszkańcy); odosobnienie; tryb życia klasztornego; w wypadku niektórych zakonów także: szkoła, kolegium; coenobium, monasterium."@pl ,
+                                          "t. 3, s. 282: zabudowanie dla zgromadzenia zakonnego zwykle połączone z kościołem, coenobium, religiosorum domus."@pl ,
+                                          "t. 9, kol. 66-76: zespół budynków lub pomieszczeń mieszkalnych i gospodarczych o różnej strukturze, przeznaczonych do prowadzenia życia pustelniczego (zob. ławra) lub wspólnotowego życia ascetycznego (zob. asceza), występujący w religiach pozachrześcijańskich i chrześcijaństwie. -- Czasem rozbudowane założenia klasztorne tworzyły wręcz miasto, a nawet państwo mnichów (civitas monachorum)"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "Kloster"@de ,
+                                                                            "claustrum"@la ,
+                                                                            "monaster"@pl ,
+                                                                            "monasterium"@la ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "opactwo"@pl ,
+                                                                               "ławra"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "klasztor"@pl ,
+                                                                             "monastery"@en ;
+                             ontohgis:hasExternalIdentifier "132"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_132 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "1. budynek lub kompleks budynków stanowiących wspólne miejsce zamieszkiwania zakonnic lub zakonników; 2. wspólnota zakonna o określonej regule"@pl ;
+   rdfs:isDefinedBy ontohgis:document_3 ,
+                    <https://sjp.pwn.pl/slowniki/klasztor.html>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_132 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "1. zgromadzenie zakonne; zakon--; 2. budynek lub kompleks budynków zamieszkiwanych przez zakonników (zakonnice) danej reguły"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_132 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 1, cz. 2, s. 1010: pomieszkanie zakonnicze"@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_132 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 10, s. 337: 1. Odosobnione i wyodrębnione spośród innych osiedli ludzkich miejsce zamieszkania zakonników i zakonnic (pojmowane jako budynek lub jego mieszkańcy); odosobnienie; tryb życia klasztornego; w wypadku niektórych zakonów także: szkoła, kolegium; coenobium, monasterium."@pl ;
+   rdfs:isDefinedBy ontohgis:document_2
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_132 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 3, s. 282: zabudowanie dla zgromadzenia zakonnego zwykle połączone z kościołem, coenobium, religiosorum domus."@pl ;
+   rdfs:isDefinedBy ontohgis:document_6
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_132 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 9, kol. 66-76: zespół budynków lub pomieszczeń mieszkalnych i gospodarczych o różnej strukturze, przeznaczonych do prowadzenia życia pustelniczego (zob. ławra) lub wspólnotowego życia ascetycznego (zob. asceza), występujący w religiach pozachrześcijańskich i chrześcijaństwie. -- Czasem rozbudowane założenia klasztorne tworzyły wręcz miasto, a nawet państwo mnichów (civitas monachorum)"@pl ;
+   rdfs:isDefinedBy ontohgis:document_7
+ ] .
+
+
+ontohgis:settlement_type_133 rdfs:comment "In most analysed cases, if the sawmill was morphologically distinct, it had the same name as the neighboring village or another locality, such as: forester's lodge. Occasionally it had its particular name."@en ,
+                                          "W większości analizowanych przypadków, jeżeli tartak był odrębny morfologicznie, to miał tę samą nazwę, co sąsiadująca wieś lub inna miejscowość, np. leśniczówka. Sporadycznie cechowała go odrębność nazewnicza."@pl ;
+                             rdfs:isDefinedBy "Obiekt lub zespół obiektów gospodarczych często zlokalizowanych w lesie lub jego pobliżu, gdzie dokonuje się przerobu drewna okrągłego na tarcicę w procesie przecierania (tarcia)."@pl ,
+                                              "Sawmill is an industrial facility often located within or near the forest, where wood is processed into sawn timber in the wiping process."@en ;
+                             rdfs:label "sawmill"@en ,
+                                        "tartak - obiekt"@pl ;
+                             rdfs:seeAlso "#Orgelbrand, t. 14, s. 412: pilarnia, machina do piłowania drzewa, której główną częścią składową jest piła, poruszana siłą wody lub pary. Tartaki istnieją już od wieku XIV, a obecnie stanowią machiny niekiedy bardzo zawiłe, które robotę wykonywają szybko i dokładnie"@pl ,
+                                          "t. 3, s. 607: młyn do tarcia drzew na tarcice, dyle"@pl ,
+                                          "t. 7, s. 29: Pilarnia, młyn do tarcia drzewa na tarcice, dyle: Tartak wodny, parowy"@pl ,
+                                          "zakład przemysłowy zajmujący się przecieraniem drewna na tarcicę"@pl ,
+                                          "«zakład zajmujący się rozpiłowywaniem kłód na tarcicę oraz przerobem tarcicy na różne elementy»"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "das Sägewerk (de), lesopilnyi zawod (ru)" ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "młyn (pl), piła (pl),die Säge (de), osada młyńska (pl), osada leśna (pl)" ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "sawmill"@en ,
+                                                                             "tartak"@pl ;
+                             ontohgis:hasExternalIdentifier "133"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_133 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 3, s. 607: młyn do tarcia drzew na tarcice, dyle"@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_133 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 7, s. 29: Pilarnia, młyn do tarcia drzewa na tarcice, dyle: Tartak wodny, parowy"@pl ;
+   rdfs:isDefinedBy ontohgis:document_5
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_133 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "zakład przemysłowy zajmujący się przecieraniem drewna na tarcicę"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4 ,
+                    <https://sjp.pwn.pl/doroszewski/tartak;5506829.html>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_133 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "«zakład zajmujący się rozpiłowywaniem kłód na tarcicę oraz przerobem tarcicy na różne elementy»"@pl ;
+   rdfs:isDefinedBy ontohgis:document_3 ,
+                    <https://sjp.pwn.pl/sjp/tartak;2528864.html>
+ ] .
+
+
+ontohgis:settlement_type_134 rdfs:comment "In all the analysed cases, in Bystrzycki's register, peat mines had the same names as the locality nearby: village and peat mine, manor and peat mine."@en ,
+                                          "We wszystkich analizowanych przypadkach z tzw. skorowidza Bystrzyckiego z 1931 r. torfiarnie posiadały takie same nazwy jak osada lub osady leżąca obok niej (wieś i torfiarnia, folwark i torfiarnia)."@pl ;
+                             rdfs:isDefinedBy "Peat mine is a mine where a peat is mined"@en ,
+                                              "Torfiarnia (obiekt) jest to kopalnia torfu."@pl ;
+                             rdfs:label "peat mine"@en ,
+                                        "torfiarnia - obiekt"@pl ;
+                             rdfs:seeAlso "kopalnia torfu"@pl ,
+                                          "t. 7, s. 85: kopalnia torfu, torfowisko eksploatowane"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "torfowisko (pl)" ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "peat mine"@en ,
+                                                                             "torfiarnia"@pl ;
+                             ontohgis:hasExternalIdentifier "134"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_134 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "kopalnia torfu"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4 ,
+                    <https://sjp.pwn.pl/doroszewski/torfiarnia>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_134 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 7, s. 85: kopalnia torfu, torfowisko eksploatowane"@pl ;
+   rdfs:isDefinedBy ontohgis:document_5
+ ] .
+
+
+ontohgis:settlement_type_135 rdfs:comment "At the very beginning, breweries had been situated only within bigger settlement unit and had not had an individual name. Some of these had only a name corresponding to the owner's name, which was frequently changed. Subsequently, particular names were assigned to breweries; often in the form of trademarks, however the process of integrating the breweries under one trademark originated relatively early/ quickly. One may not find a difference between brewery and distillery in historical sources."@en ,
+                                          "Browary początkowo mieściły się wyłącznie w obrębie większych jednostek osadniczych i nie miały własnej nazwy, ew. nazwę wywiedzioną od nazwiska właściciela, często zmienianą. Z czasem browary zaczęły mieć własne nazwy, często w postaci znaków handlowych, jednakże dość szybko zaczął się proces łączenia się browarów pod wspólną nazwą. Źródłowo zdarza się brak rozróżnienia gorzelni i browaru."@pl ;
+                             rdfs:isDefinedBy "Brewery is a factory producing beer, as well as a complex of buildings established for production and accomodation for factory workers."@en ,
+                                              "Browar jest to zakład wytwarzający piwo jak również zespół budynków przeznaczonych na cele produkcyjne i mieszkalne dla obsługi zakladu."@pl ;
+                             rdfs:label "brewery"@en ,
+                                        "browar - obiekt"@pl ;
+                             rdfs:seeAlso <http://dbpedia.org/ontology/Brewery> ,
+                                          <http://vocab.getty.edu/aat/300006341> ,
+                                          <https://www.wikidata.org/wiki/Q131734> ,
+                                          "t. 1, cz.12, s. 272: Browar, budynek, gdzie się piwo warzy, piwowarnia, mielcuch"@pl ,
+                                          "t. 2, s. 455-456: budynek, w którym się warzy piwo, piwowarnia"@pl ,
+                                          "zakład produkujący piwo"@pl ,
+                                          "zakład przemysłowy, w którym wyrabia się piwo; wytwórnia piwa"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "Bierbrauerei"@de ,
+                                                                            "Brauerei"@de ,
+                                                                            "Brauhaus"@de ,
+                                                                            "braxatorium"@la ,
+                                                                            "piwowarnia"@pl ,
+                                                                            "пивоварня"@ru ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "mielcuch"@pl ,
+                                                                               "warzelnia"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "brewery"@en ,
+                                                                             "browar - obiekt"@pl ;
+                             ontohgis:hasExternalIdentifier "135"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_135 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 1, cz.12, s. 272: Browar, budynek, gdzie się piwo warzy, piwowarnia, mielcuch"@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_135 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 2, s. 455-456: budynek, w którym się warzy piwo, piwowarnia"@pl ;
+   rdfs:isDefinedBy ontohgis:document_2
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_135 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "zakład produkujący piwo"@pl ;
+   rdfs:isDefinedBy <http://sjp.pwn.pl/slowniki/browar.html> ,
+                    ontohgis:document_3
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_135 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "zakład przemysłowy, w którym wyrabia się piwo; wytwórnia piwa"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+
+ontohgis:settlement_type_136 rdfs:comment "In each case analysed, a brickyard with a particular name has been located near a village, a city or a town, or a settlement with the same name. If it was an integral part of a superior locality, it had not been given a proper name. (One should remember that exporting produced goods outside the area of production was difficult)."@en ,
+                                          "We wszystkich analizowanych przypadkach jeżeli cegielnia jest odrębną miejscowością, to znajduje się w pobliżu wsi, miasta lub osady o tej samej nazwie. Jeśli znajduje się w obrębie większej miejscowości to dość długo nie ma nazwy własnej. (Trudności w eksporcie towaru poza miejsce wyrobu.)"@pl ;
+                             rdfs:isDefinedBy "Brickyard is a factory where bricks and other ceramic building materials and elements are being produced together with a complex of buildings established for production and houses for factory workers."@en ,
+                                              "Cegielnia jest to zakład wytwarzający cegły oraz ew. inne ceramiczne elementy budowlane jak również zespół budynków przeznaczonych na cele produkcyjne i mieszkalne dla obsługi zakładu."@pl ;
+                             rdfs:label "brickyard"@en ,
+                                        "cegielnia - obiekt"@pl ;
+                             rdfs:seeAlso <http://vocab.getty.edu/aat/300006278> ,
+                                          <https://www.wikidata.org/wiki/Q198632> ,
+                                          "t. 1, cz. 1, s. 221: Cegielnia, Cegielnica, budynek z piecem od palenia cegieł, die Ziegelscheune, der Ziegelofen"@pl ,
+                                          "t. 3, s. 142: cegielnia – miejsce wyrobu cegieł"@pl ,
+                                          "wytwórnia cegly oraz innych materiałów budowlanych z gliny: dachówek, sączków (drenów), kafli, klinkierów, płytek itp."@pl ,
+                                          "wytwórnia cegły oraz innych materiałów budowlanych z gliny"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "Ziegelei"@de ,
+                                                                            "cegielnica"@pl ,
+                                                                            "кирпичный завод"@ru ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Ziegelscheune"@de ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "brickyard"@en ,
+                                                                             "cegielnia"@pl ;
+                             ontohgis:hasExternalIdentifier "136"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_136 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 1, cz. 1, s. 221: Cegielnia, Cegielnica, budynek z piecem od palenia cegieł, die Ziegelscheune, der Ziegelofen"@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_136 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 3, s. 142: cegielnia – miejsce wyrobu cegieł"@pl ;
+   rdfs:comment ontohgis:document_2
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_136 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "wytwórnia cegly oraz innych materiałów budowlanych z gliny: dachówek, sączków (drenów), kafli, klinkierów, płytek itp."@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_136 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "wytwórnia cegły oraz innych materiałów budowlanych z gliny"@pl ;
+   rdfs:isDefinedBy <http://sjp.pwn.pl/sjp/cegielnia.html> ,
+                    ontohgis:document_3
+ ] .
+
+
+ontohgis:settlement_type_137 rdfs:comment "Mines presented on majority of analysed maps had their individual symbol."@en ,
+                                          "Na wszystkich badanych mapach kopalnie miały własny znak umowny."@pl ;
+                             rdfs:isDefinedBy "A mine is a factory extracting minerals from the earth. It may be connected with a settlement, it may be inhabited by the personnel."@en ,
+                                              "Kopalnia jest to zakład wydobywający z ziemi kopaliny. Może być połączony z osadą, miewa stale zamieszkujący personel."@pl ;
+                             rdfs:label "kopalnia - obiekt"@pl ,
+                                        "mine"@en ;
+                             rdfs:seeAlso <http://dbpedia.org/ontology/Mine> ,
+                                          <http://vocab.getty.edu/aat/300000390> ,
+                                          <https://www.wikidata.org/wiki/Q820477> ,
+                                          "Teren zakładu górniczego, zajmującego się wydobywaniem z ziemi kopalin użytecznych. Ze względu na sposób wydobycia rozróżnia się kopalnie odkrywkowe (naziemne), głębinowe (podziemne) i otworowe."@pl ,
+                                          "t. 1, cz. 2, s. 1077: Kopalnia, miejsce gdzie się iakowe rzeczy kopalne z ziemi dobywają"@pl ,
+                                          "zakład górniczy zajmujący się wydobywaniem z ziemi kopalin"@pl ,
+                                          "zakład górniczy zajmujący się wydobywaniem z ziemi kopalin użytecznych"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "Bergwerk"@de ,
+                                                                            "gruba"@pl ,
+                                                                            "рудник"@ru ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Binge"@de ,
+                                                                               "Bruch"@de ,
+                                                                               "Miene"@de ,
+                                                                               "Schacht"@de ,
+                                                                               "шахта"@ru ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "kopalnia"@pl ,
+                                                                             "mine"@en ;
+                             ontohgis:hasExternalIdentifier "137"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_137 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "Teren zakładu górniczego, zajmującego się wydobywaniem z ziemi kopalin użytecznych. Ze względu na sposób wydobycia rozróżnia się kopalnie odkrywkowe (naziemne), głębinowe (podziemne) i otworowe."@pl ;
+   rdfs:isDefinedBy ontohgis:document_9
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_137 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 1, cz. 2, s. 1077: Kopalnia, miejsce gdzie się iakowe rzeczy kopalne z ziemi dobywają"@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_137 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "zakład górniczy zajmujący się wydobywaniem z ziemi kopalin"@pl ;
+   rdfs:isDefinedBy ontohgis:document_3 ,
+                    <https://sjp.pwn.pl/sjp/kopalnia;2473819.html>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_137 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "zakład górniczy zajmujący się wydobywaniem z ziemi kopalin użytecznych"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+
+ontohgis:settlement_type_138 rdfs:comment "Cukrownia może mieć własną nazwę, najczęściej powiązaną z nazwą firmy lub znakiem firmowym, ale nie musi. Rzadko zaznaczana na mapach."@pl ,
+                                          "Sugar factory or refinery may have its own name - usually related to the factory name or a trademark - however it is not nocessary. Very seldom, it has been indicated on maps."@en ;
+                             rdfs:isDefinedBy "A sugar factory or refinery is a factory producing sugar, as well as a complex of buildings established for production and accomodation for factory workers."@en ,
+                                              "Cukrownia jest to zakład wytwarzający cukier jak również zespół budynków przeznaczonych na cele produkcyjne i mieszkalne dla obsługi zakładu."@pl ;
+                             rdfs:label "cukrownia - obiekt"@pl ,
+                                        "sugar factory"@en ;
+                             rdfs:seeAlso "fabryka cukru"@pl ,
+                                          "t. 1, cz. 1, s. 327: [Brak hasła „cukrownia”.] Cukrowarz, fabrykant cukru, warzący sok na cukier, derZuckersieder, cf. Cukiernik."@pl ,
+                                          "zakład przemysłowy produkujący cukier"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "die Zuckerfabrik (de), die Zuckersiederei (de) Сахарный завод (ru)" ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "cukrownia"@pl ,
+                                                                             "sugar factory"@en ;
+                             ontohgis:hasExternalIdentifier "138"^^xsd:int ,
+                                                            "138" ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_138 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "fabryka cukru"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_138 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 1, cz. 1, s. 327: [Brak hasła „cukrownia”.] Cukrowarz, fabrykant cukru, warzący sok na cukier, derZuckersieder, cf. Cukiernik."@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_138 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "zakład przemysłowy produkujący cukier"@pl ;
+   rdfs:isDefinedBy <http://sjp.pwn.pl/sjp/cukrownia.html> ,
+                    ontohgis:document_3
+ ] .
+
+
+ontohgis:settlement_type_139 rdfs:comment "Distillery may have its own name - usually related to the factory name or a trademark - however it is not nocessary. As a separate locality, it may - however it is not obligatory - be located near a village, a city or a town, or a settlement sharing the same name. One may not find a difference between brewery and distillery in historical sources."@en ,
+                                          "Gorzelnie znajdujące się w obrębie miast mogą, ale nie muszą mieć własnej nazwy, zazwyczaj nazwa ta powiązana jest z nazwą firmy, znakiem firmowym. Jeśli jest odrębną miejscowością to może ale nie musi znajdować się w pobliżu wsi, miasta lub osady o tej samej nazwie. Źródłowo zdarza się brak rozróżnienia gorzelni i browaru."@pl ;
+                             rdfs:isDefinedBy "Distillery is a factory where alcohol and spirits requiring distillation whilst manufacturing are produced."@en ,
+                                              "Gorzelnia jest to zakład wytwarzający spirytus oraz napoje alkoholowe o wysokiej zawartości alkoholu, wymagające w trakcie procesu produkcyjnego destylacji."@pl ;
+                             rdfs:label "distillery"@en ,
+                                        "gorzelnia - obiekt"@pl ;
+                             rdfs:seeAlso <http://vocab.getty.edu/aat/300006346> ,
+                                          <https://www.wikidata.org/wiki/Q1251750> ,
+                                          "t. 1, cz. 2, s. 54: Gorzalnia, gorzelnia, budowanie do palenia gorzałki (pospolicie zowią: browarem, ale borwar na piwo iest.)"@pl ,
+                                          "zakład przemysłowy produkujący alkohol etylowy"@pl ,
+                                          "zakład przemysłowy produkujący spirytus i wódki głównie z kartofli lub zboża"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#altLabel> "Brantweinbrennerei"@de ,
+                                                                            "Brennerei"@de ,
+                                                                            "Brennhaus"@de ,
+                                                                            "Destillerie"@de ,
+                                                                            "gorzalnia"@pl ,
+                                                                            "винокуренныйзавод"@ru ,
+                                                                            "винокурня"@ru ;
+                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "browar"@pl ;
+                             <http://www.w3.org/2004/02/skos/core#prefLabel> "distillery"@en ,
+                                                                             "gorzelnia"@pl ;
+                             ontohgis:hasExternalIdentifier "139"^^xsd:int ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_139 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 1, cz. 2, s. 54: Gorzalnia, gorzelnia, budowanie do palenia gorzałki (pospolicie zowią: browarem, ale borwar na piwo iest.)"@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_139 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "zakład przemysłowy produkujący alkohol etylowy"@pl ;
+   rdfs:isDefinedBy <http://sjp.pwn.pl/slowniki/gorzelnia.html> ,
+                    ontohgis:document_3
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_139 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "zakład przemysłowy produkujący spirytus i wódki głównie z kartofli lub zboża"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+
+ontohgis:settlement_type_17 rdfs:comment "Forest-guard's lodge is a kind of forester's lodge; criteria for distinguishing a forester's lodge, forestry and forest-guard's lodge are unknown (in the context of topographic maps); the term forest-guard's lodge is very rarely used in Bystrzycki's register 1931 (Forest-guard's lodges depicted on MGI maps are forester's lodges in Bystrzycki's register 1931 or are not included in Bystrzycki's register 1931 whereas depicted on MGI maps)."@en ,
+                                         "Gajówka jest rodzajem leśniczówki; kryteria odróżniania leśniczówki, leśnictwa i gajówki są nieznane (w świetle kartografii); termin bardzo rzadko stosowany w skorowidzu Bystrzyckiego z 1931 r. (gajówki na mapach WIG to często leśniczówki w skorowidzu Bystrzyckiego z 1931 r.; gajówki nie ujęte w skorowidzu Bystrzyckiego z 1931 r. występują na mapach WIG)"@pl ;
+                            rdfs:isDefinedBy "Forest-guard's lodge (a locality) is a settlement in which the main role is played by a forest-guard's lodge (a facility). Forest-guard's lodge is a locality as long as it has its own name and is not located in the immediate vicinity of another locality."@en ,
+                                             "Gajówka (miejscowość) to miejscowość, w której główną rolę pełni gajówka (obiekt). Gajówka jest miejscowością jeżeli posiada nazwę własną i jest przestrzennie wyodrębniona od innej miejscowości."@pl ;
+                            rdfs:label "forest-guard's lodge"@en ,
+                                       "gajówka"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Forestrey"@de ,
+                                                                              "Forst Amt"@de ,
+                                                                              "Hegerhaus"@de ,
+                                                                              "Jägerhaus"@de ,
+                                                                              "leśnictwo"@pl ,
+                                                                              "leśniczówka"@pl ,
+                                                                              "nadleśnictwo"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "forest-guard's lodge"@en ,
+                                                                            "gajówka"@pl ;
+                            ontohgis:hasExternalIdentifier "17" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_18 rdfs:comment "A distillery may be a separate locality, both individual and a part of a cluster of localities sharing the same name, however most often it has been an integral part of a city or a town and has not been distinguished."@en ,
+                                         "Gorzelnia może być odrębną miejscowością, zarówno samodzielną jak i częścią grupy miejscowości o tej samej nazwie, ale najczęściej znajduje się w obrębie miasta i nie jest wyróżniona."@pl ;
+                            rdfs:isDefinedBy "A distillery (locality) is a settlement, where a distillery (a factory) plays the most important role."@en ,
+                                             "Gorzelnia (miejscowość) jest to osada, w której główną role odgrywa gorzelnia (obiekt)."@pl ;
+                            rdfs:label "distillery"@en ,
+                                       "gorzelnia"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Brantweinbrennerei"@de ,
+                                                                              "Brennerei"@de ,
+                                                                              "Brennhaus"@de ,
+                                                                              "Destillerie"@de ,
+                                                                              "browar"@pl ,
+                                                                              "винокуренныйзавод"@ru ,
+                                                                              "винокурня"@ru ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "distillery"@en ,
+                                                                            "gorzelnia"@pl ;
+                            ontohgis:hasExternalIdentifier "18" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
+
+
+ontohgis:settlement_type_19 rdfs:comment "Klasztor może być odrębną miejscowością (rzadko, przed II wojną światową) lub częścią miejscowości."@pl ,
+                                         "Monastery can be a separate locality (rarely, before the Second World War) or a part of a locality."@en ;
+                            rdfs:isDefinedBy "Monastery (locality) is a settlement in which the main role is played by a monastery (facility)."@en ,
+                                             "Osada klasztorna jest to osada, w której główą rolę odgrywa klasztor (obiekt)."@pl ;
+                            rdfs:label "monastery"@en ,
+                                       "osada klasztorna"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Kloster"@de ,
+                                                                              "claustrum"@la ,
+                                                                              "monaster"@pl ,
+                                                                              "monasterium"@la ,
+                                                                              "opactwo"@pl ,
+                                                                              "ławra"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "monastery"@en ,
+                                                                            "osada klasztorna"@pl ;
+                            ontohgis:hasExternalIdentifier "19" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_2 rdfs:comment """A development in a village may be dense (i.e. villages established according to a German law introducing a linear development) or scattered (i.e. Hauländer colonies, Dutch settlement, from 18th century or early medieval single manor settlements). A village may preponderate (be a superior settlement) any other units, such as: a hamlet or a mill settlement; it is also dependent on a manor, which supervises a village in legal and administrative issues. Inhabitants from all units forming a village comprise a village community. Studies on this type of localities distinguish an abandoned village, a settlement that lost its functions due to environmental, political, or economic incidents. In historiography, one can find an expression a lost village, which stands for a village, where settlement was not re-established.
+In German language in the nineteenth century, two terms could coexist - Pfarrdorf and Kirchdorf. The first meant a larger village with a parish church, and a second smaller village with an auxiliary (filial) church, but these criteria of distinction were not strict and neither used consistently. For example on the Gilly map (1802-1803), only the following categories exist: Kirchdorf and Dorf ohne Kirche."""@en ,
+                                        """Wieś może posiadać zwartą (np. wsie lokowane na prawie niemieckim np. ulicówki, łańcuchówki) lub rozproszoną zabudowę (często kolonie olęderskie w XVIII w. lub wczesnośredniowieczne osady jednodworcze). Wieś może dominować (być jednostką nadrzędną osadniczo) w stosunku do innych jednostek takich jak np. przysiółek, osada młyńska; jest także zależna od pana gruntowego, który sprawuje nad nią nadzór własnościowy. Mieszkańcy wszystkich jednostek składających się na wieś tworzą jedną wspólnotę wiejską. W badaniach nad wsią rozróżnia się także pojęcie wsi opustoszałej, czyli takiej, która fizycznie przestała pełnić swoje funkcje w wyniku zdarzeń o charakterze losowym, środowiskowym, politycznym lub gospodarczym. W literaturze przedmiotu funkcjonuje także określenie wieś zaginiona, które odnosi się do wsi, w których nie wznowiono osadnictwa.
+W języku niemieckim w XIX wieku mogły funkcjonować równolegle dwa terminy – Pfarrdorf i Kirchdorf.  Pierwszy oznaczał raczej większą wieś z kościołem parafialnym, zaś drugi mniejszą wieś z kościołem pomocniczym. Terminy te nie były jednak ścisłe i używane konsekwentnie, np. na mapie Gilly’ego z lat 1802-1803 występują tylko kategorie: Kirchdorf oraz Dorf ohne Kirche."""@pl ;
+                           rdfs:isDefinedBy "Village is a locality composed of a group of buildings, mostly of residential and economic character, but sometimes, also industrial ones (i.e. ironworks, mill) as well as a belonging land, inhabited by people involved particularly in agricultural and construction activities or in farming industry (i.e. blacksmith or mill work), and not having city rights nor a status of a city or a town. Some villages in Early Middle Ages had a right to organise a fair and a market."@en ,
+                                            "Wieś jest to miejscowość składająca się z zabudowań mieszkalno-gospodarczych, niekiedy przemysłowych (np. kuźnia, młyn) wraz z przynależnymi do nich gruntami (rozłogi), zamieszkała przez ludność zajmującą się w większości zajęciami rolniczo-hodowlanymi oraz przemysłem wiejskim (np. kowalstwo, młynarstwo), nieposiadająca praw miejskich ani statusu miasta. Niekiedy we wczesnym średniowieczu posiadająca prawo odbywania targu."@pl ;
+                           rdfs:label "village"@en ,
+                                      "wieś"@pl ;
+                           rdfs:seeAlso <http://dbpedia.org/page/Village> ,
+                                        <http://gov.genealogy.net/types.owl#55> ,
+                                        <http://linkedgeodata.org/ontology/Village> ,
+                                        <http://vocab.getty.edu/aat/300008372> ,
+                                        <https://pzgik.geoportal.gov.pl/ontologies/prng/wies> ,
+                                        <https://www.wikidata.org/wiki/Q532> ,
+                                        "1. miejscowość zamieszkała przez ludzi, którzy trudnią się pracą na roli, 2. mieszkańcy takiej miejscowości, 3. tereny pozamiejskie, rolnicze, letniskowe, 4. ludzie trudniący się pracą na roli"@pl ,
+                                        "Jednostka osadnicza o zwartej lub rozproszonej zabudowie i istniejących funkcjach rolniczych lub związanych z nimi usługowych lub turystycznych, nieposiadająca praw miejskich lub statusu miasta"@pl ,
+                                        "Kirchdorf: Dorf mit Kirche (I) und Pfarrer, rechtlicher und religiöser Mittelpunkt einer (eventuell aus mehreren Filialdörfern bestehenden) politischen oder Pfarr-Gemeinde [Wieś z kościołem i parafią, prawne i religijne centrum gminy politycznej albo parafialnej (ewentualnie składającej się z kilku wsi filialnych, wsi z kościołami filialnymi]"@de ,
+                                        "Pfarrdorf: 1. Dorf, in dem die für die Pfarrgemeinde konstitutive Pfarrkirche (I) steht [wieś, w której stoi kościół parafialny właściwy dla całej parafii, gminy parafialnej]; 2. zu einer Pfarre (I) gehöriges Dorf [wieś należąca do parafii]"@de ,
+                                        "s. 15: 1. osada, której ludność zajmuje się uprawą roślin i chowem zwierząt, wieś: osada (osiedle wiejskie; teren zabudowany), na którym mieszka ludność pracująca w gospodarstwach wiejskich, koncentrująca większość środków produkcji, i na którym są dokonywane różne procesy produkcyjne, istnieje życie społeczne oraz kulturalne mieszkańców wsi (def. na podstawie Nowosielski 1964, Kiełczewska-Zaleska 1976, Chowaniem 1989); 2. podstawą (atomem) dla wsi nie jest pojedynczy wiejski budynek lecz ich komplet (zagroda), tworzący samodzielne gospodarstwo rolne z należącą doń powierzchnią ziemi --. Wieś w sensie antropogeograficznym jest częścią gminy (lub gromady), która stanowi grupę gospodarstw rolnych zabudowaną według jednolitego planu i tworzącą typ kształtu i skupienia (def. na podstawie Zaborski 1926); 3. to zbiorowisko ludzi albo osiedle z należącymi doń gruntami. Wieś: rozłóg i osada. O istnieniu wsi ma decydować także zestaw więzi wewnątrz wsi: rozłóg, siedlisko i ludność rolnicza (def. na podstawie Szymański 1969, Olechowski 1948); 4. wieś to społeczność lokalna, której funkcję produkcyjną uzupełniała funkcja rodziny. Wieś stanowi pewną historyczną formę struktury społecznej, względnie trwałą i jednolitą całość, której członkowie są ze sobą powiązani siecią zależności i więzi sprawiających, że całość ta jest wewnętrznie zintegrowana. Cechą konstytutywną tak rozumianej grupy jest określone terytorium geograficzne, które wspólnie użytkują, a efektem tego jest pewien stopień psychologicznego zespolenia całości lub części społeczności ze strukturą społeczno-przestrzenną jako znaczącą wartością kulturową. Podstawową funkcją środowiska kulturowego wsi, a zwłaszcza jego wartości przestrzennych jest kształtowanie poczucia tożsamości z rodzinną tradycją i jej wartościami oraz wynikającej stąd świadomości przynależności do miejscowej społeczności oraz identyfikacja z jej przestrzenią życiową (def. na podstawie Turowski 1992); 5. twór terytorialny mający granice, rozłóg ziemi, siedlisko (zagrodę),  stanowiące całość przestrzenną o określonych więzach społecznych i terytorialnych oraz uprawnieniach prawnych. -- Jest to osiedle nie mające praw miejskich (def. wg Tkocza 1992, s. 15–16)."@pl ,
+                                        "s. 29: wsią nazywamy osiedle w zasadzie otwarte, której ludność zajmuje się produkcją śródków żywności oraz surowców technicznych (tj. rolnictwem, hodowlą bydła, rybołówstwem itd.)"@pl ,
+                                        "t. 4, s. 365: wioska, imienie, dobro, grunt leżący; wieś targowa, wsie łowcze, osoczne, wołoskie."@pl ,
+                                        "t. 7, s. 594–595: osada rolnicza, z pewnej liczby chat złożona, sioło"@pl ,
+                                        "t. XX, s. 199–201: 1. osada, w której ludność zajmuje się głównie rolnictwem, 2. mieszkańcy wsi, ogół mieszkańców wsi."@pl ;
+                           <http://www.w3.org/2004/02/skos/core#altLabel> "Dorf"@de ,
+                                                                          "pagus"@la ,
+                                                                          "sioło"@pl ,
+                                                                          "villa"@la ,
+                                                                          "село"@ru ;
+                           <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Kirchdorf"@de ,
+                                                                             "Pfarrdorf"@de ,
+                                                                             "ager"@la ,
+                                                                             "osada"@pl ,
+                                                                             "osiedle wiejskie"@pl ,
+                                                                             "rus"@la ,
+                                                                             "siedlisko wiejskie"@pl ,
+                                                                             "vicus"@la ,
+                                                                             "wioseczka"@pl ,
+                                                                             "wioska"@pl ,
+                                                                             "włość i klucz"@pl ,
+                                                                             "źreb"@pl ,
+                                                                             "погост"@ru ;
+                           <http://www.w3.org/2004/02/skos/core#prefLabel> "village"@en ,
+                                                                           "wieś"@pl ;
+                           ontohgis:hasExternalIdentifier "2" ;
+                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                           ontohgis:hasTranslator ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_2 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "1. miejscowość zamieszkała przez ludzi, którzy trudnią się pracą na roli, 2. mieszkańcy takiej miejscowości, 3. tereny pozamiejskie, rolnicze, letniskowe, 4. ludzie trudniący się pracą na roli"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_2 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "Jednostka osadnicza o zwartej lub rozproszonej zabudowie i istniejących funkcjach rolniczych lub związanych z nimi usługowych lub turystycznych, nieposiadająca praw miejskich lub statusu miasta"@pl ;
+   rdfs:isDefinedBy ontohgis:document_9
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_2 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "Kirchdorf: Dorf mit Kirche (I) und Pfarrer, rechtlicher und religiöser Mittelpunkt einer (eventuell aus mehreren Filialdörfern bestehenden) politischen oder Pfarr-Gemeinde [Wieś z kościołem i parafią, prawne i religijne centrum gminy politycznej albo parafialnej (ewentualnie składającej się z kilku wsi filialnych, wsi z kościołami filialnymi]"@de ;
+   rdfs:isDefinedBy ontohgis:document_10
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_2 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "Pfarrdorf: 1. Dorf, in dem die für die Pfarrgemeinde konstitutive Pfarrkirche (I) steht [wieś, w której stoi kościół parafialny właściwy dla całej parafii, gminy parafialnej]; 2. zu einer Pfarre (I) gehöriges Dorf [wieś należąca do parafii]"@de ;
+   rdfs:isDefinedBy ontohgis:document_10
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_2 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "s. 15: 1. osada, której ludność zajmuje się uprawą roślin i chowem zwierząt, wieś: osada (osiedle wiejskie; teren zabudowany), na którym mieszka ludność pracująca w gospodarstwach wiejskich, koncentrująca większość środków produkcji, i na którym są dokonywane różne procesy produkcyjne, istnieje życie społeczne oraz kulturalne mieszkańców wsi (def. na podstawie Nowosielski 1964, Kiełczewska-Zaleska 1976, Chowaniem 1989); 2. podstawą (atomem) dla wsi nie jest pojedynczy wiejski budynek lecz ich komplet (zagroda), tworzący samodzielne gospodarstwo rolne z należącą doń powierzchnią ziemi --. Wieś w sensie antropogeograficznym jest częścią gminy (lub gromady), która stanowi grupę gospodarstw rolnych zabudowaną według jednolitego planu i tworzącą typ kształtu i skupienia (def. na podstawie Zaborski 1926); 3. to zbiorowisko ludzi albo osiedle z należącymi doń gruntami. Wieś: rozłóg i osada. O istnieniu wsi ma decydować także zestaw więzi wewnątrz wsi: rozłóg, siedlisko i ludność rolnicza (def. na podstawie Szymański 1969, Olechowski 1948); 4. wieś to społeczność lokalna, której funkcję produkcyjną uzupełniała funkcja rodziny. Wieś stanowi pewną historyczną formę struktury społecznej, względnie trwałą i jednolitą całość, której członkowie są ze sobą powiązani siecią zależności i więzi sprawiających, że całość ta jest wewnętrznie zintegrowana. Cechą konstytutywną tak rozumianej grupy jest określone terytorium geograficzne, które wspólnie użytkują, a efektem tego jest pewien stopień psychologicznego zespolenia całości lub części społeczności ze strukturą społeczno-przestrzenną jako znaczącą wartością kulturową. Podstawową funkcją środowiska kulturowego wsi, a zwłaszcza jego wartości przestrzennych jest kształtowanie poczucia tożsamości z rodzinną tradycją i jej wartościami oraz wynikającej stąd świadomości przynależności do miejscowej społeczności oraz identyfikacja z jej przestrzenią życiową (def. na podstawie Turowski 1992); 5. twór terytorialny mający granice, rozłóg ziemi, siedlisko (zagrodę),  stanowiące całość przestrzenną o określonych więzach społecznych i terytorialnych oraz uprawnieniach prawnych. -- Jest to osiedle nie mające praw miejskich (def. wg Tkocza 1992, s. 15–16)."@pl ;
+   rdfs:isDefinedBy ontohgis:document_8
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_2 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "s. 29: wsią nazywamy osiedle w zasadzie otwarte, której ludność zajmuje się produkcją śródków żywności oraz surowców technicznych (tj. rolnictwem, hodowlą bydła, rybołówstwem itd.)"@pl ;
+   rdfs:isDefinedBy ontohgis:document_16
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_2 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 4, s. 365: wioska, imienie, dobro, grunt leżący; wieś targowa, wsie łowcze, osoczne, wołoskie."@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_2 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 7, s. 594–595: osada rolnicza, z pewnej liczby chat złożona, sioło"@pl ;
+   rdfs:isDefinedBy ontohgis:document_5
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_2 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. XX, s. 199–201: 1. osada, w której ludność zajmuje się głównie rolnictwem, 2. mieszkańcy wsi, ogół mieszkańców wsi."@pl ;
+   rdfs:isDefinedBy ontohgis:document_6
+ ] .
+
+
+ontohgis:settlement_type_20 rdfs:comment "Colony is usually a part of another locality, more rarely, although these are not exceptional cases, it can have the status of a separate locality, usually a village. Both in the case where the colony is a separate locality or it is apart of another one, it is always located near the village (village or - sometimes - small town) from which its name is derived. On topographic maps, a colony is distinguished mainly by the explanatory abbreviation (pol.: kol.), by its own name, and morphologically."@en ,
+                                         "Kolonia jest przeważnie częścią miejscowości, rzadziej, choć nie są to wyjątkowe przypadki, ma obecnie status odrębnej miejscowości, z reguły wsi. Zarówno w przypadku, gdy kolonia jest odrębną miejscowością jak i częścią miejscowości, zawsze znajduje się w pobliżu miejscowości (wsi a wyjątkowo małego miasta) od której pochodzi jej nazwa. W ujęciu kartograficznym wyodrębniona przede wszystkim przez skrót kategorii (kol.), nazwę własną, oraz morfologicznie."@pl ;
+                            rdfs:isDefinedBy "Colony (pol. kolonia) is a built-up area located away from previously existing buildings (locality) to which it is related. It is created on newly developed land allocated as a result of enfranchisement, parceling, consolidation, or internal migration."@en ,
+                                             "Kolonia jest to obszar zabudowany oddalony od wcześniej istniejącej zabudowy, od której jest zależna, powstały na nowo zagospodarowanych gruntach przydzielonych w wyniku uwłaszczenia, parcelacji, komasacji lub migracji wewnętrznej."@pl ;
+                            rdfs:label "colony"@en ,
+                                       "kolonia"@pl ;
+                            rdfs:seeAlso <http://gov.genealogy.net/types.owl#121> ,
+                                         <https://pzgik.geoportal.gov.pl/ontologies/prng/kolonia> ,
+                                         <https://www.wikidata.org/wiki/Q12015918> ,
+                                         "Jednostka osadnicza powstała jako rezultat ekspansji miejscowości poza obszar wcześniej istniejącej zabudowy, w szczególności kolonia miasta, kolonia wsi."@pl ,
+                                         "t. 1, s. 900: Osiedla mieszkaniowe położone z dala od centrum miasta, osady: niewielka posiadłość ziemska , nowa osada lub gospodarstwo rolne na gruntach przydzielonych w wyniku uwłaszczenia, parcelacji, komasacji, migracji wewnętrznej itp."@pl ,
+                                         "t. 1-2, s. 1566: część miejscowości, zwykle  z dale od jej centrum, składająca się z nowobudowanych domostw, will, itp."@pl ,
+                                         "t. 2,  s. 240: zabudowa, osiedle, domy znajdujące się z dala od miasta, wsi, osady; kolonia mieszkaniowa na przedmieściach, kolonia położona daleko za wsią, gospodarstwo rolne położone za wsią, posiadłość ziemska z dala od innych."@pl ,
+                                         "t. 2, s. 404: mała posiadłość ziemska należąca do przybysza z obcego kraju; osada włościańska po uwłaszczeniu włościan; osada, miejsce, gdzie koloniści osadnicy mieszkają, budy, szopy, majdan."@pl ,
+                                         "t. 5, s. 720: kolonia rolna -- gospodarstwo rolne powstałe w oddaleniu od wsi na gruntach przydzielonych w wyniku uwłaszczenia, parcelacji, komasacji, itp.; także kilka lub kilkanaście zagród w rozproszeniu -- osada na ziemiach nowo zagospodarowanych"@pl ,
+                                         "„W ten sposób termin 'osada' może tutaj oznaczać nie tylko małe osiedla, złożone z jednego lub kilku wyodrębnionych terytorialnie gospodarstw włościańskich, jak to miało miejsce na innych ziemiach polskich, lecz i większe, o charakterze kolonii, t. j. osiedli rozrzuconych na większej przestrzeni, a powstałych zazwyczaj na gruntach rozparcelowanych przez władze zaborcze”"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "Kolonie"@de ,
+                                                                           "colonia"@la ,
+                                                                           "колония"@ru ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "chutor"@pl ,
+                                                                              "część wsi"@pl ,
+                                                                              "housing estate"@en ,
+                                                                              "osada"@pl ,
+                                                                              "osiedle"@pl ,
+                                                                              "przysiółek"@pl ,
+                                                                              "settlement"@en ,
+                                                                              "sioło"@pl ,
+                                                                              "stanica"@pl ,
+                                                                              "wybudowanie"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "colony"@en ,
+                                                                            "kolonia"@pl ;
+                            ontohgis:hasExternalIdentifier "20" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_20 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "Jednostka osadnicza powstała jako rezultat ekspansji miejscowości poza obszar wcześniej istniejącej zabudowy, w szczególności kolonia miasta, kolonia wsi."@pl ;
+   rdfs:isDefinedBy ontohgis:document_9
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_20 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 1, s. 900: Osiedla mieszkaniowe położone z dala od centrum miasta, osady: niewielka posiadłość ziemska , nowa osada lub gospodarstwo rolne na gruntach przydzielonych w wyniku uwłaszczenia, parcelacji, komasacji, migracji wewnętrznej itp."@pl ;
+   rdfs:isDefinedBy ontohgis:document_19
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_20 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 1-2, s. 1566: część miejscowości, zwykle  z dale od jej centrum, składająca się z nowobudowanych domostw, will, itp."@pl ;
+   rdfs:isDefinedBy ontohgis:document_18
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_20 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 2,  s. 240: zabudowa, osiedle, domy znajdujące się z dala od miasta, wsi, osady; kolonia mieszkaniowa na przedmieściach, kolonia położona daleko za wsią, gospodarstwo rolne położone za wsią, posiadłość ziemska z dala od innych."@pl ;
+   rdfs:comment ontohgis:document_20
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_20 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 2, s. 404: mała posiadłość ziemska należąca do przybysza z obcego kraju; osada włościańska po uwłaszczeniu włościan; osada, miejsce, gdzie koloniści osadnicy mieszkają, budy, szopy, majdan."@pl ;
+   rdfs:isDefinedBy ontohgis:document_5
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_20 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 5, s. 720: kolonia rolna -- gospodarstwo rolne powstałe w oddaleniu od wsi na gruntach przydzielonych w wyniku uwłaszczenia, parcelacji, komasacji, itp.; także kilka lub kilkanaście zagród w rozproszeniu -- osada na ziemiach nowo zagospodarowanych"@pl ;
+   rdfs:isDefinedBy ontohgis:document_11
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_20 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "„W ten sposób termin 'osada' może tutaj oznaczać nie tylko małe osiedla, złożone z jednego lub kilku wyodrębnionych terytorialnie gospodarstw włościańskich, jak to miało miejsce na innych ziemiach polskich, lecz i większe, o charakterze kolonii, t. j. osiedli rozrzuconych na większej przestrzeni, a powstałych zazwyczaj na gruntach rozparcelowanych przez władze zaborcze”"@pl ;
+   rdfs:isDefinedBy ontohgis:document_91
+ ] .
+
+
+ontohgis:settlement_type_21 rdfs:comment "A mine may be a separate locality, an individual one or a part of a cluster of localities sharing the same name, however, even if a mine is an integral part of a bigger locality, it has its particular name."@en ,
+                                         "Kopalnia może być odrębną miejscowością, zarówno samodzielną jak i częścią grupy miejscowości o tej samej nazwie, ale najczęściej, nawet jeśli znajduje się w obrębie większej miejscowości, ma własną nazwę."@pl ;
+                            rdfs:isDefinedBy "A mine (a locality) is a settlement with a mine (a factory) as the most important element."@en ,
+                                             "Kopalnia (miejscowość) jest to osada, w której główną rolę odgrywa kopalnia (obiekt)."@pl ;
+                            rdfs:label "mining settlement"@en ,
+                                       "osada górnicza"@pl ;
+                            rdfs:seeAlso <http://vocab.getty.edu/aat/300008464> ,
+                                         <https://www.wikidata.org/wiki/Q820254> ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "Bergwerksort"@de ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Bergwerk"@de ,
+                                                                              "Binge"@de ,
+                                                                              "Bruch"@de ,
+                                                                              "Miene"@de ,
+                                                                              "Schacht"@de ,
+                                                                              "gruba"@pl ,
+                                                                              "kopalnia"@pl ,
+                                                                              "mine"@en ,
+                                                                              "mining camp"@en ,
+                                                                              "mining community"@en ,
+                                                                              "mining town"@en ,
+                                                                              "рудник"@ru ,
+                                                                              "шахта"@ru ,
+                                                                              "шахтёрский город"@ru ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "mining settlement"@en ,
+                                                                            "osada górnicza"@pl ;
+                            ontohgis:hasExternalIdentifier "21" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
+
+
+ontohgis:settlement_type_23 rdfs:comment """Included as a kind of locality in Bystrzycki's register as abbreviation (\"lat. mor.\"); dinstinct symbol on topographic maps; included in DBTO10k as a \"communication buildings, stations and terminals\" (BUBD feature class).
+Functional distinctivness - distinguished as a kind of locality in Bystrzycki's register, and on topographic maps as distinct symbol, sometimes with the proper name.
+Morphological and spatial distinctivness - usually a lightouse is a building (structure) within the area of the locality or in its vicinity. 
+If it has its a particular (proper) name, it can be treated as a separate locality (interpretation of maps is necessary, see: Rozewie). Otherwise it is either part of another locality or an object (building/structure) in it (see: Hel, Jastarnia)."""@en ,
+                                         """Występuje jako rodzaj miejscowości u Bystrzyckiego w spisie (\"lat. mor.\"); na mapach osobna sygnatura. W BDOT10k jako budynek łączności, dworców i terminali.
+Odrębność funkcjonalna – wyróżniana jako rodzaj miejscowości u Bystrzyckiego, a na mapach topograficznych odrębnym znakiem, niekiedy z nazwą własną. Odrębność morfologiczna/przestrzenna – przeważnie jest obiektem na obszarze miejscowości lub w niewielkim od niej oddaleniu. Jeżeli posiada nazwę własną może być traktowana jako osobna miejscowość (konieczna interpretacja map; patrz: Rozewie). W przeciwnym razie jest albo częścią innej, większej miejscowości lub obiektem terenowym (budowlą) w niej (patrz: Hel, Jastarnia)."""@pl ;
+                            rdfs:isDefinedBy "A lighthouse (a locality) is a settlement in which a main role is played by a lighthouse (building)."@en ,
+                                             "Latarnia morska (miejscowość) to osada obejmująca latarnię morską (obiekt)."@pl ;
+                            rdfs:label "latarnia morska"@pl ,
+                                       "lighthouse"@en ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "Leuchtturm"@de ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "latarnia morska"@pl ,
+                                                                            "lighthouse"@en ;
+                            ontohgis:hasExternalIdentifier "23" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 ,
+                                                   ontohgis:person_9 .
+
+
+ontohgis:settlement_type_25 rdfs:comment """It can be either a separate locality (e.g. Celestynów) or a part of another locality, morphologically it is most often a complex of (summer) houses (Chylice, Skolimów), but also a typical (based on the interpretation of the topographic map drawing) non-urban built-up area (Choszczówka).
+Included as a kind of locality in Bystrzycki's register as explanatory abbreviation (\"letn.\"). All summer resorts in Bystrzycki's register are located near Warsaw. Exception: Wisła, Zełmianka (Stryj district).
+Included on topographic maps as a part of a place name annotation (\"letn.\"), but not in symbology keys (legends). On the MGI maps, summer resort is one of the types of localities. In DBTO10k as \"summer house\" (pol \"dom letniskowy\") in the feature class of single-family residential buildings (BUBD01)."""@en ,
+                                         """Może być albo osobną miejscowością (Celestynów) albo częścią miejscowości. Morfologicznie jest to najczęściej zabudowa złożona z domków letniskowych (Chylice, Skolimów), ale również typowa (na podstawie interpretacji rysunku mapy) zabudowa zwarta niemiejska (Choszczówka). 
+Występuje jako rodzaj miejscowości u Bystrzyckiego w spisie (\"letn.\"). 
+Wszystkie letniska u Bystrzyckiego znajdują się w okolicach Warszawy. Wyjątek: Wisła, Zełmianka (pow. Stryj).
+Występuje na mapach w nazwach miejscowości (letn.), ale nie w kluczach znaków. W legendach map WIG jest to jeden z rodzajów osiedli. W BDOT10k („dom letniskowy”) w klasie budynki mieszkalne jednorodzinne (BUBD01)."""@pl ;
+                            rdfs:isDefinedBy "Letnisko to miejscowość o charakterze wypoczynkowym, złożona z domków letniskowych lub posiadająca zwartą zabudowę"@pl ,
+                                             "Summer resort is a holiday locality consisting of holiday houses or densely built-up"@en ;
+                            rdfs:label "letnisko"@pl ,
+                                       "summer resort"@en ;
+                            rdfs:seeAlso <http://vocab.getty.edu/aat/300000547> ,
+                                         <http://vocab.getty.edu/aat/300000558> ,
+                                         <https://www.wikidata.org/wiki/Q317548> ,
+                                         <https://www.wikidata.org/wiki/Q875157> ,
+                                         "miejscowość wypoczynkowa; letni pobyt poza miastem w celach wypoczynkowych"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "osada letniskowa"@pl ,
+                                                                           "resort destination"@en ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Erholungsort"@de ,
+                                                                              "dom letniskowy"@pl ,
+                                                                              "resort town"@en ,
+                                                                              "sanatorium"@pl ,
+                                                                              "uzdrowisko"@pl ,
+                                                                              "willa"@pl ,
+                                                                              "курортный город"@ru ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "letnisko"@pl ,
+                                                                            "summer resort"@en ;
+                            ontohgis:hasExternalIdentifier "25" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 ,
+                                                   ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_25 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "miejscowość wypoczynkowa; letni pobyt poza miastem w celach wypoczynkowych"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+
+ontohgis:settlement_type_27 rdfs:comment "Dziś leśniczówka jest miejscowością lub budynkiem (BDOT10k), ale nie wszystkie leśniczówki-budynki (BUBD01) to leśniczówki-miejscowości (ADMS11). Przed wojną leśniczówka prawie zawsze była wyróżniana jako odrębna miejscowość."@pl ,
+                                         "Today, the forester's lodge is a locality or a building (DBTO10k), but not all forester's lodges (feature class: BUBD01) which are buildings are forester's lodges (feature class: ADMS11) understood as localities. Before the second world war, forester's lodge was almost always distinguished as a separate locality."@en ;
+                            rdfs:isDefinedBy "Forester's lodge (a locality) is a locality in which the main role is played by a forester's lodge (an area). Forester's lodge is a locality as long as it has a particular (proper) name and is not located in the immediate vicinity of another locality."@en ,
+                                             "Leśniczówka (miejscowość) to miejscowość, w której główną rolę pełni leśniczówka (obiekt). Leśniczówka jest miejscowością jeżeli posiada nazwę własną i jest przestrzennie wyodrębniona od innej miejscowości."@pl ;
+                            rdfs:label "forester's lodge"@en ,
+                                       "leśniczówka"@pl ;
+                            rdfs:seeAlso <http://gov.genealogy.net/types.owl#115> ,
+                                         <https://pzgik.geoportal.gov.pl/ontologies/prng/lesniczowka> ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Forestrey"@de ,
+                                                                              "Forst Amt"@de ,
+                                                                              "Hegerhaus"@de ,
+                                                                              "Jägerhaus"@de ,
+                                                                              "gajówka"@pl ,
+                                                                              "nadleśnictwo"@pl ,
+                                                                              "osada leśna"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "forester's lodge"@en ,
+                                                                            "leśniczówka"@pl ;
+                            ontohgis:hasExternalIdentifier "27" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_28 rdfs:comment "Miasteczko z zasady jest odrębną miejscowością. Na ziemiach polskich nie istniało rozróżnienie formalne między miastem i miasteczkiem, funkcjonowało ono natomiast na niektórych obszarach Rzeszy Niemieckiej (Flecken, Marktsiedlung - Stadt)."@pl ,
+                                         "Town is always (ex definitione) a separate locality. On the Polish lands, there was no formal distinction between the city and the town, but such distinction was present in some areas of the German Reich (Flecken, Marktsiedlung - Stadt)."@en ;
+                            rdfs:isDefinedBy "Miasteczko to małe miasto, odróżniające się od dużych miast wielkością (liczoną według miary właściwej dla danej epoki i regionu) i stopniem złożoności."@pl ,
+                                             "Town (pol. miasteczko) is a small city, distniguished from larger cities by it size (estimated by standards appropriate for given period and region) and complexity."@en ;
+                            rdfs:label "miasteczko"@pl ,
+                                       "town"@en ;
+                            rdfs:seeAlso <http://dbpedia.org/ontology/Town> ,
+                                         <http://gov.genealogy.net/types.owl#51> ,
+                                         <http://linkedgeodata.org/ontology/Town> ,
+                                         <http://vocab.getty.edu/aat/300008375> ,
+                                         <https://www.wikidata.org/wiki/Q3957> ,
+                                         "małe miasto, -- przen. ludność małego miasta"@pl ,
+                                         "małe miasto; pot. mieszkańcy małego miasta"@pl ,
+                                         "t. 13, s. 369-372: 1. Od znacz. 'miejsce' --; 2. Od znacz. 'wytyczony i najczęściej otoczony murem teren pokryty gęstą i planową zabudową"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "Städtchen"@de ,
+                                                                           "oppidulum"@la ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Flecken"@de ,
+                                                                              "miasto"@pl ,
+                                                                              "oppidum"@la ,
+                                                                              "osada targowa"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "miasteczko"@pl ,
+                                                                            "town"@en ;
+                            ontohgis:hasExternalIdentifier "28" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_28 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "małe miasto, -- przen. ludność małego miasta"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4 ,
+                    <https://sjp.pwn.pl/doroszewski/miasteczko;5451005.html>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_28 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "małe miasto; pot. mieszkańcy małego miasta"@pl ;
+   rdfs:isDefinedBy ontohgis:document_3 ,
+                    <https://sjp.pwn.pl/sjp/miasteczko;2482785.html>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_28 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 13, s. 369-372: 1. Od znacz. 'miejsce' --; 2. Od znacz. 'wytyczony i najczęściej otoczony murem teren pokryty gęstą i planową zabudową"@pl ;
+   rdfs:isDefinedBy ontohgis:document_2
+ ] .
+
+
+ontohgis:settlement_type_3 rdfs:comment "During those periods, when legal status of localities was established and defined, cities/towns were granted specific municipal rights (location bill), which should be considered as an auxiliary indicator for distinguishing cities/towns. A city/town may consists of other settlement units, like: a core city/town (a founded one), a district, a suburb, a castle, a gord. At least from the 13th to the 18th century, two parallel notions existed: general (meaning the whole settlement unit with its own society, economy, and urban structure, perceived mostly by intuition), and a city in its political and legal meaning, as a community with an extensive autonomy. As a consequence, cities within other city or units lying partly in and partly outside the city existed. For these complex structures, in this project, first explanations of the city should be applied."@en ,
+                                        "W okresach, w których status prawny miejscowości był ukształtowany miasta posiadały szczególne prawa miejskie (lokacyjne), które stanowią postawowe kryterium pomocnicze odróżniania miast. W skład miasta mogą wchodzić inne jednostki osadnicze, jak miasto właściwe (lokacyjne), dzielnica, przedmieście, zamek, gród. Przynamniej w okresie od XIII do XVIII w. funkcjonowały równolegle dwa pojęcia miasta: ogólne, obejmujące cały zespół osadniczy o odrębności społecznej, gospodarczej i urbanistycznej, postrzegane przede wszystkim intuicyjnie oraz miasto w sensie polityczno-prawnym, obdarzona względnie szeroką autonomią gmina. W konsekwencji mogły istnieć miasta w mieście i obiekty leżące jednocześnie w mieście i poza nim. Dla takich złożonych struktur w niniejszym projekcie należy się posługiwać pierwszym znaczeniem miasta."@pl ;
+                           rdfs:isDefinedBy "A city/town is a superior locality, distinguished from others, surrounding basic units by size (measured differently in different periods of time and regions), a level of complexity, and central functions provided for those units."@en ,
+                                            "Miasto jest to miejscowość wyższego rzędu, odróżniająca się od otaczających je podstawowych wielkością (liczoną według miary właściwej dla danej epoki i regionu), stopniem złożoności i funkcjami centralnymi względem nich."@pl ;
+                           rdfs:label "city / town"@en ,
+                                      "miasto"@pl ;
+                           rdfs:seeAlso <http://dbpedia.org/ontology/City> ,
+                                        <http://gov.genealogy.net/types.owl#51> ,
+                                        <http://linkedgeodata.org/ontology/City> ,
+                                        <http://vocab.getty.edu/aat/300008389> ,
+                                        <https://pzgik.geoportal.gov.pl/ontologies/prng/miasto> ,
+                                        <https://schema.org/City> ,
+                                        <https://www.wikidata.org/wiki/Q515> ,
+                                        "Jednostka osadnicza (wyodrębniony przestrzennie obszar zabudowy mieszkaniowej wraz z obiektami infrastruktury technicznej zamieszkany przez ludzi) o przewadze zwartej zabudowy i funkcjach nierolniczych posiadająca prawa miejskie bądź status miasta nadany w trybie określonym odrębnymi przepisami."@pl ,
+                                        "Skupisko ludności, odróżniające się od innych swymi głównie nierolniczymi funkcjami, znaczną wielkością oraz intensywnością zabudowy. Definicja ta musi być jednak interpretowana elastycznie i zawsze na tle aktualnej sieci osadniczej."@pl ,
+                                        "s. 63: Miasto jest osadą różniącą się od wsi i nierolniczych osad monofunkcyjnych względną wielkością z zagęszczoną i rozczłonkowaną zabudową, z ludnością wyspecjalizowaną zawodowo i rozwarstwioną społecznie oraz funkcjami centralnymi pełnionymi wobec określonego regionu lub lokalnej ludności w sferze polityki, panowania, obronności, gospodarki, kultu i kultury [Stadt ist eine vom Dorf und nichtagrarischen Einzwecksiedlungen unterschiedene Siedlung relativer Größe mit verdichteter, gegliederter Bebauung, beruflich spezialisierter und sozial geschichteter Bevölkerung und zentralen Funktionen politisch-herrschaftlich-militärischer, wirtschaftlicher und kultisch-kultureller Art für eine bestimmte Region oder regionale Bevölkerung]"@de ,
+                                        "t. 13, s. 37: Wytyczony i najczęściej otoczony murem teren, pokryty gęstą i planową zabudową tworzącą place i ulice, stanowiący mniej lub więcej samodzielną jednostkę administracyjną, samorządową, a czasem polityczną."@pl ;
+                           <http://www.w3.org/2004/02/skos/core#altLabel> "Stadt"@de ,
+                                                                          "civitas"@la ,
+                                                                          "oppidum"@la ,
+                                                                          "urbs"@la ,
+                                                                          "город"@ru ;
+                           <http://www.w3.org/2004/02/skos/core#hiddenLabel> "aglomeracja"@pl ,
+                                                                             "miasteczko"@pl ,
+                                                                             "osada miejska"@pl ,
+                                                                             "месте́чко"@ru ;
+                           <http://www.w3.org/2004/02/skos/core#prefLabel> "city / town"@en ,
+                                                                           "miasto"@pl ;
+                           ontohgis:hasExternalIdentifier "3" ;
+                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                           ontohgis:hasTranslator ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_3 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "Jednostka osadnicza (wyodrębniony przestrzennie obszar zabudowy mieszkaniowej wraz z obiektami infrastruktury technicznej zamieszkany przez ludzi) o przewadze zwartej zabudowy i funkcjach nierolniczych posiadająca prawa miejskie bądź status miasta nadany w trybie określonym odrębnymi przepisami."@pl ;
+   rdfs:isDefinedBy ontohgis:document_9
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_3 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "Skupisko ludności, odróżniające się od innych swymi głównie nierolniczymi funkcjami, znaczną wielkością oraz intensywnością zabudowy. Definicja ta musi być jednak interpretowana elastycznie i zawsze na tle aktualnej sieci osadniczej."@pl ;
+   rdfs:isDefinedBy ontohgis:document_11
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_3 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "s. 63: Miasto jest osadą różniącą się od wsi i nierolniczych osad monofunkcyjnych względną wielkością z zagęszczoną i rozczłonkowaną zabudową, z ludnością wyspecjalizowaną zawodowo i rozwarstwioną społecznie oraz funkcjami centralnymi pełnionymi wobec określonego regionu lub lokalnej ludności w sferze polityki, panowania, obronności, gospodarki, kultu i kultury [Stadt ist eine vom Dorf und nichtagrarischen Einzwecksiedlungen unterschiedene Siedlung relativer Größe mit verdichteter, gegliederter Bebauung, beruflich spezialisierter und sozial geschichteter Bevölkerung und zentralen Funktionen politisch-herrschaftlich-militärischer, wirtschaftlicher und kultisch-kultureller Art für eine bestimmte Region oder regionale Bevölkerung]"@de ;
+   rdfs:isDefinedBy ontohgis:document_12
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_3 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 13, s. 37: Wytyczony i najczęściej otoczony murem teren, pokryty gęstą i planową zabudową tworzącą place i ulice, stanowiący mniej lub więcej samodzielną jednostkę administracyjną, samorządową, a czasem polityczną."@pl ;
+   rdfs:isDefinedBy ontohgis:document_2
+ ] .
+
+
+ontohgis:settlement_type_33 rdfs:comment "A small locality organised in relation to a workplace or a particular occupation of its inhabitants. Settlement had usually been established as a separate locality, later on – especially in case of industrial settlements – particular settlements could develop into a city, merge with other settlement to create a new locality, or it could be incorporated into another locality. Depending on the type of inhabitants’ occupations one can, or could in the past, indicate a fair (market), craft, industrial, fishing, forestry, and railway settlements."@en ,
+                                         "Niewielka miejscowość zorganizowana w związku z miejscem lub rodzajem pracy mieszkańców. Osada powstawała z reguły jako odrębna miejscowość, później, dość często, szczególnie w przypadku osad przemysłowych, rozwijała się do rangi miasta, łączyła się z inną osadą jako odrębna miejscowość, lub była włączana do innej miejscowości. W zależności od rodzaju wykonywanej pracy wyróżnia lub wyróżniało się osady targowe, rzemieślnicze, przemysłowe, rybackie, leśne, kolejowe."@pl ,
+                                         "„W ten sposób termin 'osada' może tutaj oznaczać nie tylko małe osiedla, złożone z jednego lub kilku wyodrębnionych terytorialnie gospodarstw włościańskich, jak to miało miejsce na innych ziemiach polskich, lecz i większe, o charakterze kolonii, t. j. osiedli rozrzuconych na większej przestrzeni, a powstałych zazwyczaj na gruntach rozparcelowanych przez władze zaborcze”"@pl ;
+                            rdfs:isDefinedBy "Niewielka miejscowość zamieszkała przez ludność związaną z określonym typem lokalizacji lub rodzajem pracy nierolniczej i usytuowana z reguły w bezpośrednim sąsiedztwie miejsca pracy."@pl ,
+                                             "Settlement is a small locality inhabited by people associated with a particular type of location or a type of a non-agricultural work and lying mostly in the vicinity of a workplace."@en ;
+                            rdfs:label "osada"@pl ,
+                                       "settlement"@en ;
+                            rdfs:seeAlso <http://dbpedia.org/page/Hamlet_(place)> ,
+                                         <http://gov.genealogy.net/types.owl#120> ,
+                                         <http://vocab.getty.edu/aat/300008369> ,
+                                         <https://pzgik.geoportal.gov.pl/ontologies/prng/osada> ,
+                                         <https://www.wikidata.org/wiki/Q5084> ,
+                                         "Niewielka jednostka osadnicza na terenie wiejskim o odmiennym (wyróżniającym się) charakterze zabudowy albo zamieszkana przez ludność związaną z miejscem lub rodzajem pracy, innymi niż wyżej wymienione [osada młyńska, osada leśna, osada rybacka, osada kolejowa, osada po byłem PGR]; źródło: ustawa z dnia 29 sierpnia 2003 r. o urzędowych nazwach miejscowości i obiektów fizjograficznych."@pl ,
+                                         "Niewielka jednostka osadnicza na terenie wiejskim o odmiennym(wyróżniającym się) charakterze zabudowy albo zamieszkana przez ludność zwiazaną z określonym miejscem lub rodzajem pracy, w szczególności: osada młyńska, osada leśna, osada rybacka, osada kolejowa, osada po byłym państwowym gospodarstwie rolnym; osada może być samodzielna lub może stanowić część innej jednostki osadniczej."@pl ,
+                                         "niewielka miejscowość, niemająca praw osiedla czy miasta; też: mieszkańcy takiej miejscowości"@pl ,
+                                         "osiedle typu wiejskiego pośrednie między wsią a miasteczkiem; kolonia, mieszkańcy tego osiedla"@pl ,
+                                         "t. 22, s. 99: 1. Osiedle, miejsce zamieszkałe przez osadzoną ludność, terytorium zamieszkałe, -- a. Siedlisko, mieszkanie --; 2. Mieszkańcy osiedla; ludność żyjąca na jakimś terenie --; 3. Miejsce zdatne, dogodne do osiedlenia się --; 4. Zasiedlenie pustego miejsca, colonia."@pl ,
+                                         "t. 3, s. 547: osada, koloniia, mieysce, gdzie się nowi mieszkańcy sadowią, eine Kolonie (cf. wola), Pflanzstadt, Pflanzort, Ansiedlung; -- Vd. selizhzhe, preselishe, selitva, naselitva; Rs.  колонїя, селенїе (ob. sieło, sioło), поселенїе, селишьба."@pl ,
+                                         "t. 3, s. 836-837: 1.a. miejsce, gdzie ś. nowi mieszkańcy usadowili, kolonja --; b. miejsce zajęte przez mieszkańców, większe od wsi a mniejsze do miasta --; c. [Osiedle] grunt, na którym osadzano chłopa; sadyba, zagroda włościańska"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "посёлок"@ru ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Ansiedlung"@de ,
+                                                                              "Kolonie"@de ,
+                                                                              "Siedlung"@de ,
+                                                                              "kolonia"@pl ,
+                                                                              "miasteczko"@pl ,
+                                                                              "osiedle"@pl ,
+                                                                              "sadyba"@pl ,
+                                                                              "zagroda włościańska"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "osada"@pl ,
+                                                                            "settlement"@en ;
+                            ontohgis:hasExternalIdentifier "33" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_33 ;
+   owl:annotatedProperty rdfs:comment ;
+   owl:annotatedTarget "„W ten sposób termin 'osada' może tutaj oznaczać nie tylko małe osiedla, złożone z jednego lub kilku wyodrębnionych terytorialnie gospodarstw włościańskich, jak to miało miejsce na innych ziemiach polskich, lecz i większe, o charakterze kolonii, t. j. osiedli rozrzuconych na większej przestrzeni, a powstałych zazwyczaj na gruntach rozparcelowanych przez władze zaborcze”"@pl ;
+   rdfs:isDefinedBy ontohgis:document_91
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_33 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "Niewielka jednostka osadnicza na terenie wiejskim o odmiennym (wyróżniającym się) charakterze zabudowy albo zamieszkana przez ludność związaną z miejscem lub rodzajem pracy, innymi niż wyżej wymienione [osada młyńska, osada leśna, osada rybacka, osada kolejowa, osada po byłem PGR]; źródło: ustawa z dnia 29 sierpnia 2003 r. o urzędowych nazwach miejscowości i obiektów fizjograficznych."@pl ;
+   rdfs:isDefinedBy ontohgis:document_22
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_33 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "Niewielka jednostka osadnicza na terenie wiejskim o odmiennym(wyróżniającym się) charakterze zabudowy albo zamieszkana przez ludność zwiazaną z określonym miejscem lub rodzajem pracy, w szczególności: osada młyńska, osada leśna, osada rybacka, osada kolejowa, osada po byłym państwowym gospodarstwie rolnym; osada może być samodzielna lub może stanowić część innej jednostki osadniczej."@pl ;
+   rdfs:isDefinedBy ontohgis:document_9
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_33 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "niewielka miejscowość, niemająca praw osiedla czy miasta; też: mieszkańcy takiej miejscowości"@pl ;
+   rdfs:isDefinedBy ontohgis:document_3 ,
+                    <https://sjp.pwn.pl/sjp/osada;2496282.html>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_33 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "osiedle typu wiejskiego pośrednie między wsią a miasteczkiem; kolonia, mieszkańcy tego osiedla"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4 ,
+                    <https://sjp.pwn.pl/doroszewski/osada;5467524.html>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_33 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 22, s. 99: 1. Osiedle, miejsce zamieszkałe przez osadzoną ludność, terytorium zamieszkałe, -- a. Siedlisko, mieszkanie --; 2. Mieszkańcy osiedla; ludność żyjąca na jakimś terenie --; 3. Miejsce zdatne, dogodne do osiedlenia się --; 4. Zasiedlenie pustego miejsca, colonia."@pl ;
+   rdfs:isDefinedBy ontohgis:document_2
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_33 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 3, s. 547: osada, koloniia, mieysce, gdzie się nowi mieszkańcy sadowią, eine Kolonie (cf. wola), Pflanzstadt, Pflanzort, Ansiedlung; -- Vd. selizhzhe, preselishe, selitva, naselitva; Rs.  колонїя, селенїе (ob. sieło, sioło), поселенїе, селишьба."@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_33 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 3, s. 836-837: 1.a. miejsce, gdzie ś. nowi mieszkańcy usadowili, kolonja --; b. miejsce zajęte przez mieszkańców, większe od wsi a mniejsze do miasta --; c. [Osiedle] grunt, na którym osadzano chłopa; sadyba, zagroda włościańska"@pl ;
+   rdfs:isDefinedBy ontohgis:document_5
+ ] .
+
+
+ontohgis:settlement_type_34 rdfs:comment """In a general meaning, currently obsolete, an expression for every settlement unit (urban or rural one). Understood as such, it had been considered a separate locality.
+In urban studies, this notion is derived from a \"neighbouring unit\" idea, covering a group of residential buildings with a service facilities and green areas. As a part of a locality, \"osiedle\" may be recognised by its particular name, physiognomy (i. e. a group of blocks of flats, detached houses), topography (occupied area), and a period, when it was established. 
+In cartography, it may be distinguished by its own name preceded by an abbreviation (i.e. Os. Zdobycz Robotnicza) as well as morphology."""@en ,
+                                         """W znaczeniu ogólnym, rzadko obecnie stosowanym, określenie każdej jednostki osadniczej (osiedle miejskie, osiedle wiejskie). W tym znaczeniu jest to osobna miejscowość.
+W urbanistyce (planowaniu przestrzennym) pojęcie osiedla wywodzi się z koncepcji „jednostki sąsiedzkiej”, na którą składa się zespół budynków mieszkalnych wraz z zapleczem obiektów usługowych oraz terenów zielonych. Jako część miejscowości osiedle wyróżnia się poprzez nazwę, swoją fizjonomię (np. osiedle bloków mieszkalnych, domków jednorodzinnych), topografię (jest wyodrębnione przestrzennie), a także przez okres powstania.
+W ujęciu kartograficznym wyodrębnione przez nazwę własną, poprzedzoną  skrótem  kategorii (np. Os. Zdobycz Robotnicza) oraz morfologicznie."""@pl ;
+                            rdfs:isDefinedBy "Housing estate is an area covering a group of residential buildings, being an integral part of a city ( a town), or - rarely - a village."@en ,
+                                             "Obszar obejmujący zespół budynków mieszkalnych, stanowiący integralną część miasta, a niekiedy wsi."@pl ;
+                            rdfs:label "housing developments"@en ,
+                                       "osiedle"@pl ;
+                            rdfs:seeAlso <http://dbpedia.org/page/Housing_development> ,
+                                         <http://vocab.getty.edu/aat/300000498> ,
+                                         <https://pzgik.geoportal.gov.pl/ontologies/prng/osiedle> ,
+                                         <https://www.wikidata.org/wiki/Q2282602> ,
+                                         "10. Rodzaj miejscowości (Klasa: AD_RodzajMiejscowosciKod): Zespół mieszkaniowy stanowiący integralną część miasta lub wsi; źródło: ustawa z dnia 29 sierpnia 2003 r. o urzędowych nazwach miejscowości i obiektów fizjograficznych."@pl ,
+                                         "12. Typ ciągu komunikacyjnego (Klasa: AD_TypUlicyKod): Część miasta, wsi lub osady, dla której utworzono odrębny spójny zbiór numerów porządkowych nieprzyporządkowanych do żadnej ulicy ani placu."@pl ,
+                                         "Rodzaj jednostki pomocniczej (Klasa: AD_RodzajJednostkiPomocniczej): Część miasta lub wsi, której uchwałą rady gminy nadano status jednostki pomocniczej."@pl ,
+                                         "t. 2, s. 526: nieduże skupisko budynków miejskich lub wiejskich, zespół bloków mieszkalnych, willowe, przyfabryczne, robotnicze, mieszkaniowe"@pl ,
+                                         "t. 20, s. 56: osiedle mieszkaniowe – zespół  mieszkaniowy stanowiący strukturalną jednostkę mieszkaniową w mieście; pojęcie „osiedle mieszkaniowe” wywodzi się z koncepcji jednostki sąsiedzkiej; wielkość osiedla mieszkaniowego wynika z zasięgu pieszego dojścia (600–800 m) do ośrodka usługowego oraz gęstości zaludnienia (5–20 tys. mieszk.) obszaru obsługiwanego przez ten ośrodek. Stanowi zespół budynków mieszkalnych wraz z integralnym zapleczem obiektów usługowych oraz terenów zieleni; niekiedy są wydzielane części osiedli mieszkaniowych – kolonie, złożone z kilku bloków mieszkalnych; kilka osiedli mieszkaniowych tworzy dzielnicę."@pl ,
+                                         "t. 22, s. 124: osiedla, osiedlisko – siedziba, gospodarstwo wraz z zabudowaniami"@pl ,
+                                         "t. 3, s. 590: osiedlić, na osadzie czyli siedlisku postanowić kogoś, osadzić go; osiedlisko – miejsce osiedlenia, osada, osiadłość"@pl ,
+                                         "t. 6, s. 1121: nieduże skupienie siedzib ludzkich (miejskich lub wiejskich); reg. na wsi: dom mieszkalny wraz z zabudowaniami gospodarczymi, zagroda, dostatnie osiedle bogatego chłopa, sołtysowe osiedle"@pl ,
+                                         "zespół mieszkaniowy stanowiący integralną część miasta lub wsi"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "Wohnsiedlung"@de ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Ansiedlung"@de ,
+                                                                              "Siedlung"@de ,
+                                                                              "część miasta"@pl ,
+                                                                              "dzielnica"@pl ,
+                                                                              "hamlet"@en ,
+                                                                              "housing estate"@en ,
+                                                                              "kolonia"@pl ,
+                                                                              "osada"@pl ,
+                                                                              "osiedle willowe"@pl ,
+                                                                              "osiedlisko"@pl ,
+                                                                              "residential quarter"@en ,
+                                                                              "settlement"@en ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "housing developments"@en ,
+                                                                            "osiedle"@pl ;
+                            ontohgis:hasExternalIdentifier "34" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 ,
+                                                   ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_34 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "10. Rodzaj miejscowości (Klasa: AD_RodzajMiejscowosciKod): Zespół mieszkaniowy stanowiący integralną część miasta lub wsi; źródło: ustawa z dnia 29 sierpnia 2003 r. o urzędowych nazwach miejscowości i obiektów fizjograficznych."@pl ;
+   rdfs:isDefinedBy ontohgis:document_22
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_34 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "12. Typ ciągu komunikacyjnego (Klasa: AD_TypUlicyKod): Część miasta, wsi lub osady, dla której utworzono odrębny spójny zbiór numerów porządkowych nieprzyporządkowanych do żadnej ulicy ani placu."@pl ;
+   rdfs:isDefinedBy ontohgis:document_22
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_34 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "Rodzaj jednostki pomocniczej (Klasa: AD_RodzajJednostkiPomocniczej): Część miasta lub wsi, której uchwałą rady gminy nadano status jednostki pomocniczej."@pl ;
+   rdfs:isDefinedBy ontohgis:document_22
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_34 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 2, s. 526: nieduże skupisko budynków miejskich lub wiejskich, zespół bloków mieszkalnych, willowe, przyfabryczne, robotnicze, mieszkaniowe"@pl ;
+   rdfs:isDefinedBy ontohgis:document_19
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_34 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 20, s. 56: osiedle mieszkaniowe – zespół  mieszkaniowy stanowiący strukturalną jednostkę mieszkaniową w mieście; pojęcie „osiedle mieszkaniowe” wywodzi się z koncepcji jednostki sąsiedzkiej; wielkość osiedla mieszkaniowego wynika z zasięgu pieszego dojścia (600–800 m) do ośrodka usługowego oraz gęstości zaludnienia (5–20 tys. mieszk.) obszaru obsługiwanego przez ten ośrodek. Stanowi zespół budynków mieszkalnych wraz z integralnym zapleczem obiektów usługowych oraz terenów zieleni; niekiedy są wydzielane części osiedli mieszkaniowych – kolonie, złożone z kilku bloków mieszkalnych; kilka osiedli mieszkaniowych tworzy dzielnicę."@pl ;
+   rdfs:isDefinedBy ontohgis:document_21
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_34 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 22, s. 124: osiedla, osiedlisko – siedziba, gospodarstwo wraz z zabudowaniami"@pl ;
+   rdfs:isDefinedBy ontohgis:document_2
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_34 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 3, s. 590: osiedlić, na osadzie czyli siedlisku postanowić kogoś, osadzić go; osiedlisko – miejsce osiedlenia, osada, osiadłość"@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_34 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 6, s. 1121: nieduże skupienie siedzib ludzkich (miejskich lub wiejskich); reg. na wsi: dom mieszkalny wraz z zabudowaniami gospodarczymi, zagroda, dostatnie osiedle bogatego chłopa, sołtysowe osiedle"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_34 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "zespół mieszkaniowy stanowiący integralną część miasta lub wsi"@pl ;
+   rdfs:isDefinedBy ontohgis:document_9
+ ] .
+
+
+ontohgis:settlement_type_35 rdfs:comment "Industrial settlement usually emerged as a separate locality, later, quite often, it developed to the rank of the city, merged with another locality creating a separate one, or was incorporated into another locality."@en ,
+                                         "Osada fabryczna powstawała z reguły jako odrębna miejscowość, później, dość często rozwijała się do rangi miasta, łączyła się z inną osadą jako odrębna miejscowość, lub była włączana do innej miejscowości."@pl ;
+                            rdfs:isDefinedBy "Industrial settlement is a settlement in which a main role is played by a factory."@en ,
+                                             "Osada fabryczna jest to osada, w której główną rolę pełni fabryka."@pl ;
+                            rdfs:label "industrial settlement"@en ,
+                                       "osada fabryczna"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "osada przemysłowa (pl)" ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "conlocationen"@la ,
+                                                                              "der Ortschaft"@de ,
+                                                                              "der Siedlung"@de ,
+                                                                              "die Ansiedlung"@de ,
+                                                                              "die Kolonie"@de ,
+                                                                              "kolonia"@pl ,
+                                                                              "miasteczko"@pl ,
+                                                                              "miejscowość"@pl ,
+                                                                              "osiedle"@pl ,
+                                                                              "sadyba"@pl ,
+                                                                              "settlement"@en ,
+                                                                              "zagroda włościańska"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "industrial settlement"@en ,
+                                                                            "osada fabryczna"@pl ;
+                            ontohgis:hasExternalIdentifier "35" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_36 rdfs:comment "Osada leśna powstawała z reguły jako odrębna, niewielka miejscowość, położona w obrębie lub na skraju obszaru leśnego."@pl ,
+                                         "The forest settlements were usually formed as a separate, small locality, located within or near the forest."@en ;
+                            rdfs:isDefinedBy "A forest settlement is a small settlement located within or at the boundaries of a forest area, inhabited by people involved in administration, exploitation, or availing the surrounding forest areas."@en ,
+                                             "Osada leśna jest to niewielka osada położona w obrębie lub na skraju obszaru leśnego, zamieszkała przez ludność związaną z administrowaniem, eksploatacją lub wykorzystywaniem otaczających obszarów leśnych."@pl ;
+                            rdfs:label "forest settlement"@en ,
+                                       "osada leśna"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Forestrey"@de ,
+                                                                              "Forst Amt"@de ,
+                                                                              "Jagerhaus"@de ,
+                                                                              "gajówka"@pl ,
+                                                                              "leśnictwo"@pl ,
+                                                                              "leśniczówka"@pl ,
+                                                                              "nadleśnictwo"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "forest settlement"@en ,
+                                                                            "osada leśna"@pl ;
+                            ontohgis:hasExternalIdentifier "36" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 ,
+                                                   ontohgis:person_9 .
+
+
+ontohgis:settlement_type_37 rdfs:comment "Osada miejska to miejscowość."@pl ,
+                                         "Termin był stosowany dla oznaczenia ośrodków, które utraciły prawa miejskie po powstaniu styczniowym. Osada miejska mogła być stosowana także sensie szerszym, obejmującym wszystkie jednostki osadnicze o charakterze miejskim, np. duże miasto, przedmieścia itp."@pl ,
+                                         "This notion was used to mark localites that lost their city rights after the \"January Uprising\". The urban settlement could also be used in a broader sense, encompassing all settlement units of urban character, e.g. a big city, suburbs, etc."@en ,
+                                         "Urban settlement is a locality."@en ;
+                            rdfs:isDefinedBy "Osada miejska to miejscowość posiadająca wcześniej prawa miejskie i aktualnie ich pozbawiona."@pl ,
+                                             "Urban settlement is a locality which used to have city rights, but currently without them."@en ;
+                            rdfs:label "osada miejska"@pl ,
+                                       "urban settlement"@en ;
+                            rdfs:seeAlso <http://dbpedia.org/page/Urban-type_settlement> ,
+                                         <https://www.wikidata.org/wiki/Q18432972> ,
+                                         <https://www.wikidata.org/wiki/Q2989457> ,
+                                         "t. 20. s.47: od 1867 nazwa „osada miejska” jest używana dla niewielkich osiedli pozbawionych praw miejskich, które nie są wsiami."@enpl ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "miasteczko"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "osada miejska"@pl ,
+                                                                            "urban settlement"@en ;
+                            ontohgis:hasExternalIdentifier "37" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_37 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 20. s.47: od 1867 nazwa „osada miejska” jest używana dla niewielkich osiedli pozbawionych praw miejskich, które nie są wsiami."@enpl ;
+   rdfs:comment ontohgis:document_21
+ ] .
+
+
+ontohgis:settlement_type_38 rdfs:comment "Mill settlement often emereged as a separete locality, which might later be combined with another locality or become a part of it."@en ,
+                                         "Osada młyńska powstawała często jako odrębna miejscowość, później łączyła się niekiedy z inną osadą  lub była włączana do innej miejscowości."@pl ;
+                            rdfs:isDefinedBy "Mill settlement is a settlement in which a main role is played by a mill, most often a watermill, but it also might be a windmill or wind turbine."@en ,
+                                             "Osada młyńska jest to osada, w której główną rolę pełni młyn, najczęściej młyn wodny, ale może to być też również wiatrak lub turbina wiatrowa."@pl ;
+                            rdfs:label "mill settlement"@en ,
+                                       "osada młyńska"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "conlocationen"@la ,
+                                                                              "der Ortschaft"@de ,
+                                                                              "der Siedlung"@de ,
+                                                                              "die Ansiedlung"@de ,
+                                                                              "die Kolonie"@de ,
+                                                                              "kolonia"@pl ,
+                                                                              "miasteczko"@pl ,
+                                                                              "miejscowość"@pl ,
+                                                                              "osiedle"@pl ,
+                                                                              "sadyba"@pl ,
+                                                                              "settlement"@en ,
+                                                                              "zagroda włościańska"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "mill settlement"@en ,
+                                                                            "osada młyńska"@pl ;
+                            ontohgis:hasExternalIdentifier "38" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_41 rdfs:comment "In each analysed case, a rectory being a separate settlement, lays in a vicinity of a village, or a town/city with the same name. In cartographical sources, one can find it presented separately, with its proper name, an abbreviation of a category (i.e. pol “pleb.”, which is “rect.”), and distinguished by its morphology. A rectory differs slightly from the house of a provost, but we leave this difference aside."@en ,
+                                         "We wszystkich analizowanych przypadkach jeżeli plebania jest odrębną miejscowością, to znajduje się w pobliżu wsi, miasta lub osady o tej samej nazwie. W ujęciu kartograficznym wyodrębniona przez nazwę własną, skrót kategorii (np. pleb.) oraz morfologicznie. Plebania różni się nieco od probostwa, gdyż pleban nie jest tożsamy z proboszczem, ale różnicę tę pomijamy."@pl ;
+                            rdfs:isDefinedBy "Plebania jest to miejscowość, w której główną rolę pełni plebania jako obiekt sakralny."@pl ,
+                                             "Rectory is a locality, where the main role is played by a rectory, a home of a provost, as a sacral object."@en ;
+                            rdfs:label "plebania"@pl ,
+                                       "rectory"@en ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "curionatus"@la ,
+                                                                              "curionis domus"@la ,
+                                                                              "curionium"@la ,
+                                                                              "die Pfarre"@de ,
+                                                                              "die Pfarrwohnung"@de ,
+                                                                              "dom plebański"@pl ,
+                                                                              "parafia"@pl ,
+                                                                              "parochia"@la ,
+                                                                              "pastorówka"@pl ,
+                                                                              "plebanatus"@la ,
+                                                                              "popówka"@pl ,
+                                                                              "probostwo"@pl ,
+                                                                              "wikariatka"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "plebania"@pl ,
+                                                                            "rectory"@en ;
+                            ontohgis:hasExternalIdentifier "41" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
+
+
+ontohgis:settlement_type_43 rdfs:comment """Przedmieście z zasady jest częścią miejscowości: miasta. 
+W miastach obwarowanych obrębem miasta była linia fortyfikacji, szczególnie murów.
+Przedmieście mogło mieć różny stopień odrębności prawnej względem miasta. Jest fenomenem charakterystycznym raczej dla epoki przedprzemysłowej. Większość przedmieść, szczególnie od schyłku XVIII w., była wcielana prawnie i następnie funkcjonalnie i morfologicznie do miasta; nazwa zazwyczaj zanikała lub nabierała innego znaczenia.
+Należy odróżnić od przedmieścia osady przedmiejskie, które były w znacznym stopniu niezależne od miasta właściwego lub wręcz sprawowały funkcje centralne względem niego, np. ze względu na siedzibę władz. Taka sytuacja była częsta w okresie lokacyjnym w przypadku większych ośrodków (gród książęcy i katedra poza gminą lokacyjną)."""@pl ,
+                                         """Suburb is always (ex definitione) a part of a locality (city, town).
+In the fortified cities, the area of the core city was limted by the fortifications, especially by the walls.
+The suburb could have a different degree of legal separation from the city. It is an entity typical rather for the pre-industrial era. Most of the suburbs, especially from the end of the 18th c., were incorporated legally and then functionally as well as morphologically into the city. The particular name of the suburb usually disappeared or obtained a different meaning.
+It is necessary to distinguish  suburbs from the suburban settlements which were largely independent of the neighboring city or even held central functions to it, e.g. due to the location of the seats of the authorities. Such a situation was common during the first stages of cities establishment, especially for larger centers (prince's stronghold and the cathedral outside the main municipality)."""@en ;
+                            rdfs:isDefinedBy "Przedmieście to peryferyjna część miasta, tj. położona poza obrębem miasta właściwego (lokacyjnego), wyodrębniona przestrzennie lub morfologicznie i z własną nazwą, wobec której miasto pełni funkcje centralne."@pl ,
+                                             "Suburb is a peripheral part of the city, towards which the city performs central functions. A suburb is located outside its initial location city; distinguished spatially or morphologically and with its own (proper) name."@en ;
+                            rdfs:label "Vorstadt"@de ,
+                                       "przedmieście"@pl ,
+                                       "suburb"@en ,
+                                       "suburbium"@la ;
+                            rdfs:seeAlso <http://linkedgeodata.org/ontology/Suburb> ,
+                                         "Obszar wokół miasta, w ówczesnej Polsce i Europie uzależniony od niego prawnie i gospodarczo"@pl ,
+                                         "osada, teren, posiadłość poza obrębem murów miejskich"@pl ,
+                                         "peryferyjna dzielnica miasta"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "osada podmiejska"@pl ,
+                                                                              "osada przedmiejska"@pl ,
+                                                                              "wieś podmiejska"@pl ;
+                            ontohgis:hasExternalIdentifier "43" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_43 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "Obszar wokół miasta, w ówczesnej Polsce i Europie uzależniony od niego prawnie i gospodarczo"@pl ;
+   rdfs:isDefinedBy ontohgis:document_2
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_43 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "osada, teren, posiadłość poza obrębem murów miejskich"@pl ;
+   rdfs:isDefinedBy ontohgis:document_6
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_43 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "peryferyjna dzielnica miasta"@pl ;
+   rdfs:isDefinedBy ontohgis:document_3
+ ] .
+
+
+ontohgis:settlement_type_44 rdfs:isDefinedBy "Hamlet (pol \"przysiółek\") is a small group of buildings belonging to another locality, located on its land, in a remote part, and legally associated with it."@en ,
+                                             "Przysiółek to mała grupa zabudowań, należących do innej miejscowości, położona na jej gruntach, w oddaleniu od niej i prawnie z nią związana."@pl ;
+                            rdfs:label "hamlet"@en ,
+                                       "przysiółek"@pl ;
+                            rdfs:seeAlso <http://linkedgeodata.org/ontology/Hamlet> ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "mała wioska (pl), niesamodzielna osada (pl), skupisko gospodarstw (pl)" ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Colonie"@de ,
+                                                                              "Dorf"@de ,
+                                                                              "Unsiedlung"@de ,
+                                                                              "kolonia"@pl ,
+                                                                              "osada"@pl ,
+                                                                              "predium"@la ,
+                                                                              "przeszolek"@pl ,
+                                                                              "siadło"@pl ,
+                                                                              "siedlisko"@pl ,
+                                                                              "siedziba"@pl ,
+                                                                              "wieś"@pl ,
+                                                                              "wioska"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "hamlet"@en ,
+                                                                            "przysiółek"@pl ;
+                            ontohgis:hasExternalIdentifier "44" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_45 rdfs:comment "Included as locality type in Bystrzycki's register in the abbreviation list (pol \"kol.\"; \"prz. k.\");included on topographic maps marked with the explanatory abbreviation (pol \"p.\"; ger \"hp.\");included in DBTO10k in the \"objects related to communication\" feature class (OIKM)."@en ,
+                                         "Występuje jako rodzaj miejscowości u Bystrzyckiego w spisie (prz. kol.; prz.. k.); na mapach jako „p.” – przystanek lub „hp.” (ger Haltepunkt). W BDOT10k w klasie obiekt związany z komunikacją."@pl ,
+                                         "dworzec kolejowy"@pl ;
+                            rdfs:isDefinedBy "Przystanek kolejowy (miejscowość) jest to osada, w której główną rolę odgrywa przystanek kolejowy (obiekt)."@pl ,
+                                             "Train stop (locality) is a settlement where the main role is played by a train stop (object)."@en ;
+                            rdfs:label "przystanek kolejowy"@pl ,
+                                       "train stop"@en ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "Haltepunkt (de)" ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Stacja kolejowa"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "przystanek kolejowy"@pl ,
+                                                                            "train stop"@en ;
+                            ontohgis:hasExternalIdentifier "45" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_47 rdfs:comment "If residential buildings were erected around the tar pitch, it could be a kind of a separate forest settlement. The boundary between a tar pitch as an economic facility and a kind of forest settlement was blurry. It dependended on the seasonality and permanence of habitation."@en ,
+                                         "Jeżeli wokół smolarni utrwaliła się zabudowa mieszkalna to smolarnia mogła stanowić rodzaj odrębnej osady leśnej. Granica między smolarnią jako obiektem gospodarczym a smolarnią jako rodzajem osady leśnej była płynna. Była uzależniona od sezonowości i stałości zamieszkiwania."@pl ;
+                            rdfs:isDefinedBy "Smolarnia (miejscowość) jest to osada, w której główną rolę pełni smolarnia jako obiekt gospodarczy."@pl ,
+                                             "Tar pitch (locality) is a settlement where the main role is played by a tar pitch (industrial facility)."@en ;
+                            rdfs:label "smolarnia"@pl ,
+                                       "tar pitch"@en ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "der Teerofen (de), smolanoi zawod (ru)" ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "dziegciarnia"@pl ,
+                                                                              "huta"@pl ,
+                                                                              "osada leśna"@pl ,
+                                                                              "terpentyniarnia"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "smolarnia"@pl ,
+                                                                            "tar pitch"@en ;
+                            ontohgis:hasExternalIdentifier "47" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_48 rdfs:comment "Included as locality type in Bystrzycki's register in the abbreviation list (pl. \"st. kol.\"; \"st. k.\");included on topographic maps marked with the explanatory abbreviation (pl. \"St.\" or \"St. tow.\" [freight station], ger \"H.st.\" [Haltestation]);included in DBTO10k in the \"communication complex\" feature class (KUKO)."@en ,
+                                         "Stacja kolejowa występuje jako rodzaj miejscowości u Bystrzyckiego w spisie (st. kol.; st. k.); na mapach oznaczana skrótem objaśniającym „St.” lub „St. tow.” (stacja towarowa), „H.st.” (ger Haltestation);w BDOT10k w klasie kompleks komunikacyjny."@pl ;
+                            rdfs:isDefinedBy "Railway station (locality) is a settlement where the main role is played by a railway station (object)."@en ,
+                                             "Stacja kolejowa (miejscowość) jest to osada, w której główną rolę odgrywa stacja kolejowa (obiekt)."@pl ;
+                            rdfs:label "railway station"@en ,
+                                       "stacja kolejowa"@pl ;
+                            rdfs:seeAlso <http://dbpedia.org/ontology/RailwayStation> ,
+                                         <http://gov.genealogy.net/types.owl#119> ,
+                                         <http://linkedgeodata.org/ontology/RailwayStation> ,
+                                         <http://linkedgeodata.org/ontology/TrainStation> ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "Haltestation (de)" ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "dworzec kolejowy"@pl ,
+                                                                              "przystanek kolejowy"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "railway station"@en ,
+                                                                            "stacja kolejowa"@pl ;
+                            ontohgis:hasExternalIdentifier "48" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_50 rdfs:comment "If residential buildings emerged around a sawmill, then it could be a kind of a separate forest settlement or a mill settlement. The distinction between the sawmill as an industrial facility and the sawmill as a kind of locality was blurry. It depended on the seasonality or permanence of habitation."@en ,
+                                         "Jeżeli wokół tartaku utrwaliła się zabudowa mieszkalna to tartak mógł stanowić rodzaj odrębnej osady leśnej lub osady młyńskiej. Granica między tartakiem jako obiektem gospodarczym a tartakiem jako rodzajem osady była płynna. Była uzależniona od sezonowości i stałości zamieszkiwania."@pl ,
+                                         "piła"@pl ;
+                            rdfs:isDefinedBy "Sawmill (locality) is a locality where the main role is played by a sawmill (facility)."@en ,
+                                             "Tartak (miejscowość) to miejscowość, w której główną rolę odgrywa tartak (obiekt)."@pl ;
+                            rdfs:label "sawmill"@en ,
+                                       "tartak"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "das Sägewerk (de), lesopilnyi zawod (ru)" ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "die Säge"@de ,
+                                                                              "młyn"@pl ,
+                                                                              "osada leśna"@pl ,
+                                                                              "osada młyńska"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "sawmill"@en ,
+                                                                            "tartak"@pl ;
+                            ontohgis:hasExternalIdentifier "50" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_51 rdfs:comment "If residential buildings emerged around a peat mine, then it could be a kind of a separate mine settlement or an industrial settlement. The distinction between the peat mine as an industrial facility and the peat mine as a kind of locality was blurry. It depended on the seasonality or permanence of habitation."@en ,
+                                         "Jeżeli wokół torfiarni utrwaliła się zabudowa mieszkalna to torfiarnia mogła stanowić rodzaj odrębnej osady górniczej lub osady fabrycznej. Granica między torfiarnią jako obiektem gospodarczym a torfiarnią jako rodzajem osady była płynna. Była uzależniona od sezonowości i stałości zamieszkiwania."@pl ;
+                            rdfs:isDefinedBy "Peat mine (locality) is a locality where the main role is played by a peat mine (facility)."@en ,
+                                             "Torfiarnia (miejscowość) jest to miejscowość, w której główną rolę odgrywa torfiarnia (obiekt)."@pl ;
+                            rdfs:label "peat mine"@en ,
+                                       "torfiarnia"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "torfowisko"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "peat mine"@en ,
+                                                                            "torfiarnia"@pl ;
+                            ontohgis:hasExternalIdentifier "51" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_52 rdfs:comment "A fortress might be a separate settlement unit or a building inside a superior unit."@en ,
+                                         "Twierdza mogła być samodzielną jednostką osadniczą lub obiektem w obrębie większej jednostki."@pl ;
+                            rdfs:isDefinedBy "Fortress is a locality for which a defensive function is dominant."@en ,
+                                             "Miejscowość, dla której dominująca jest funkcja obronna."@pl ;
+                            rdfs:label "fortress"@en ,
+                                       "twierdza"@pl ;
+                            rdfs:seeAlso <http://linkedgeodata.org/ontology/Fortress> ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "forteca (pl)" ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "fortyfikacje"@pl ,
+                                                                              "gród"@pl ,
+                                                                              "umocnienia"@pl ,
+                                                                              "zamek"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "fortress"@en ,
+                                                                            "twierdza"@pl ;
+                            ontohgis:hasExternalIdentifier "52" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
+
+
+ontohgis:settlement_type_53 rdfs:comment """Functional distinctivness - clearly defined function, a locality connected with the service of bathers/visitors; it seems this is not the most important criterion of defining a type of locality (e.g. Ciechocinek in Bystrzycki's register is a city, not a spa).
+Morphological distinctiness - loose built-up area (spa-type), mostly in the woods (e.g. Czarniecka Góra, Miłowody); Nałęczów in Bystrzycki's register is also referred to as a health resort, and is characterized as densely built-up area (see: MGI maps).
+Spatial distinctiveness - clear, as far as Czarniecka Góra and Miłowody (spas located among the forest) are concerned."""@en ,
+                                         "Included as a kind of locality in Bystrzycki's register in the abbreviations as \"spa\" (pol \"uzdrow.\").Included on MGI maps where spas are annotated in the same manner as localites (e.g. Czarniecka Góra, Nałęczów) or buildings/field objects (Miłowody); there is no distinct symbol/abbreviation explained in maps' key to symbols (legends)."@en ,
+                                         """Odrębność funkcjonalna – jasno zdefiniowana funkcja, miejscowość związana z obsługa kuracjuszy; wydaje się, że nie jest to najistotniejsze kryterium (np. Ciechocinek u Bystrzyckiego jest miastem, a nie uzdrowiskiem).
+Odrębność morfologiczna – luźna zabudowa (uzdrowiskowa), najczęściej pośród lasu (Czarniecka Góra, Miłowody); Nałęczów u Bystrzyckiego również jest określany jako uzdrowisko, a cechuje się zabudową zwartą (patrz: mapy WIG).
+Odrębność przestrzenna – wyraźna w przy Czarnieckiej Górze i Miłowodach (uzdrowiska położone pośród lasu)."""@pl ,
+                                         "Występuje jako rodzaj miejscowości u Bystrzyckiego w spisie (uzdrow.).Na mapach WIG oznaczane krojem pisma charakterystycznym dla miejscowości (Czarniecka Góra, Nałęczów) lub budynków/obiektów terenowych (Miłowody); brak odrębnej sygnatury/skrótu objaśniające w legendach."@pl ;
+                            rdfs:isDefinedBy "A spa is a locality, where climate enhances treatment, and a main function of which is to serve bathers and visitors."@en ,
+                                             "Uzdrowisko jest miejscowością, w której warunki klimatyczne sprzyjają leczeniu chorób i której główną funkcją jest obsługa kuracjuszy"@pl ;
+                            rdfs:label "spa"@en ,
+                                       "uzdrowisko"@pl ;
+                            rdfs:seeAlso <http://dbpedia.org/page/Spa_town> ,
+                                         <https://www.wikidata.org/wiki/Q4946461> ,
+                                         <https://www.wikidata.org/wiki/Q6882870> ,
+                                         "miejscowość, która ze względu na warunki klimatyczne, źródła lecznicze, pokłady borowiny, itp. sprzyja leczeniu chorób i służy jako ośrodek leczniczy i wypoczynkowy"@pl ,
+                                         "t. 7, s. 424 – zakład leczniczy, lecznisko, leczysko, sanatorium"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "spa town"@en ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "lecznica"@pl ,
+                                                                              "letnisko"@pl ,
+                                                                              "sanatorium"@pl ;
+                            ontohgis:hasExternalIdentifier "53" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 ,
+                                                   ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_53 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "miejscowość, która ze względu na warunki klimatyczne, źródła lecznicze, pokłady borowiny, itp. sprzyja leczeniu chorób i służy jako ośrodek leczniczy i wypoczynkowy"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_53 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 7, s. 424 – zakład leczniczy, lecznisko, leczysko, sanatorium"@pl ;
+   rdfs:isDefinedBy ontohgis:document_5
+ ] .
+
+
+ontohgis:settlement_type_54 rdfs:comment """Forest distrct as it had a separate name and was spatially distinct, it could have been a locality (inhabited forest district) or a settlement unit (uninhabited, deserted forest district). This second category was dominant. As an inhabited forest district (next to the village, town, farm, etc.), it is mentioned in the registers concerning the eastern provinces of the former Polish-Lithuanian Commonwealth. The number of residents usually did not exceed a dozen or so people. Currently, a forest district is a type of physiographic object in the \"Other physiographic object\" class of objects in the State Register of Geographical Names.
+The basic criterion of distinguishing forest district from other localities or settlement units from the perspective of its functionality is its relation to the organization of forestry or agricultural production. Individual parts of forest or agricultural areas for a better understanding of space received their own names. It also did not exclude the forest settlement form the process of settling and thus the transformation to the kind of locality. The morphological distinctiveness of forest districts due to the nature of natural boundaries (swamps, glades, etc.) is fuzzy. From the legal point of view, the status of the forest district is rather unclear because this term was also used in relation to various types of forest settlements or parts of forests such as \"bór\" or \"ostęp\"."""@en ,
+                                         """Uroczysko, ponieważ posiadało odrębną nazwę i było wydzielone przestrzennie, mogło być miejscowością (uroczysko zamieszkane) lub jednostką osadniczą (uroczysko niezamieszkane, uroczysko opuszczone). Ta druga kategoria była dominująca. Jako kategoria miejscowości (obok wsi, miasta, folwarku etc.) wymieniane jest w rejestrach dotyczących wschodnich województw dawnej Rzeczypospolitej. Liczba mieszkańców nie przekraczała zazwyczaj kilkunastu osób. Obecnie uroczysko jest rodzajem obiektu fizjograficznego w klasie obiektów \"Inny obiekt fizjograficzny\" w Państwowym Rejestrze Nazw Geograficznych.
+Podstawowym kryterium wyodrębniającym uroczysko od innych miejscowości lub jednostek osadniczych w aspekcie funkcjonalnym jest jego związek z organizacją produkcji leśnej lub rolniczej. Poszczególne części obszarów leśnych lub rolnych dla lepszej orientacji w przestrzeni otrzymywały swoje nazwy własne. Nie wykluczało to też procesu osiedlania się a tym samym przekształcania uroczyska w rodzaj miejscowości. Odrębność morfologiczna uroczysk ze względu na charakter granic naturalnych (bagna, polany etc.) jest rozmyta. Od strony prawnej status uroczyska jest dość niejasny, gdyż termin ten był używany także w odniesieniu do różnego typu osad leśnych lub części lasów takich jak bory czy ostępy."""@pl ;
+                            rdfs:isDefinedBy "Forest distrct is a part of a forest, meadow or swampy area separated by natural borders and an own (proper) name for better organization of social and economic life. Built-up and inhabited forest district used to be a locality."@en ,
+                                             "Uroczysko to obszar leśny, łąkowy lub bagnisty wyodrębniony naturalnymi granicami oraz nazwą własną w celu lepszej organizacji życia społecznego i gospodarczego. Uroczysko zabudowane i zamieszkane było miejscowością."@pl ;
+                            rdfs:label "forest district"@en ,
+                                       "uroczysko"@pl ;
+                            rdfs:seeAlso <http://vocab.getty.edu/aat/300379281> ,
+                                         <https://pzgik.geoportal.gov.pl/ontologies/prng/uroczysko> ,
+                                         <https://pzgik.geoportal.gov.pl/ontologies/prng/uroczysko-dawnaMiejsc> ,
+                                         <https://www.wikidata.org/wiki/Q1434274> ,
+                                         "1. teren trudno dostępny, najczęściej bagnisty, leśny; też: miejsce odludne, 2. część terenu otoczona naturalnymi granicami, wyodrębniona za pomocą nazwy topograficznej, 3. u dawnych Słowian: miejsce w głębi puszczy związane z kultem bóstwa, odbywaniem narad lub uważane za siedzibę złych duchów"@pl ,
+                                         "s. 57-80: uroczyska to cała gama pojęć, stale łąki i lokacje straży leśnej, czasem synonimy borów i ostępów, zjawiska terenowe zasadniczo rozległe o wielce zróżniczkowanej, a raczej nieuchwytnej i zatraconej już, treści. Można tylko utrzymywać, że uroczyska to teren eksploatacji par excellence."@pl ,
+                                         "t. 15, s. 34: nazwa kopca lub miejsca granicznego nieosiedlonego. Według Chodakowskiego, uroczyska, na Rusi horodyszczami zwane, były to w Słowiańszczyźnie przedchrześcijańskiej place, czyli świątyń posady, do sprawowania uroczystych pogańskich ofiar przeznaczone i nie mające śladu opisania wałami, byleby oddzielna, właściwe imię mająca, przywiązana do nich była jakaś pamiątka."@pl ,
+                                         "t. 6, s. 80: uroczysko, uroczyszcze -- (Rs. urocziszcze, = powiat, kraina); kopiec, mieysce graniczne. Tr. Gränzstein, Mohlhausen."@pl ,
+                                         "t. 7, s. 348: 1. starożytny , z czasów pogańskich nasyp ziemny w postaci mogiły a. okopu, kopiec, kurhan; miejsce graniczne. Troc. 2. miejsce odludne, tajemnicze – 3. miejscowość nie zamieszkana, nosząca jakie oddzielne charakterystyczne miano – 4. pewna część gruntu a. gruntów kilku posiadaczy w jednym miejscu, nosząca pewną nazwę – 5. miejsce w polu, składające się z gruntu i łąk, dawniej zarosłe lasem. 6. bart. okręg bartniczy --, 7. leśn. część lasu, oddzielona od innych części naturalnymi granicami, jako oto: wzgórzami, strumykami, łąkami, drogami i.t.p. albo też różniąca się drzewostanem"@pl ,
+                                         "t. 9, s. 431: 1. miedza graniczna, granica, limes agrorum, finis -- 2. teren poza granicą posiadłości, ale do niej przynależny, z własnymi granicami naturalnymi, locus extra fines praedii situs, sed ad id praedium pertinens, proprios fines naturales habens."@pl ,
+                                         "u dawnych Słowian: miejsce przed świątynią lub w głębi puszczy, związane z kultem jakiegoś bóstwa, z odbywaniem narad, sądów; ogólnie: miejsce odludne, tajemnicze; pustkowie -- 2. część terenu (zwykle lasu wyodrębniona za pomocą nazwy o charakterze topograficznym."@pl ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "урочище"@ru ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "bór"@pl ,
+                                                                              "leśniczówka"@pl ,
+                                                                              "osada leśna"@pl ,
+                                                                              "ostęp"@pl ,
+                                                                              "strażnica leśna"@pl ,
+                                                                              "łąka"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "forest district"@en ,
+                                                                            "uroczysko"@pl ;
+                            ontohgis:hasExternalIdentifier "54" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_54 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "1. teren trudno dostępny, najczęściej bagnisty, leśny; też: miejsce odludne, 2. część terenu otoczona naturalnymi granicami, wyodrębniona za pomocą nazwy topograficznej, 3. u dawnych Słowian: miejsce w głębi puszczy związane z kultem bóstwa, odbywaniem narad lub uważane za siedzibę złych duchów"@pl ;
+   rdfs:isDefinedBy <http://sjp.pwn.pl/sjp/uroczysko;2533316.html> ,
+                    ontohgis:document_3
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_54 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "s. 57-80: uroczyska to cała gama pojęć, stale łąki i lokacje straży leśnej, czasem synonimy borów i ostępów, zjawiska terenowe zasadniczo rozległe o wielce zróżniczkowanej, a raczej nieuchwytnej i zatraconej już, treści. Można tylko utrzymywać, że uroczyska to teren eksploatacji par excellence."@pl ;
+   rdfs:isDefinedBy ontohgis:document_14
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_54 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 15, s. 34: nazwa kopca lub miejsca granicznego nieosiedlonego. Według Chodakowskiego, uroczyska, na Rusi horodyszczami zwane, były to w Słowiańszczyźnie przedchrześcijańskiej place, czyli świątyń posady, do sprawowania uroczystych pogańskich ofiar przeznaczone i nie mające śladu opisania wałami, byleby oddzielna, właściwe imię mająca, przywiązana do nich była jakaś pamiątka."@pl ;
+   rdfs:isDefinedBy ontohgis:document_15
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_54 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 6, s. 80: uroczysko, uroczyszcze -- (Rs. urocziszcze, = powiat, kraina); kopiec, mieysce graniczne. Tr. Gränzstein, Mohlhausen."@pl ;
+   rdfs:isDefinedBy ontohgis:person_21
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_54 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 7, s. 348: 1. starożytny , z czasów pogańskich nasyp ziemny w postaci mogiły a. okopu, kopiec, kurhan; miejsce graniczne. Troc. 2. miejsce odludne, tajemnicze – 3. miejscowość nie zamieszkana, nosząca jakie oddzielne charakterystyczne miano – 4. pewna część gruntu a. gruntów kilku posiadaczy w jednym miejscu, nosząca pewną nazwę – 5. miejsce w polu, składające się z gruntu i łąk, dawniej zarosłe lasem. 6. bart. okręg bartniczy --, 7. leśn. część lasu, oddzielona od innych części naturalnymi granicami, jako oto: wzgórzami, strumykami, łąkami, drogami i.t.p. albo też różniąca się drzewostanem"@pl ;
+   rdfs:isDefinedBy ontohgis:document_5
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_54 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 9, s. 431: 1. miedza graniczna, granica, limes agrorum, finis -- 2. teren poza granicą posiadłości, ale do niej przynależny, z własnymi granicami naturalnymi, locus extra fines praedii situs, sed ad id praedium pertinens, proprios fines naturales habens."@pl ;
+   rdfs:isDefinedBy ontohgis:document_6
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_54 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "u dawnych Słowian: miejsce przed świątynią lub w głębi puszczy, związane z kultem jakiegoś bóstwa, z odbywaniem narad, sądów; ogólnie: miejsce odludne, tajemnicze; pustkowie -- 2. część terenu (zwykle lasu wyodrębniona za pomocą nazwy o charakterze topograficznym."@pl ;
+   rdfs:isDefinedBy <http://sjp.pwn.pl/doroszewski/uroczysko;5512266.html> ,
+                    ontohgis:document_4
+ ] .
+
+
+ontohgis:settlement_type_56 rdfs:comment "\"Zaścianek\" is typical mostly for Mazovia, Podlachia and areas of the former Grand Duchy of Lithuania."@en ,
+                                         "Zaścianki są najbardziej charakterystyczne dla Mazowsza, Podlasia i obszarów dawnego Wielkiego Księstwa Litewskiego."@pl ;
+                            rdfs:isDefinedBy "\"Zaścianek\" is an agricultural locality inhabited by the poor nobility who cultivate their land on their own."@en ,
+                                             "Zaścianek to miejscowość o charakterze rolniczym zamieszkała przez drobną szlachtę samodzielnie uprawiającą posiadaną ziemię."@pl ;
+                            rdfs:label "\"zaścianek\""@en ,
+                                       "zaścianek"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "okolica"@pl ,
+                                                                           "zagroda"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "obszar"@pl ,
+                                                                              "osada"@pl ,
+                                                                              "przysiółek"@pl ,
+                                                                              "wieś"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "\"zaścianek\""@en ,
+                                                                            "zaścianek"@pl ;
+                            ontohgis:hasExternalIdentifier "56" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_60 rdfs:comment "Część kolonii jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Części kolonii występują najczęściej w woj. lubelskim, łódzkim i pomorskim. W sumie jest ich w Polsce 281."@pl ,
+                                         "Part of a colony is a separate settlement unit, a kind of locality, always has a particular name. Parts of colonies occur most often in Lubelskie, Łódzkie, and Pomorskie voivodships. In total, there are 281 parts of colonies in Poland."@en ;
+                            rdfs:isDefinedBy "Część kolonii to miejscowość stanowiąca integralną część miejscowości podstawowej kolonii, jest wydzielona administracyjnie, ale należy do jednostki nadrzędnej."@pl ,
+                                             "Part of a colony is an integral part of the main locality a colony; it is administratively separated, but belongs to the superior unit."@en ;
+                            rdfs:label "część kolonii"@pl ,
+                                       "part of a colony"@en ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "część kolonii"@pl ,
+                                                                            "part of a colony"@en ;
+                            ontohgis:hasExternalIdentifier "60" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_61 rdfs:comment "Część miasta jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. W sumie jest ich w Polsce 10425. Są to części miejscowości skupiające się często wokół większych miejscowości w całej Polsce, większe skupiska części miejscowości są m. in. w woj. śląskim, mazowieckim, małopolskim, wielkopolskim, pomorskim."@pl ,
+                                         "Part of a city is a separate settlement unit, a kind of locality, it always has a particular name. There are 10425 of these units in Poland at the moment. These are mostly parts of localities converging upon bigger localities around Poland. Large clusters of these units are located i.e. in Śląskie, Mazowieckie, Małopolskie, Wielkopolskie, and Pomorskie voivodeships."@en ;
+                            rdfs:isDefinedBy "Część miasta to miejscowość stanowiąca integralną część miejscowości podstawowej miasta, jest wydzielona administracyjnie, ale należy do jednostki nadrzędnej."@pl ,
+                                             "Part of a city is an integral part of the main locality a city (or a town); it is administratively separated, but belongs to the superior unit."@en ;
+                            rdfs:label "część miasta"@pl ,
+                                       "part of a city"@en ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Stadt"@de ,
+                                                                              "city"@en ,
+                                                                              "gorod"@ru ,
+                                                                              "gród"@pl ,
+                                                                              "metropolia"@pl ,
+                                                                              "miasteczko"@pl ,
+                                                                              "miejscowość"@pl ,
+                                                                              "mieścina"@pl ,
+                                                                              "town"@en ,
+                                                                              "urbs"@la ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "część miasta"@pl ,
+                                                                            "part of a city"@en ;
+                            ontohgis:hasExternalIdentifier "61" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
+
+
+ontohgis:settlement_type_62 rdfs:comment "Część osady jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Części osady występują w większości na Pomorzu. W sumie jest ich w Polsce 76."@pl ,
+                                         "Part of a settlement is a separate settlement unit, a kind of locality, it always has a particular name. Parts of settlements occur mostly in Pomorze. In total, there are 76 parts of settlements in Poland."@en ;
+                            rdfs:isDefinedBy "Część osady to miejscowość stanowiąca integralną część miejscowości podstawowej osady, jest wydzielona administracyjnie, ale należy do jednostki nadrzędnej."@pl ,
+                                             "Part of a settlement is an integral part of the main locality a settlement, it is administratively separated, but belongs to the superior unit."@en ;
+                            rdfs:label "część osady"@pl ,
+                                       "part of a settlement"@en ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "conlocationen"@la ,
+                                                                              "der Ortschaft"@de ,
+                                                                              "der Siedlung"@de ,
+                                                                              "die Ansiedlung"@de ,
+                                                                              "die Kolonie"@de ,
+                                                                              "kolonia"@pl ,
+                                                                              "miasteczko"@pl ,
+                                                                              "miejscowość"@pl ,
+                                                                              "osiedle"@pl ,
+                                                                              "sadyba"@pl ,
+                                                                              "settlement"@en ,
+                                                                              "zagroda włościańska"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "część osady"@pl ,
+                                                                            "part of a settlement"@en ;
+                            ontohgis:hasExternalIdentifier "62" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_63 rdfs:comment "A part of a village is a separate settlement unit, a kind of locality, and always has its own (individual) name. There are 41942 parts of villages around the whole Poland at the moment."@en ,
+                                         "Część wsi jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Części wsi występują w całej Polsce. W sumie jest ich w Polsce 41942."@pl ;
+                            rdfs:isDefinedBy "A part of a village is a locality being an integral part of the main locality a village; it is administratively separated, but belongs to the superior unit."@en ,
+                                             "Część wsi to miejscowość stanowiąca integralną część miejscowości podstawowej wsi, jest wydzielona administracyjnie, ale przynależy do jednostki nadrzędnej."@pl ;
+                            rdfs:label "część wsi"@pl ,
+                                       "part of a village"@en ;
+                            rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/czescWsi> ,
+                                         <https://www.wikidata.org/wiki/Q41970180> ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Dorf"@de ,
+                                                                              "Land"@de ,
+                                                                              "country"@en ,
+                                                                              "derewnia"@ru ,
+                                                                              "pagus"@la ,
+                                                                              "seło"@ru ,
+                                                                              "sioło"@pl ,
+                                                                              "village"@en ,
+                                                                              "wioska"@pl ;
+                            ontohgis:hasExternalIdentifier "63" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
+
+
+ontohgis:settlement_type_64 rdfs:comment "Colony of a colony is a separate settlement unit, a kind of locality, and always has its particular name. They occur most often in the Lubelskie and Podlaskie voivodships. In total, there are 31 colonies of colony at the moment."@en ,
+                                         "Kolonia kolonii jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Kolonia kolonii występują w większości w woj. lubelskim i woj. podlaskim. W sumie jest ich obecnie w Polsce 31."@pl ;
+                            rdfs:isDefinedBy "Colony of a colony is a colony which is related to a colony."@en ,
+                                             "Kolonia osady to kolonia zależna od kolonii."@pl ;
+                            rdfs:label "colony of a colony"@en ,
+                                       "kolonia kolonii"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "chutor"@pl ,
+                                                                              "coloniam"@la ,
+                                                                              "część wsi"@pl ,
+                                                                              "die Kolonie"@de ,
+                                                                              "housing estate"@en ,
+                                                                              "koloniya"@ru ,
+                                                                              "kolonizacja"@pl ,
+                                                                              "osiedle"@pl ,
+                                                                              "przysiółek"@pl ,
+                                                                              "settlement"@en ,
+                                                                              "sioło"@pl ,
+                                                                              "stanica"@pl ,
+                                                                              "wybudowanie"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "colony of a colony"@en ,
+                                                                            "kolonia kolonii"@pl ;
+                            ontohgis:hasExternalIdentifier "64" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_65 rdfs:comment "A built-up area located away from previously existing buildings (locality) to which it is related. Colony of a settlement is a separate settlement unit, a kind of locality, always with its particular name. Colonies of settlements occur mainly in Zachodniopomorskie, Warmińsko-mazurskie and Podlaskie voivodships. In total, there are 17 colonies of settlements in Poland."@en ,
+                                         "Obszar zabudowany oddalony od wczesniejszej zabudowy, od której jest zależny. Kolonia osady jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Kolonie osady występują w większości w woj. zachodniopomorskim, warmińsko-mazurskim i woj. podlaskim. W sumie jest ich w Polsce 17."@pl ;
+                            rdfs:isDefinedBy "Colony of a settlement is a colony related to a settlement."@en ,
+                                             "Kolonia osady to kolonia zależna od osady."@pl ;
+                            rdfs:label "colony of a settlement"@en ,
+                                       "kolonia osady"@pl ;
+                            rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/koloniaOsady> ,
+                                         <https://www.wikidata.org/wiki/Q41970180> ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "colony of a settlement"@en ,
+                                                                            "kolonia osady"@pl ;
+                            ontohgis:hasExternalIdentifier "65" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_66 rdfs:comment "Colony of a village is a separate settlement unit, a kind of locality, and always has its particular name. They are spread all over modern Poland and there are 4043 collonies of villages at the moment."@en ,
+                                         "Kolonia wsi jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Kolonie wsi występują w całej Polsce. W sumie jest ich obecnie w Polsce 4043."@pl ;
+                            rdfs:isDefinedBy "Colony of a village is a colony related to a village."@en ,
+                                             "Kolonia wsi to kolonia zależna od wsi."@pl ;
+                            rdfs:label "colony of a village"@en ,
+                                       "kolonia wsi"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "chutor"@pl ,
+                                                                              "coloniam"@pl ,
+                                                                              "część wsi"@pl ,
+                                                                              "die Kolonie"@de ,
+                                                                              "housing estate"@en ,
+                                                                              "koloniya"@ru ,
+                                                                              "kolonizacja"@pl ,
+                                                                              "osiedle"@pl ,
+                                                                              "przysiółek"@pl ,
+                                                                              "settlement"@en ,
+                                                                              "sioło"@pl ,
+                                                                              "stanica"@pl ,
+                                                                              "wybudowanie"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "colony of a village"@en ,
+                                                                            "kolonia wsi"@pl ;
+                            ontohgis:hasExternalIdentifier "66" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_68 rdfs:comment "Brak oficjalnej definicji w \"Ustawie o nazwach urzędowych miejscowości i jednostek fizjograficznych\"."@pl ,
+                                         "No official definition in the \"Act on official names of localities and physiographic units\"."@en ,
+                                         "Są cztery takie obiekty w Polsce, wszystkie w woj. lubelskim."@pl ,
+                                         "There are 4 such a settlements is contemporary Poland: all in Lubelskie voivodship."@en ;
+                            rdfs:isDefinedBy "Osada kolonii jest to osada stanowiąca integralną część kolonii."@pl ,
+                                             "Settlement of a colony is a settlement which is an integral part of a colony."@en ;
+                            rdfs:label "osada kolonii"@pl ,
+                                       "settlement of a colony"@en ;
+                            rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/osadaKolonii> ,
+                                         <https://www.wikidata.org/wiki/Q41970180> ;
+                            ontohgis:hasExternalIdentifier "68" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_69 rdfs:comment "Brak oficjalnej definicji w \"Ustawie o nazwach urzędowych miejscowości i jednostek fizjograficznych\"."@pl ,
+                                         "No official definition in the \"Act on official names of localities and physiographic units\"."@en ,
+                                         "Są 233 takie obiekty w Polsce, świętokrzyskie, północnym lubelskim, północnym lubuskim, Borach Tucholskich."@pl ,
+                                         "There are 233 forest settlements of a village in Poland, mainly in Świętokrzyskie northern part of Lubelskie, northern part of Lubuskie voivodships as well as in \"Bory Tuchulskie\" (Pomorskie voivodship)."@en ;
+                            rdfs:isDefinedBy "Forest settlement of a village is a forest settlement which is an integral part of  a village."@en ,
+                                             "Osada leśna wsi to osada leśna stanowiąca integralną część wsi."@pl ;
+                            rdfs:label "forest settlement of a village"@en ,
+                                       "osada leśna wsi"@pl ;
+                            rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/osadaLesnaWsi> ,
+                                         <https://www.wikidata.org/wiki/Q41970180> ,
+                                         "t. 20. s.47: Osady przemysłowe - osiedla dla robotników i rzemieślników zakładane XVIII – XIX w. w związku z dokonującym się procesem uprzemysłowienia, niekiedy zwane osadami fabrycznymi; zwykle osady przemysłowe obejmowały zarówno zakłady przemysłowe jak i związane z nimi kolonie domów mieszkalnych. Na ziemiach polskich powstawały od końca XVIII wieku jako osady prywatne bądź rządowe i stopniowo uzyskiwały prawa miejskie;  w drugiej połowie XIX wieku termin „osady przemysłowe” zaczęto używać do wszelkich osiedli rozwijających się wokół zakładów przemysłowych; dzielnice mieszkaniowe, zwane koloniami lub domami fabrycznymi wznoszono w drugiej połowie XIX i w XX wieku przez wielkie zakłady przemysłowe w już istniejących miejscowościach dla robotników i urzędników niższego szczebla, zwykle o niskim standardzie i niewysokich czynszach."@pl ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "osada przemysłowa (pl)" ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Ansiedlung"@de ,
+                                                                              "Kolonie"@de ,
+                                                                              "Ortschaft"@de ,
+                                                                              "Siedlung"@de ,
+                                                                              "conlocationen"@la ,
+                                                                              "kolonia"@pl ,
+                                                                              "miasteczko"@pl ,
+                                                                              "miejscowość"@pl ,
+                                                                              "osiedle"@pl ,
+                                                                              "sadyba"@pl ,
+                                                                              "settlement"@en ,
+                                                                              "zagroda włościańska"@pl ;
+                            ontohgis:hasExternalIdentifier "69" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_69 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 20. s.47: Osady przemysłowe - osiedla dla robotników i rzemieślników zakładane XVIII – XIX w. w związku z dokonującym się procesem uprzemysłowienia, niekiedy zwane osadami fabrycznymi; zwykle osady przemysłowe obejmowały zarówno zakłady przemysłowe jak i związane z nimi kolonie domów mieszkalnych. Na ziemiach polskich powstawały od końca XVIII wieku jako osady prywatne bądź rządowe i stopniowo uzyskiwały prawa miejskie;  w drugiej połowie XIX wieku termin „osady przemysłowe” zaczęto używać do wszelkich osiedli rozwijających się wokół zakładów przemysłowych; dzielnice mieszkaniowe, zwane koloniami lub domami fabrycznymi wznoszono w drugiej połowie XIX i w XX wieku przez wielkie zakłady przemysłowe w już istniejących miejscowościach dla robotników i urzędników niższego szczebla, zwykle o niskim standardzie i niewysokich czynszach."@pl ;
+   rdfs:isDefinedBy ontohgis:document_21
+ ] .
+
+
+ontohgis:settlement_type_7 rdfs:comment "Usually, a manor house was located away from the main group of houses in a village, on the outskirts, or in a vicinity. A manor house is recognised in historiography as identical with a manor (folwark, demesne), however a manor house appears in texts on culture, customs, legal issues, whereas a manor (folwark, demesne) usually corresponds with economic matters."@en ,
+                                        "Zazwyczaj dwór położony był poza głównym zbudową wsi, na jej obrzeżach lub w nieznacznym oddaleniu. Pojęcie często tożsame w literaturze z folwarkiem. Z czasem dwór pojawia się w kontekście pisania o życiu, kulturze, obyczajowości, a folwark dotyczy kwestii gospodarczych."@pl ;
+                           rdfs:isDefinedBy "A manor (a notion with a multiple meaning) is a home or a temporary house of a land lord and the managment of different clusters of estates, including a house and a farmstead ( a manor). In High and Late Middle Ages it could be a defensive tower (conical gord or a manor built on a mound) or a castle. Most of these, however, were one-floor homes (i.e. nobleman manor), which later (in 16th-20th century) evolved into palaces."@en ,
+                                            "Dwór (pojęcie wieloznaczne) jest to siedziba lub miejsce okresowego pobytu pana gruntowego oraz zarządu poszczególnych kluczy dóbr, składająca się z domu oraz zabudowań gospodarczych ( folwark). W pełnym i późnym średniowieczu mógł przyjmować charakter rezydencjonalno-obronnej wieży (tzw. grodzisko stożkowate, lub dworu na kopcu) ew. zamku. W większości były to jednak jednokondygnacyjne siedziby (tzw. dwór szlachecki) mogące później (XVI-XX w.) przybierać formę pałacową."@pl ;
+                           rdfs:label "dwór - obiekt"@pl ,
+                                      "manor house"@en ;
+                           rdfs:seeAlso <http://gov.genealogy.net/types.owl#24> ,
+                                        <http://linkedgeodata.org/ontology/Manor> ,
+                                        <http://vocab.getty.edu/aat/300005579> ,
+                                        <https://www.wikidata.org/wiki/Q879050> ,
+                                        "1. dom mieszkalny, budynek; siedziba szlachcica, właściciela majątku ziemskiego; majętność, posiadłość ziemska; 2. miejsce czasowego pobytu; lokal wynajęty (może dom zajezdny); 3. pałac, zamek, rezydencja; ewentualnie miejsce czasowego pobytu panującego; siedziba zwierzchnika (magnata) świeckiego lub duchownego; 4. miejsce posiedzeń senatu lub sądu w starożytnym Rzymie; także sama rada senatu; 5. otoczenie, środowisko skupiające się dokoła monarchy lub magnata, duchownego; dworzanie, urzędnicy, świta dworska, orszak; ogólnie: rząd danego państwa z panującym na czele; 6. siły zbrojne nadworne, żołnierze straży przybocznej monarchy; 7. praw. sąd królewski, w którym orzekał sam król osobiście przy asyście dygnitarzy królewskich lub zlecał rozpatrzenie sprawy i wydanie wyroku wyznaczonym dygnitarzom znajdującym się w danym momencie na dworze, to jest w miejscu pobytu władcy; 8. miejsce na zewnątrz domu, otaczająca dom; podwórze, dziedziniec, przestrzeń pod gołym niebem"@pl ,
+                                        "1. miejsce pod niebem zagrodzone przy pomieszkanu, podworze (por. dziedziniec); 2. sądy za dworem królewskim, przy boku króla odprawujące się; 3. w wiekach dawnych, zjazd króla na różne miejsca, gdzie święta uroczystsze odbywał, obywatelów zgromadzał, sprawy sądził, okoliczności powiatowe ułatwiał, igrzyska i uczty dawał; 4. dwór królewski, zgromadzenie u króla, pokoje"@pl ,
+                                        "1. przestrzeń otaczając dom, otwarte powietrze, miejsce pod gołym niebem; 2. podwórze, dziedziniec; 3. dom właściciela majątku ziemskiego, mieszkanie dziedzica; 4. gospodarstwo dworskie, folwark; 5. (przenośnie) mieszkańcy dworu wiejskiego, szczególnie dziedzic z rodziną, państwo; 6. dom, mieszkanie; 7. oficjaliści panów, szczególnie wyżsi, dworzanie; 8. miejsce pobytu albo mieszkanie panującego albo magnata; 9. panujący i jego otoczenie; 10. służba dworska; 11. zebranie u króla, sąd dworski, żołnierze nadworni"@pl ,
+                                        "1. siedziba panującego lub księcia; 2. ludzie otaczający panującego lub księcia; 3. obszerny dom mieszkalny, charakterystyczny dla dawnych posiadłości ziemskich; 4. majątek ziemski z domem i zabudowaniami; 5. właściciele posiadłości ziemskiej, jej mieszkańcy, administracja; 6. otwarta przestrzeń na zewnątrz domu"@pl ,
+                                        "s. 9: -- desygnatem dworu jest tzw. gródek stożkowaty, czyli stanowisko archeologiczne mające wyodrębnioną formę terenową, najczęściej w postaci kopca lub przestrzeni zamkniętej dookolnymi obronnymi wałami"@pl ;
+                           <http://www.w3.org/2004/02/skos/core#altLabel> "Hof"@de ,
+                                                                          "curia"@la ,
+                                                                          "dworzecz (określenie staropolskie)"@pl ,
+                                                                          "двор"@ru ;
+                           <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Gutshof"@de ,
+                                                                             "Herrenhof"@de ,
+                                                                             "aula"@la ,
+                                                                             "curiaculum"@la ,
+                                                                             "czwierdza (określenie staropolskie)"@pl ,
+                                                                             "mons seu fortalicium"@la ,
+                                                                             "rezydencja"@pl ,
+                                                                             "господский двор"@ru ,
+                                                                             "усадьба"@ru ;
+                           <http://www.w3.org/2004/02/skos/core#prefLabel> "dwór"@pl ,
+                                                                           "manor house"@en ;
+                           ontohgis:hasExternalIdentifier "7" ;
+                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                           ontohgis:hasTranslator ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_7 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "1. dom mieszkalny, budynek; siedziba szlachcica, właściciela majątku ziemskiego; majętność, posiadłość ziemska; 2. miejsce czasowego pobytu; lokal wynajęty (może dom zajezdny); 3. pałac, zamek, rezydencja; ewentualnie miejsce czasowego pobytu panującego; siedziba zwierzchnika (magnata) świeckiego lub duchownego; 4. miejsce posiedzeń senatu lub sądu w starożytnym Rzymie; także sama rada senatu; 5. otoczenie, środowisko skupiające się dokoła monarchy lub magnata, duchownego; dworzanie, urzędnicy, świta dworska, orszak; ogólnie: rząd danego państwa z panującym na czele; 6. siły zbrojne nadworne, żołnierze straży przybocznej monarchy; 7. praw. sąd królewski, w którym orzekał sam król osobiście przy asyście dygnitarzy królewskich lub zlecał rozpatrzenie sprawy i wydanie wyroku wyznaczonym dygnitarzom znajdującym się w danym momencie na dworze, to jest w miejscu pobytu władcy; 8. miejsce na zewnątrz domu, otaczająca dom; podwórze, dziedziniec, przestrzeń pod gołym niebem"@pl ;
+   rdfs:isDefinedBy ontohgis:document_2
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_7 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "1. miejsce pod niebem zagrodzone przy pomieszkanu, podworze (por. dziedziniec); 2. sądy za dworem królewskim, przy boku króla odprawujące się; 3. w wiekach dawnych, zjazd króla na różne miejsca, gdzie święta uroczystsze odbywał, obywatelów zgromadzał, sprawy sądził, okoliczności powiatowe ułatwiał, igrzyska i uczty dawał; 4. dwór królewski, zgromadzenie u króla, pokoje"@pl ;
+   rdfs:isDefinedBy ontohgis:document_1
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_7 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "1. przestrzeń otaczając dom, otwarte powietrze, miejsce pod gołym niebem; 2. podwórze, dziedziniec; 3. dom właściciela majątku ziemskiego, mieszkanie dziedzica; 4. gospodarstwo dworskie, folwark; 5. (przenośnie) mieszkańcy dworu wiejskiego, szczególnie dziedzic z rodziną, państwo; 6. dom, mieszkanie; 7. oficjaliści panów, szczególnie wyżsi, dworzanie; 8. miejsce pobytu albo mieszkanie panującego albo magnata; 9. panujący i jego otoczenie; 10. służba dworska; 11. zebranie u króla, sąd dworski, żołnierze nadworni"@pl ;
+   rdfs:isDefinedBy ontohgis:document_5
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_7 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "1. siedziba panującego lub księcia; 2. ludzie otaczający panującego lub księcia; 3. obszerny dom mieszkalny, charakterystyczny dla dawnych posiadłości ziemskich; 4. majątek ziemski z domem i zabudowaniami; 5. właściciele posiadłości ziemskiej, jej mieszkańcy, administracja; 6. otwarta przestrzeń na zewnątrz domu"@pl ;
+   rdfs:isDefinedBy ontohgis:document_4
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_7 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "s. 9: -- desygnatem dworu jest tzw. gródek stożkowaty, czyli stanowisko archeologiczne mające wyodrębnioną formę terenową, najczęściej w postaci kopca lub przestrzeni zamkniętej dookolnymi obronnymi wałami"@pl ;
+   rdfs:comment ontohgis:document_13
+ ] .
+
+
+ontohgis:settlement_type_70 rdfs:comment "Jest 17 takich obiektów w Polsce, zachodniopomorskie, północne wielkopolskie."@pl ,
+                                         "Therea are 17 such localities in Poland: in Zachodniopomorskie and in the northern part of Wielkopolskie voivodships."@en ;
+                            rdfs:isDefinedBy "Osada osady jest to osada stanowiąca integralną część innej osady."@pl ,
+                                             "Settlement of a settlement is a settlement which is an integral part of a settlement."@en ;
+                            rdfs:label "osada osady"@pl ,
+                                       "settlement of a settlement"@en ;
+                            rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/osadaOsady> ,
+                                         <https://www.wikidata.org/wiki/Q41970180> ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Ansiedlung"@de ,
+                                                                              "Kolonie"@de ,
+                                                                              "Ortschaft"@de ,
+                                                                              "Siedlung"@de ,
+                                                                              "conlocationen"@la ,
+                                                                              "kolonia"@pl ,
+                                                                              "miejscowość"@pl ,
+                                                                              "osiedle"@pl ,
+                                                                              "sadyba"@pl ,
+                                                                              "settlement"@en ,
+                                                                              "zagroda włościańska"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "osada osady"@pl ,
+                                                                            "settlement of a settlement"@en ;
+                            ontohgis:hasExternalIdentifier "70" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_71 rdfs:comment "Jest 778 takich obiektów w Polsce, są one równomiernie rozmieszczone w całej Polsce."@pl ,
+                                         "There are 778 such localities in Poland and they are evenly spread across Poland."@en ;
+                            rdfs:isDefinedBy "Osada wsi jest to osada przynależna administracyjnie do wsi."@pl ,
+                                             "Settlement of a village is a settlement which is related to a village."@en ;
+                            rdfs:label "osada wsi"@pl ,
+                                       "settlement of a village"@en ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "conlocationen"@la ,
+                                                                              "der Ortschaft"@de ,
+                                                                              "der Siedlung"@de ,
+                                                                              "die Ansiedlung"@de ,
+                                                                              "die Kolonie"@de ,
+                                                                              "kolonia"@pl ,
+                                                                              "miasteczko"@pl ,
+                                                                              "miejscowość"@pl ,
+                                                                              "osiedle"@pl ,
+                                                                              "sadyba"@pl ,
+                                                                              "settlement"@en ,
+                                                                              "zagroda włościańska"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "osada wsi"@pl ,
+                                                                            "settlement of a village"@en ;
+                            ontohgis:hasExternalIdentifier "71" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_72 rdfs:comment "In urban studies, this notion is derived from a \"neighbouring unit\" idea, which denotes a group of residential buildings with service facilities and green areas."@en ,
+                                         "Jest 11 takich obiektów w Polsce, są one rozmieszczone w północno-zachodniej Polsce."@pl ,
+                                         "There are 11 housing estates of a village which are located in NW Poland."@en ,
+                                         "W urbanistyce (planowaniu przestrzennym) pojęcie osiedla wywodzi się z koncepcji „jednostki sąsiedzkiej”, na którą składa się zespół budynków mieszkalnych wraz z zapleczem obiektów usługowych oraz terenów zielonych."@pl ;
+                            rdfs:isDefinedBy "Housing estate of a village is a housing estate which is an integral part of a village."@en ,
+                                             "Osiedle wsi jest to osiedle stanowiące integralną część wsi."@pl ;
+                            rdfs:label "housing estate of a village"@en ,
+                                       "osiedle wsi"@pl ;
+                            rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/osiedleWsi> ,
+                                         <https://www.wikidata.org/wiki/Q41970180> ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Ansiedlung"@de ,
+                                                                              "Siedlung"@de ,
+                                                                              "Wohnsiedlung"@de ,
+                                                                              "conlocationen"@la ,
+                                                                              "część miasta"@pl ,
+                                                                              "dzielnica"@pl ,
+                                                                              "hamlet"@en ,
+                                                                              "housing estate"@en ,
+                                                                              "kolonia"@pl ,
+                                                                              "osada"@pl ,
+                                                                              "osiedle willowe"@pl ,
+                                                                              "osiedlisko"@pl ,
+                                                                              "residential quarter"@en ,
+                                                                              "settlement"@en ;
+                            ontohgis:hasExternalIdentifier "72" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 ,
+                                                   ontohgis:person_9 .
+
+
+ontohgis:settlement_type_73 rdfs:comment "Hamlet of a colony is a separate settlement unit, a kind of locality, it always has a particular name. Hamlets of colonies occur most often in Lubelskie voivodship. In total, there are 72 hamlets of colonies in Poland."@en ,
+                                         "Przysiółek kolonii jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Przysiółki kolonii występują głównie w lubelskim. W sumie są to 72 obiekty."@pl ;
+                            rdfs:isDefinedBy "Hamlet of a colony is a hamlet, for which a colony is a superior unit."@en ,
+                                             "Przysiółek kolonii jest to przysiółek, dla którego jednostką nadrzędną jest kolonia."@pl ;
+                            rdfs:label "hamlet of a colony"@en ,
+                                       "przysiółek kolonii"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "hamlet of a colony"@en ,
+                                                                            "przysiółek kolonii"@pl ;
+                            ontohgis:hasExternalIdentifier "73" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_74 rdfs:comment "Przysiółek osady jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Przysiółki osady występują główniezachodnio-pomorskim, pomorskim, warmińsko-mazurskim. W sumie jest 80 takich obiektów."@pl ,
+                                         "The hamlet of a settlement is a separate settlement unit, a kind of locality, always has its particular name. Hamlets of settlements occur mainly in the Zachodniopomorskie, Pomorskie, and Warmińsko-Mazurskie voivodships. In total, there are 80 hamlets of settlements in Poland. "@en ;
+                            rdfs:isDefinedBy "Hamlet of a settlement is a hamlet, for which a superior unit is a settlement."@en ,
+                                             "Przysiółek osady jest to przysiółek, dla którego jednostką nadrzędną jest osada."@pl ;
+                            rdfs:label "hamlet of a settlement"@en ,
+                                       "przysiółek osady"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#altLabel> "osada przemysłowa (pl)" ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "conlocationen"@la ,
+                                                                              "der Ortschaft"@de ,
+                                                                              "der Siedlung"@de ,
+                                                                              "die Ansiedlung"@de ,
+                                                                              "die Kolonie"@de ,
+                                                                              "kolonia"@pl ,
+                                                                              "miasteczko"@pl ,
+                                                                              "miejscowość"@pl ,
+                                                                              "osiedle"@pl ,
+                                                                              "sadyba"@pl ,
+                                                                              "settlement"@en ,
+                                                                              "zagroda włościańska"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "hamlet of a settlement"@en ,
+                                                                            "przysiółek osady"@pl ;
+                            ontohgis:hasExternalIdentifier "74" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_75 rdfs:comment "Brak oficjalnej definicji w \"Ustawie o nazwach urzędowych miejscowości i jednostek fizjograficznych\"."@pl ,
+                                         "No official definition in the \"Act on official names of localities and physiographic units\"."@en ,
+                                         "Przysiółek wsi jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Przysiółki wsi występują głównie w woj. podkarpackim, małopolskim oraz w świętokrzyskim. W sumie jest ich 11580."@pl ,
+                                         "The hamlet of a village is a separate settlement unit, a kind of locality, always has its particular name. Hamlets of villages occur mainly in Podkarpackie, Małopolskie, and Świętokrzyskie voivodships. In total, there are 11 580 hamlets of villages in Poland. "@en ;
+                            rdfs:isDefinedBy "Hamlet of a village is a hamlet, for which a superior unit is a village."@en ,
+                                             "Przysiółek wsi jest to przysiółek, dla którego jednostką nadrzędną jest wieś."@pl ;
+                            rdfs:label "hamlet of a village"@en ,
+                                       "przysiółek wsi"@pl ;
+                            rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/przysiolekWsi> ,
+                                         <https://www.wikidata.org/wiki/Q41970180> ;
+                            ontohgis:hasExternalIdentifier "75" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_76 rdfs:comment "In BDTO10k a tourist shelter is distinguished as a [1] building, [2] hotel services' complex, and [3] locality; in PRNG as a \"tourist shelter\". On MGI maps - a shelter [developed or undeveloped were depicted using different symbols] (\"schr.\"), on German maps - Jugenherberge (youth hostel, \"Jg. Hb.\"), Winterhutte (winter shelter, \"Wint. H.\"), Schutzhutte (hostel). Tourist shelters are not included in Bystrzycki's register."@en ,
+                                         "W BDOT10k schronisko turystyczne wyróżnione jest jako budynek, kompleks usług hotelarskich oraz miejscowość; w PRNG jako „schronisko turystyczne”.Na mapach WIG – schronisko [zagospodarowane lub niezagospodarowane odmiennym znakiem] („schr.”), niemieckich – Jugenherberge (schronisko młodzieżowe, „Jg. Hb.”), Winterhutte (schron zimowy, „Wint. H.”), Schutzhutte (schronisko). Brak u Bystrzyckiego."@pl ;
+                            rdfs:isDefinedBy "Schronisko turystyczne (miejscowość) to miejscowość, w której główną rolę pełni schronisko turystyczne (obiekt)."@pl ,
+                                             "Tourist shelter (locality) is a settlement where the main role is played by a tourist shelter (object)."@en ;
+                            rdfs:label "schronisko turystyczne"@pl ,
+                                       "tourist shelter"@en ,
+                                       "schronisko turystyczne" ;
+                            rdfs:seeAlso <http://linkedgeodata.org/ontology/Shelter> ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "karczma"@pl ,
+                                                                              "schronisko"@pl ,
+                                                                              "schronisko górskie"@pl ,
+                                                                              "stacja turystyczna"@pl ,
+                                                                              "szałas"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "schronisko turystyczne"@pl ,
+                                                                            "tourist shelter"@en ;
+                            ontohgis:hasExternalIdentifier "76" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_8 rdfs:comment "A demesne (manor) may be considered as an independent locality as long as it is distinguished by an individual name. Usually, a demesne was located away from the main group of houses in a village, on the outskirts, or in its vicinity."@en ,
+                                        "Folwark może być traktowany jako odrębna miejscowość, o ile posiadał własną nazwę. Zazwyczaj folwark położony był poza główną zabudową wsi, na jej obrzeżach lub w nieznacznym oddaleniu."@pl ;
+                           rdfs:isDefinedBy "A demesne (en: manor, pl: folwark, de: Volwerk) is a locality with an industrial function, often located near the manor (a building) or separate."@en ,
+                                            "Folwark (niem: Volwerk) to miejscowość o charakterze gospodarczym, często funkcjonująca obok dworu lub osobno."@pl ;
+                           rdfs:label "demesne"@en ,
+                                      "folwark"@pl ;
+                           rdfs:seeAlso <http://dbpedia.org/page/Demesne> ,
+                                        <http://dbpedia.org/page/Folwark> ,
+                                        <http://dbpedia.org/page/Manor> ,
+                                        <http://gov.genealogy.net/types.owl#64> ,
+                                        <http://vocab.getty.edu/aat/300000238> ,
+                                        <http://vocab.getty.edu/aat/300108235> ,
+                                        "duże gospodarstwo rolne wraz z zabudowaniami."@pl ,
+                                        "t. 1, s. 173: duże gospodarstwo rolne lub rolno-hodowlane, produkujące głównie na zbyt, posługujące się pracą chłopów pańszczyźnianych albo siłą najemną. Organizowane przez feudalnych właścicieli ziemskich już w XIV w., stanowiły kontynuację tzw. rezerwy pańskiej, czyli gruntów wyłączonych spod uprawy chłopskiej i przeznaczonych do zaspokajania bezpośrednich potrzeb dworu--’"@pl ,
+                                        "t. 1, s. 759: 1. mała wioska, leżąca obok dużej, oddzielona część wsi; przysiółek; 2. majętność, grunt z zabudowaniem, ferma; 3. dwór we wsi, mieszkanie dziedzica albo dzierżawcy razem z zabudowaniami dworskimi."@pl ,
+                                        "t. 7, s. 90–91: 1. ziemskie gospodarstwo, w przeciwieństwie do gospodarstwa chłopskiego, grunt z zabudowaniami gospodarskimi i mieszkalnymi, często będący częścią większej majętności; zazwyczaj wydzielona część wsi; 2. zabudowania gospodarcze; 3. ziemia orna, rola należąca do folwarku; 4. posiadłość ziemska, dworek z zabudowaniami gospodarskimi położony pod miastem; 5. wieś"@pl ;
+                           <http://www.w3.org/2004/02/skos/core#altLabel> "Vorwerk"@de ,
+                                                                          "praedium"@la ,
+                                                                          "фолварок"@ru ;
+                           <http://www.w3.org/2004/02/skos/core#hiddenLabel> "allodium"@la ,
+                                                                             "dobra"@pl ,
+                                                                             "domena"@pl ,
+                                                                             "dwór"@pl ,
+                                                                             "majątek"@pl ,
+                                                                             "manor"@en ,
+                                                                             "имение"@ru ,
+                                                                             "усадьба"@ru ,
+                                                                             "хутор"@ru ;
+                           <http://www.w3.org/2004/02/skos/core#prefLabel> "demesne"@en ,
+                                                                           "folwark"@pl ;
+                           ontohgis:hasExternalIdentifier "8" ;
+                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                           ontohgis:hasTranslator ontohgis:person_9 .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_8 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "duże gospodarstwo rolne wraz z zabudowaniami."@pl ;
+   rdfs:isDefinedBy ontohgis:document_4 ,
+                    <https://sjp.pwn.pl/doroszewski/folwark;5428273.html>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_8 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 1, s. 173: duże gospodarstwo rolne lub rolno-hodowlane, produkujące głównie na zbyt, posługujące się pracą chłopów pańszczyźnianych albo siłą najemną. Organizowane przez feudalnych właścicieli ziemskich już w XIV w., stanowiły kontynuację tzw. rezerwy pańskiej, czyli gruntów wyłączonych spod uprawy chłopskiej i przeznaczonych do zaspokajania bezpośrednich potrzeb dworu--’"@pl ;
+   rdfs:isDefinedBy ontohgis:document_17
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_8 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 1, s. 759: 1. mała wioska, leżąca obok dużej, oddzielona część wsi; przysiółek; 2. majętność, grunt z zabudowaniem, ferma; 3. dwór we wsi, mieszkanie dziedzica albo dzierżawcy razem z zabudowaniami dworskimi."@pl ;
+   rdfs:isDefinedBy ontohgis:document_5
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_8 ;
+   owl:annotatedProperty rdfs:seeAlso ;
+   owl:annotatedTarget "t. 7, s. 90–91: 1. ziemskie gospodarstwo, w przeciwieństwie do gospodarstwa chłopskiego, grunt z zabudowaniami gospodarskimi i mieszkalnymi, często będący częścią większej majętności; zazwyczaj wydzielona część wsi; 2. zabudowania gospodarcze; 3. ziemia orna, rola należąca do folwarku; 4. posiadłość ziemska, dworek z zabudowaniami gospodarskimi położony pod miastem; 5. wieś"@pl ;
+   rdfs:isDefinedBy ontohgis:document_2
+ ] .
+
+
+ontohgis:settlement_type_80 rdfs:comment "Characteristic for the Commonwealth of Poland and Lithuania from 16th to 18th century."@en ,
+                                         "Charakterystycznego dla Rzeczypospolitej XVII–XVIII wieku"@pl ;
+                            rdfs:isDefinedBy "\"Holendry\" (a Dutch type locality) is a colony established on an empty territory, in areas not very useful for agriculture. It was a type of locality characteristic for a \"Dutch colonisation\", which was a specific form of a settlement movement - widespread in the Commonwealth of Poland and Lithuania from 16th to 18th century. Granting uncongenial land difficult to cultivate or for animal husbandry to local people or (more often) immigrants inflowing from Flanders, German countries and Silesia was the core element of this process."@en ,
+                                             "Holendry to kolonia zakładana na obszarach nieobjętych osadnictwem z powodu nikłej przydatności rolniczej, właściwa dla tzw. kolonizacji olęderskiej, czyli specyficznej formy ruchu osadniczego – charakterystycznego dla Rzeczypospolitej XVII–XVIII wieku – polegającego na nadaniu ludności rodzimej – lub częściej – imigrantom pochodzącym z Flandrii, państw niemieckich lub Śląska, trudnej (w uprawie lub hodowli) ziemi."@pl ;
+                            rdfs:label "\"holendry\""@en ,
+                                       "holendry"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Hauland"@de ,
+                                                                              "Holander"@de ,
+                                                                              "Olander"@de ,
+                                                                              "Olender"@pl ,
+                                                                              "Olęder"@pl ,
+                                                                              "kolonia"@pl ,
+                                                                              "osada"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "\"holendry\""@en ,
+                                                                            "holendry"@pl ;
+                            ontohgis:hasExternalIdentifier "80" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 .
+
+
+ontohgis:settlement_type_82 rdfs:comment "Port morski na austriackiej mapie 1:75 000 wyróżniony explicite i opisany krojem pisma takim jak miasta większe niż 100 000 mieszkańców i twierdze.W BDOT10k „port wodny lub przystań” w klasie kompleks komunikacyjny.Jest u Bystrzyckiego (nie w skrótach) – port, miasto portowe."@pl ,
+                                         "Sea harbour on the Austrian map 1:75,000 (Spezialkarte...) is explicitly distinguished as a placename using the same annotation style as \"cities larger than 100,000 inhabitants and fortresses\".Sea harbour is included in DBTO10k as \"sea harbour port or marina\" in the communication complex feature class (KUKO).Sea harbour is included in Bystrzycki's register (however, not in abbreviations list) as \"harbour\" (pol \"port\"), \"harbour city\" (pol \"miasto portowe\")."@en ;
+                            rdfs:isDefinedBy "Port morski (miejscowość) jest to miejscowość w której główną rolę pełni port morski jako obiekt"@pl ,
+                                             "Sea harbour (locality) is a locality where the main role is played by a sea harbour (area)."@en ;
+                            rdfs:label "port morski"@pl ,
+                                       "sea harbour"@en ;
+                            rdfs:seeAlso <http://dbpedia.org/ontology/Port> ,
+                                         <https://www.wikidata.org/wiki/Q15310171> ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "port morski"@pl ,
+                                                                            "sea harbour"@en ;
+                            ontohgis:hasExternalIdentifier "82" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+ontohgis:settlement_type_99 rdfs:isDefinedBy "Inn (locality) is a settlement in which the main role is played by an inn (builing)."@en ,
+                                             "Osada karczemna to osada, w której główną rolę pełni karczma (obiekt)."@pl ;
+                            rdfs:label "inn"@en ,
+                                       "osada karczemna"@pl ;
+                            rdfs:seeAlso <http://dbpedia.org/page/Hamlet_(place)> ,
+                                         <http://gov.genealogy.net/types.owl#120> ,
+                                         <https://www.wikidata.org/wiki/Q5084> ;
+                            <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Gasthof"@de ,
+                                                                              "Krug"@de ,
+                                                                              "Wirthaus"@de ,
+                                                                              "budynek"@pl ,
+                                                                              "gospoda"@pl ,
+                                                                              "gościniec"@pl ,
+                                                                              "gościnny dom"@pl ,
+                                                                              "oberża"@pl ,
+                                                                              "restauracja"@pl ,
+                                                                              "szynkowny dom"@pl ,
+                                                                              "taberna"@la ,
+                                                                              "zajazd"@pl ;
+                            <http://www.w3.org/2004/02/skos/core#prefLabel> "inn"@en ,
+                                                                            "osada karczemna"@pl ;
+                            ontohgis:hasExternalIdentifier "99" ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
+
+
+###  Generated by the OWL API (version 4.5.24.2023-01-14T21:28:32Z) https://github.com/owlcs/owlapi


### PR DESCRIPTION
We would like to have one subproperty of rdfs:isDefinedBy for IRIs and the other for the literals.