### PR TITLE
Split of rdfs:seeAlso

### DIFF
--- a/ontohgis.ttl
+++ b/ontohgis.ttl
@@ -7051,7 +7051,6 @@ ontohgis:administrative_type_153 rdf:type owl:Class ;
                                             "archidiaconatus"@la ,
                                             "archidiakonat (Kościół katolicki ob. łacińskiego)"@pl ;
                                  rdfs:seeAlso <http://dbpedia.org/page/Archdeacon> ,
-                                              <http://vocab.getty.edu/aat/300387197> ,
                                               <https://www.wikidata.org/wiki/Q16528361> ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "archdeaconship"@en ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "dziekania"@pl ,
@@ -7059,7 +7058,8 @@ ontohgis:administrative_type_153 rdf:type owl:Class ;
                                                                                    "terytorium"@pl ;
                                  ontohgis:hasExternalIdentifier 153 ;
                                  ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
-                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_240 .
+                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_240 ;
+                                 ontohgis:seeAlsoIRI <http://vocab.getty.edu/aat/300387197> .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_154
@@ -19067,7 +19067,6 @@ Podstawowym kryterium wyodrębniającym uroczysko od innych miejscowości lub je
                                          <https://pzgik.geoportal.gov.pl/ontologies/prng/uroczysko> ,
                                          <https://pzgik.geoportal.gov.pl/ontologies/prng/uroczysko-dawnaMiejsc> ,
                                          <https://www.wikidata.org/wiki/Q1434274> ,
-                                         "1. teren trudno dostępny, najczęściej bagnisty, leśny; też: miejsce odludne, 2. część terenu otoczona naturalnymi granicami, wyodrębniona za pomocą nazwy topograficznej, 3. u dawnych Słowian: miejsce w głębi puszczy związane z kultem bóstwa, odbywaniem narad lub uważane za siedzibę złych duchów"@pl ,
                                          "s. 57-80: uroczyska to cała gama pojęć, stale łąki i lokacje straży leśnej, czasem synonimy borów i ostępów, zjawiska terenowe zasadniczo rozległe o wielce zróżniczkowanej, a raczej nieuchwytnej i zatraconej już, treści. Można tylko utrzymywać, że uroczyska to teren eksploatacji par excellence."@pl ,
                                          "t. 15, s. 34: nazwa kopca lub miejsca granicznego nieosiedlonego. Według Chodakowskiego, uroczyska, na Rusi horodyszczami zwane, były to w Słowiańszczyźnie przedchrześcijańskiej place, czyli świątyń posady, do sprawowania uroczystych pogańskich ofiar przeznaczone i nie mające śladu opisania wałami, byleby oddzielna, właściwe imię mająca, przywiązana do nich była jakaś pamiątka."@pl ,
                                          "t. 6, s. 80: uroczysko, uroczyszcze -- (Rs. urocziszcze, = powiat, kraina); kopiec, mieysce graniczne. Tr. Gränzstein, Mohlhausen."@pl ,
@@ -19085,15 +19084,8 @@ Podstawowym kryterium wyodrębniającym uroczysko od innych miejscowości lub je
                                                                             "uroczysko"@pl ;
                             ontohgis:hasExternalIdentifier "54" ;
                             ontohgis:isDefinedByLiteral "Forest distrct is a part of a forest, meadow or swampy area separated by natural borders and an own (proper) name for better organization of social and economic life. Built-up and inhabited forest district used to be a locality."@en ,
-                                                        "Uroczysko to obszar leśny, łąkowy lub bagnisty wyodrębniony naturalnymi granicami oraz nazwą własną w celu lepszej organizacji życia społecznego i gospodarczego. Uroczysko zabudowane i zamieszkane było miejscowością."@pl .
-
-[ rdf:type owl:Axiom ;
-   owl:annotatedSource ontohgis:settlement_type_54 ;
-   owl:annotatedProperty rdfs:seeAlso ;
-   owl:annotatedTarget "1. teren trudno dostępny, najczęściej bagnisty, leśny; też: miejsce odludne, 2. część terenu otoczona naturalnymi granicami, wyodrębniona za pomocą nazwy topograficznej, 3. u dawnych Słowian: miejsce w głębi puszczy związane z kultem bóstwa, odbywaniem narad lub uważane za siedzibę złych duchów"@pl ;
-   ontohgis:isDefinedByIRI <http://sjp.pwn.pl/sjp/uroczysko;2533316.html> ,
-                           ontohgis:document_3
- ] .
+                                                        "Uroczysko to obszar leśny, łąkowy lub bagnisty wyodrębniony naturalnymi granicami oraz nazwą własną w celu lepszej organizacji życia społecznego i gospodarczego. Uroczysko zabudowane i zamieszkane było miejscowością."@pl ;
+                            ontohgis:seeAlsoLiteral "1. teren trudno dostępny, najczęściej bagnisty, leśny; też: miejsce odludne, 2. część terenu otoczona naturalnymi granicami, wyodrębniona za pomocą nazwy topograficznej, 3. u dawnych Słowian: miejsce w głębi puszczy związane z kultem bóstwa, odbywaniem narad lub uważane za siedzibę złych duchów"^^rdfs:Literal .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_54 ;
@@ -19136,6 +19128,14 @@ Podstawowym kryterium wyodrębniającym uroczysko od innych miejscowości lub je
    owl:annotatedTarget "u dawnych Słowian: miejsce przed świątynią lub w głębi puszczy, związane z kultem jakiegoś bóstwa, z odbywaniem narad, sądów; ogólnie: miejsce odludne, tajemnicze; pustkowie -- 2. część terenu (zwykle lasu wyodrębniona za pomocą nazwy o charakterze topograficznym."@pl ;
    ontohgis:isDefinedByIRI <http://sjp.pwn.pl/doroszewski/uroczysko;5512266.html> ,
                            ontohgis:document_4
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource ontohgis:settlement_type_54 ;
+   owl:annotatedProperty ontohgis:seeAlsoLiteral ;
+   owl:annotatedTarget "1. teren trudno dostępny, najczęściej bagnisty, leśny; też: miejsce odludne, 2. część terenu otoczona naturalnymi granicami, wyodrębniona za pomocą nazwy topograficznej, 3. u dawnych Słowian: miejsce w głębi puszczy związane z kultem bóstwa, odbywaniem narad lub uważane za siedzibę złych duchów"^^rdfs:Literal ;
+   ontohgis:isDefinedByIRI <http://sjp.pwn.pl/sjp/uroczysko;2533316.html> ,
+                           ontohgis:document_3
  ] .
 
 

--- a/ontohgis.ttl
+++ b/ontohgis.ttl
@@ -458,6 +458,22 @@ ontohgis:isValidThroughout rdf:type owl:AnnotationProperty ;
                            rdfs:range ontohgis:object_204 .
 
 
+###  https://onto.kul.pl/ontohgis/seeAlsoIRI
+ontohgis:seeAlsoIRI rdf:type owl:AnnotationProperty ;
+                    rdfs:label "see also an IRI"@en ,
+                               "zobacz też IRI"@pl ;
+                    rdfs:subPropertyOf rdfs:seeAlso ;
+                    rdfs:range xsd:anyURI .
+
+
+###  https://onto.kul.pl/ontohgis/seeAlsoLiteral
+ontohgis:seeAlsoLiteral rdf:type owl:AnnotationProperty ;
+                        rdfs:label "see also a literal"@en ,
+                                   "zobacz też tekst"@pl ;
+                        rdfs:subPropertyOf rdfs:seeAlso ;
+                        rdfs:range rdfs:Literal .
+
+
 #################################################################
 #    Datatypes
 #################################################################
@@ -6537,11 +6553,11 @@ ontohgis:administrative_type_1 rdf:type owl:Class ;
                                rdfs:subClassOf ontohgis:administrative_type_24 ;
                                rdfs:comment """\"1808: Städte-Ordnung.
 Gminy miejskie i gminy wiejskie były jednostkami organizacji samorządowej (komunalnej), ale równocześnie pełniły funkcje podstawowych jednostek administracji terytorialnej. M. Bär, s. 228: „Die Landgemeinde ist außer einem Kommunalverband auch ein Bezirk der allgemeinen Landesverwaltung für die mannigfachen Geschäfte des staatlichen Polizei- und Finanzwesens, insbesondere für die Handhabung der Ortspolizei, und der Gemeindevorsteher ist das Organ des Amtsvorstehers für die örtliche Polizeiverwaltung“. W. Roger W.Frotscher, „Überblick über die Verwaltungsorganisation in den Bundesstaaten, w: Deutsche Verwaltungsgeschichte, Bd. 3 hrsg. von K.G.A. Jeserich, H. Pohl und G. Ch. v. Unruh, Stuttgart 1984, S. 417: „Der preußische Staat endete beim Landrat. In diesem oft zitierten Satz kommt zum Ausdruck, dass Gemeindeorgane, auch soweit sie staatliche Angelegenheiten wahrnahmen, nicht als staatliche, sondern als kommunale Behörden tätig wurden. Sie handelten, etwa als Ortspolizei `für den Staat` in einem ihnen übertragenen Wirkungskreis.\""""@de ;
-                               ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                rdfs:label "Stadtgemeinde"@de ,
                                           "gmina miejska"@pl ,
                                           "town commune"@en ;
                                ontohgis:hasExternalIdentifier 1 ;
+                               ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
@@ -6552,12 +6568,12 @@ ontohgis:administrative_type_10 rdf:type owl:Class ;
                                                   owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                   owl:someValuesFrom ontohgis:administrative_type_11
                                                 ] ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                 rdfs:label "land district (The Second Polish Republic)"@en ,
                                            "powiat (Rzeczpospolita Polska (1918-1939))"@pl ;
                                 rdfs:seeAlso "http://gov.genealogy.net/types.owl#32" ,
                                              "https://www.wikidata.org/wiki/Q247073" ;
                                 ontohgis:hasExternalIdentifier 10 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -6565,19 +6581,18 @@ ontohgis:administrative_type_10 rdf:type owl:Class ;
 ontohgis:administrative_type_11 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:object_3014 ;
                                 rdfs:comment "Ustawy z lat 1919-1925 decydowały o utworzeniu poszczególnych województw (jako ostatnie zostało utworzone woj. wileńskie); na poziomie województwa (III stopień) klasyfikowane było także w ramach podziału terytorialnego administracji zespolonej miasto Warszawa, Mielcarek, s. 52."@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                 rdfs:label "voivodeship (The Second Polish Republic)"@en ,
                                            "województwo (Rzeczpospolita Polska (1918-1939))"@pl ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "province"@en ,
                                                                                "vojvodship"@en ;
                                 ontohgis:hasExternalIdentifier 11 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_111
 ontohgis:administrative_type_111 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_19 ;
                                  rdfs:label "Kreis"@de ,
                                             "district (Silesia (1372-1782))"@en ,
                                             "powiat (Śląsk (1372-1782))"@pl ,
@@ -6590,6 +6605,7 @@ ontohgis:administrative_type_111 rdf:type owl:Class ;
                                                                                 "okręg"@pl ,
                                                                                 "ziemia"@pl ;
                                  ontohgis:hasExternalIdentifier 111 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_19 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -6600,10 +6616,10 @@ ontohgis:administrative_type_115 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_118
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_20 ;
                                  rdfs:label "miasto-ziemia (Księstwo Pomorskie (1230-1648))"@pl ,
                                             "town (The Duchy of Pomerania (1230-1648))"@en ;
                                  ontohgis:hasExternalIdentifier 115 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_20 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_40 .
 
 
@@ -6611,10 +6627,10 @@ ontohgis:administrative_type_115 rdf:type owl:Class ;
 ontohgis:administrative_type_116 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_115 ;
                                  rdfs:comment "Miasta pokolokacyjne zastąpiły wcześniejszy, rodzimy (słowiański) system grodów kasztelańskich. Władzę sprawowali w nich w imieniu księcia mianowani spośród mieszczan sołtysi (sculteti) zwani również wójtami lub podwójtami (advocati minores, subadvocati)."@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_20 ;
                                  rdfs:label "charter town (The Duchy of Pomerania (1230-1648))"@en ,
                                             "miasto polokacyjne (Księstwo Pomorskie (1230-1648))"@pl ;
                                  ontohgis:hasExternalIdentifier 116 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_20 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_40 .
 
 
@@ -6622,11 +6638,11 @@ ontohgis:administrative_type_116 rdf:type owl:Class ;
 ontohgis:administrative_type_117 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_115 ;
                                  rdfs:comment "Dawne opola przekształcono w niewielkie jednostki terytorialne (Land), stanowiące zespół dóbr panującego, lub obszary będące lennami wielkich feudałów. Władzę sprawują wójtowie."@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_20 ;
                                  rdfs:label "Land"@de ,
                                             "land (The Duchy of Pomerania (1230-1648))"@en ,
                                             "ziemia (Księstwo Pomorskie (1230-1648))"@pl ;
                                  ontohgis:hasExternalIdentifier 117 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_20 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_40 .
 
 
@@ -6635,10 +6651,10 @@ ontohgis:administrative_type_118 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
                                  rdfs:comment """\"Powstały przeważnie z dawnych kasztelanii, zarządzane przez landwójtów (advocatus maior, Grosswogt, Landwogt). Zakres władzy: sądy nad rycerstwem, sądy odwoławcze w sprawach miejskich i chłopów z domen panujących; zarząd domen książęcych i egzekucja powinności; nadzór nad zamkami książęcymi i miastami.
 Od poł. XVI wieku równolegle powstają okręgi zarządów domen. Okręgi zarządów domen powstawały w wyniku sekularyzacji i przejmowania przez książąt pomorskich dóbr kościelnych, jednak nie objęły terytorium całego kraju i „nie były jeszcze w pełnym tego słowa znaczeniu okręgami administracji państwowej” (Historia Pomorza, II, 1, s. 842).\""""@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_20 ;
                                  rdfs:label "landwójtostwo (Księstwo Pomorskie (1230-1648))"@pl ,
                                             "rural bailiwick (The Duchy of Pomerania (1230-1648))"@en ;
                                  ontohgis:hasExternalIdentifier 118 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_20 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
@@ -6649,7 +6665,6 @@ ontohgis:administrative_type_121 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_122
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_21 ;
                                  rdfs:label "Kreis"@de ,
                                             "rural district (The Margraviate of Branderburg (1540-1713))"@en ,
                                             "urząd dominialny (Marchia Brandenburska (1540-1713))"@pl ;
@@ -6658,6 +6673,7 @@ ontohgis:administrative_type_121 rdf:type owl:Class ;
                                                                                 "okręg"@pl ,
                                                                                 "powiat ziemski"@pl ;
                                  ontohgis:hasExternalIdentifier 121 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_21 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -6669,11 +6685,11 @@ ontohgis:administrative_type_122 rdf:type owl:Class ;
                                                    owl:someValuesFrom ontohgis:administrative_type_123
                                                  ] ;
                                  rdfs:comment "Landvogtei (landwójtostwo) (zwane również okręgiem, w którym władzę sprawuje Landeshauptmann). Powstało w XIV w. w wyniku zmian politycznych (zmiana dynastii) oraz osłabienia dawnego systemu wójtostw, spowodowanego obficie udzielanymi przez margrafów przywilejami ekonomicznymi i sądowniczymi dla miast, klasztorów i dóbr rycerskich. Ponadto kolonizacja pustek, zmuszała do tworzenia znacznie większych obszarów administracji lokalnej niż poprzednie wójtostwa."@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_21 ;
                                  rdfs:label "landwójtostwo (Marchia Brandenburska (1540-1713))"@pl ,
                                             "rural bailiwick (The Margraviate of Branderburg (1540-1713))"@en ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "voyt's rural dominion"@en ;
                                  ontohgis:hasExternalIdentifier 122 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_21 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
@@ -6681,11 +6697,11 @@ ontohgis:administrative_type_122 rdf:type owl:Class ;
 ontohgis:administrative_type_123 rdf:type owl:Class ;
                                  owl:equivalentClass ontohgis:administrative_type_30 ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_21 ;
                                  rdfs:label "Kreis"@de ,
                                             "Province (The Margraviate of Branderburg (1540-1713))"@en ,
                                             "prowincja (Marchia Brandenburska (1540-1713))"@pl ;
                                  ontohgis:hasExternalIdentifier 123 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_21 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_60 .
 
 
@@ -6697,13 +6713,13 @@ ontohgis:administrative_type_127 rdf:type owl:Class ;
                                                    owl:someValuesFrom ontohgis:administrative_type_128
                                                  ] ;
                                  rdfs:comment "Vogtei (wójtostwo) i równolegle lub na ich bazie powstający Kreis (powiat) ziemski oraz Amt zwany również Domänenamt (okręg, urząd dominialny)"@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_23 ;
                                  rdfs:label "Vogtei"@de ,
                                             "bailiwick (The Margraviate of Branderburg (1323-1540))"@en ,
                                             "wójtostwo (Marchia Brandenburska (1323-1540))"@pl ;
                                  rdfs:seeAlso "http://dbpedia.org/page/Bailiwick" ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "voyt's dominion,"@en ;
                                  ontohgis:hasExternalIdentifier 127 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_23 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_20 .
 
 
@@ -6714,11 +6730,11 @@ ontohgis:administrative_type_128 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_129
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_23 ;
                                  rdfs:label "Landvogtei"@de ,
                                             "landwójtostwo (Marchia Brandenburska (1323-1540))"@pl ,
                                             "rural bailiwick (The Margraviate of Branderburg (1323-1540))"@en ;
                                  ontohgis:hasExternalIdentifier 128 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_23 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
@@ -6727,11 +6743,11 @@ ontohgis:administrative_type_129 rdf:type owl:Class ;
                                  owl:equivalentClass ontohgis:administrative_type_30 ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
                                  rdfs:comment "W Nowej Marchii był także starosta generalny dla całej prowincji, stojący ponad landwójtami (Walachowicz, Advocatia, s. 195)."@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_23 ;
                                  rdfs:label "province (The Margraviate of Branderburg (1323-1540))"@en ,
                                             "prowincja (Marchia Brandenburska (1323-1540))"@pl ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "starostwo generalne"@pl ;
                                  ontohgis:hasExternalIdentifier 129 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_23 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_60 .
 
 
@@ -6739,11 +6755,11 @@ ontohgis:administrative_type_129 rdf:type owl:Class ;
 ontohgis:administrative_type_13 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_24 ;
                                 rdfs:comment "1818: Edykt o urzędach sołtysów w gminach wiejskich i obszarach dworskich."@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 rdfs:label "Landgemeinde"@de ,
                                            "gmina wiejska (Wolne Państwo Prusy (1920-1945))"@pl ,
                                            "rural commune (The Free State of Prussia)"@en ;
                                 ontohgis:hasExternalIdentifier 13 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
@@ -6751,10 +6767,10 @@ ontohgis:administrative_type_13 rdf:type owl:Class ;
 ontohgis:administrative_type_132 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
                                  rdfs:comment "Kasztelania, opole, żupa, pagast; tutaj należy szukać genezy polskich powiatów; inne terytoria zależne nie posiadające statusu księstwa czy marchii (ziemie, miasta, część księstw, regiony)"@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_24 ;
                                  rdfs:label "district"@en ,
                                             "dzielnica (System średniowieczny (do XIV w.))"@pl ;
                                  ontohgis:hasExternalIdentifier 132 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_24 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -6766,34 +6782,34 @@ ontohgis:administrative_type_136 rdf:type owl:Class ;
                                                    owl:someValuesFrom ontohgis:administrative_type_139
                                                  ] ;
                                  rdfs:comment "Od XIV w. J. Tandecki, Struktury i podziały administracyjne w zakonie krzyżackim w Inflantach, [w:] Zakon Krzyżacki w Prusach i Inflantach. Podziały admiinistracyjne i kościelne w XIII-XVI wieku, red. R. Czaja, A. Radzimiński, Toruń 2013, s. 171: \"Od samego początku istnienia terytorium zakonnego w Inflantach podstawowymi jednostkami jego ustroju administracyjnego były wójtostwa (Vogtei) i komturstwa (Komturei), będące zarazem siedzibami krzyżackich konwentów zakonnych\""@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_25 ;
                                  rdfs:label "bailiwick (The State of the Teutonic Order (1226-1525))"@en ,
                                             "wójtostwo (Państwo Krzyżackie (1226-1525))"@pl ;
                                  rdfs:seeAlso "http://dbpedia.org/page/Bailiwick" ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "district"@en ;
                                  ontohgis:hasExternalIdentifier 136 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_25 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_20 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_137
 ontohgis:administrative_type_137 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_136 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_25 ;
                                  rdfs:label "bailiwick (The State of the Teutonic Order (1226-1525))"@en ,
                                             "wójtostwo (Państwo Krzyżackie (1226-1525))"@pl ;
                                  rdfs:seeAlso "http://dbpedia.org/page/Bailiwick" ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "district"@en ;
                                  ontohgis:hasExternalIdentifier 137 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_25 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_20 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_138
 ontohgis:administrative_type_138 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_136 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_25 ;
                                  rdfs:label "pfleger's dominion (The State of the Teutonic Order (1226-1525))"@en ,
                                             "prokuratorstwo (Państwo Krzyżackie (1226-1525))"@pl ;
                                  ontohgis:hasExternalIdentifier 138 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_25 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_20 .
 
 
@@ -6801,11 +6817,11 @@ ontohgis:administrative_type_138 rdf:type owl:Class ;
 ontohgis:administrative_type_139 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
                                  rdfs:comment "Do 1309 roku właściwie jedyny podział terytorialny; w latach 20. i 30. XIV w. - w wyniku likwidacji komturstwa ziemi chełmińskiej - powstały wójtostwo lipienieckie i nowomiejskie (potem bratiańskie), zaś w wyniku likwidacji komturstw unisławskiego i rogozińskiego powstały prokuratorstwo unisławskie i wójtostwo rogozińskie; wójtostwa istniały też na innych obszarach państwa. J. Tandecki, Podziały administracyjne państwa zakonnego w Prusach, [w:] Zakon Krzyżacki w Prusach i Inflantach. Podziały admiinistracyjne i kościelne w XIII-XVI wieku, red. R. Czaja, A. Radzimiński, Toruń 2013, s. 30: \"Od początku istnienia państwa zakonnego w Prusach podstawowymi jednostkami ustroju terytorialnego były komturstwa (Komturei), będące jednocześnie siedzibami krzyżackich konwentów zakonnych\"."@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_25 ;
                                  rdfs:label "commandery (The State of the Teutonic Order (1226-1525))"@en ,
                                             "komturstwo (Państwo Krzyżackie (1226-1525))"@pl ;
                                  rdfs:seeAlso "https://www.wikidata.org/wiki/Q1434544" ;
                                  ontohgis:hasExternalIdentifier 139 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_25 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -6814,37 +6830,37 @@ ontohgis:administrative_type_14 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_24 ;
                                 rdfs:comment """1818: Edykt o urzędach sołtysów w gminach wiejskich i obszarach dworskich.
 31.12.1842: Terytorialne rozgraniczenie gmin wiejskich i obszarów dworskich w prowincjach wschodnich"""@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 rdfs:label "Gutsbezirk"@de ,
                                            "manorial demesne (The Free State of Prussia)"@en ,
                                            "obszar dworski (Wolne Państwo Prusy (1920-1945))"@pl ;
                                 rdfs:seeAlso "http://gov.genealogy.net/types.owl#109" ,
                                              "https://www.wikidata.org/wiki/Q451019" ;
                                 ontohgis:hasExternalIdentifier 14 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_140
 ontohgis:administrative_type_140 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_139 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_25 ;
                                  rdfs:label "commandery (The State of the Teutonic Order (1226-1525))"@en ,
                                             "komturstwo (Państwo Krzyżackie (1226-1525))"@pl ;
                                  rdfs:seeAlso "http://dbpedia.org/page/Commandry_(military_orders)" ,
                                               "http://gov.genealogy.net/types.owl#191" ,
                                               "https://www.wikidata.org/wiki/Q1434544" ;
                                  ontohgis:hasExternalIdentifier 140 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_25 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_141
 ontohgis:administrative_type_141 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_139 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_25 ;
                                  rdfs:label "chapter lands (The State of the Teutonic Order (1226-1525))"@en ,
                                             "władztwo biskupa i kapituły (Państwo Krzyżackie (1226-1525))"@pl ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "bishop's lands"@en ;
                                  ontohgis:hasExternalIdentifier 141 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_25 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -6870,7 +6886,6 @@ ontohgis:administrative_type_144 rdf:type owl:Class ;
                                                    owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
                                                    owl:onClass ontohgis:administrative_type_147
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  rdfs:label "Pfarre"@de ,
                                             "parafia (Kościół katolicki ob. łacińskiego)"@pl ,
                                             "parish (Latin Church)"@en ,
@@ -6885,6 +6900,7 @@ ontohgis:administrative_type_144 rdf:type owl:Class ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "community"@en ,
                                                                                    "gmina"@pl ;
                                  ontohgis:hasExternalIdentifier 144 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_210 .
 
 
@@ -6905,10 +6921,10 @@ ontohgis:administrative_type_145 rdf:type owl:Class ;
                                                    owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
                                                    owl:onClass ontohgis:administrative_type_146
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  rdfs:label "deanery-archpresbyterate-forane vicariate (Latin Church)"@en ,
                                             "dekanat-archiprezbiterat-wikariat okręgowy (Kościół katolicki ob. łacińskiego)"@pl ;
                                  ontohgis:hasExternalIdentifier 145 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
@@ -6919,10 +6935,10 @@ ontohgis:administrative_type_146 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_147
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  rdfs:label "archdeaconry-deaconry-provostship-territory (Latin Church)"@en ,
                                             "archidiakonat-dziekania-prepozytura-terytorium (Kościół katolicki ob. łacińskiego)"@pl ;
                                  ontohgis:hasExternalIdentifier 146 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_240 .
 
 
@@ -6939,7 +6955,6 @@ ontohgis:administrative_type_147 rdf:type owl:Class ;
                                                    owl:onClass ontohgis:administrative_type_148
                                                  ] ;
                                  rdfs:comment "szczególną kategorią diecezji, jest diecezja metropolitalna zwana inaczej archidiecezją, pozostałe diecezje w metropolii nazywane są sufraganiami"@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  rdfs:label "Diözese"@de ,
                                             "diecezja (Kościół katolicki ob. łacińskiego)"@pl ,
                                             "diocese (Latin Church)"@en ,
@@ -6953,13 +6968,13 @@ ontohgis:administrative_type_147 rdf:type owl:Class ;
                                                                                    "biskupstwo"@pl ,
                                                                                    "sufragania"@pl ;
                                  ontohgis:hasExternalIdentifier 147 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_200 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_148
 ontohgis:administrative_type_148 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3012 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  rdfs:label "metropolia (Kościół katolicki ob. łacińskiego)"@pl ,
                                             "metropolis"@la ,
                                             "metropoly (Latin Church)"@en ;
@@ -6969,6 +6984,7 @@ ontohgis:administrative_type_148 rdf:type owl:Class ;
                                                                                 "metropolis"@en ,
                                                                                 "prowincja kościelna"@pl ;
                                  ontohgis:hasExternalIdentifier 148 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_220 .
 
 
@@ -6976,7 +6992,6 @@ ontohgis:administrative_type_148 rdf:type owl:Class ;
 ontohgis:administrative_type_150 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_145 ;
                                  rdfs:comment "podział na dekanaty był wprowadzany od XII wieku"@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  rdfs:label "deanery (Latin Church)"@en ,
                                             "decanatus"@la ,
                                             "decanatus ruralis"@la ,
@@ -6989,6 +7004,7 @@ ontohgis:administrative_type_150 rdf:type owl:Class ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "archiprezbiterat"@pl ,
                                                                                    "wikariat okręgowy"@pl ;
                                  ontohgis:hasExternalIdentifier 150 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
@@ -6996,7 +7012,6 @@ ontohgis:administrative_type_150 rdf:type owl:Class ;
 ontohgis:administrative_type_151 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_145 ;
                                  rdfs:comment "dotyczy diecezji wrocławskiej oraz diecezji pruskich"@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  rdfs:label "archipresbyteratus"@la ,
                                             "archiprezbiterat (Kościół katolicki ob. łacińskiego)"@pl ,
                                             "archpresbyterate (Latin Church)"@en ;
@@ -7006,13 +7021,13 @@ ontohgis:administrative_type_151 rdf:type owl:Class ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "dekanat"@pl ,
                                                                                    "wikariat okręgowy"@pl ;
                                  ontohgis:hasExternalIdentifier 151 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_152
 ontohgis:administrative_type_152 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_145 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  rdfs:label "forane vicariate (Latin Church)"@en ,
                                             "vicariatus foraneus"@la ,
                                             "wikariat okręgowy (Kościół katolicki ob. łacińskiego)"@pl ,
@@ -7024,6 +7039,7 @@ ontohgis:administrative_type_152 rdf:type owl:Class ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "archiprezbiterat"@pl ,
                                                                                    "dekanat"@pl ;
                                  ontohgis:hasExternalIdentifier 152 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
@@ -7031,7 +7047,6 @@ ontohgis:administrative_type_152 rdf:type owl:Class ;
 ontohgis:administrative_type_153 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_146 ;
                                  rdfs:comment "podział na archidiakonaty był wprowadzany od XII wieku; archdiakonaty zostały zlikwidowane w II połowie XVIII i początku XIX wieku (zabór austriacki - 1782, 1805, zabór rosyjski - 1818, zabór pruski - 1821)"@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  rdfs:label "archdeaconry (Latin Church)"@en ,
                                             "archidiaconatus"@la ,
                                             "archidiakonat (Kościół katolicki ob. łacińskiego)"@pl ;
@@ -7043,13 +7058,13 @@ ontohgis:administrative_type_153 rdf:type owl:Class ;
                                                                                    "prepozytura"@pl ,
                                                                                    "terytorium"@pl ;
                                  ontohgis:hasExternalIdentifier 153 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_240 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_154
 ontohgis:administrative_type_154 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_146 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  rdfs:label "deaconry (Latin Church)"@en ,
                                             "decanatus"@la ,
                                             "dziekania (Kościół katolicki ob. łacińskiego)"@pl ;
@@ -7058,13 +7073,13 @@ ontohgis:administrative_type_154 rdf:type owl:Class ;
                                                                                    "prepozytura"@pl ,
                                                                                    "terytorium"@pl ;
                                  ontohgis:hasExternalIdentifier 154 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_240 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_155
 ontohgis:administrative_type_155 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_146 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  rdfs:label "praepositura"@la ,
                                             "prepozytura (Kościół katolicki ob. łacińskiego)"@pl ,
                                             "provostship (Latin Church)"@en ;
@@ -7075,13 +7090,13 @@ ontohgis:administrative_type_155 rdf:type owl:Class ;
                                                                                    "dziekania"@pl ,
                                                                                    "terytorium"@pl ;
                                  ontohgis:hasExternalIdentifier 155 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_240 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_156
 ontohgis:administrative_type_156 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_146 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  rdfs:label "territorium"@la ,
                                             "territory (Latin Church)"@en ,
                                             "terytorium (Kościół katolicki ob. łacińskiego)"@pl ;
@@ -7089,6 +7104,7 @@ ontohgis:administrative_type_156 rdf:type owl:Class ;
                                                                                    "dziekania"@pl ,
                                                                                    "prepozytura"@pl ;
                                  ontohgis:hasExternalIdentifier 156 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_26 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_240 .
 
 
@@ -7099,7 +7115,6 @@ ontohgis:administrative_type_157 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_158
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  rdfs:label "Pfarre"@de ,
                                             "parafia (Kościół katolicki ob. greckiego)"@pl ,
                                             "parish (Greek Catholic Church)"@en ,
@@ -7111,6 +7126,7 @@ ontohgis:administrative_type_157 rdf:type owl:Class ;
                                               <https://www.wikidata.org/wiki/Q102496> ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "community"@en ;
                                  ontohgis:hasExternalIdentifier 157 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_210 .
 
 
@@ -7121,10 +7137,10 @@ ontohgis:administrative_type_158 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_159
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  rdfs:label "protopopia-namiestnictwo-dekanat (Kościół katolicki ob. greckiego)"@pl ,
                                             "protopopy-governorship-deanery (Greek Catholic Church)"@en ;
                                  ontohgis:hasExternalIdentifier 158 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
@@ -7135,10 +7151,10 @@ ontohgis:administrative_type_159 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_160
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  rdfs:label "general governorship-kliros-officialate (Greek Catholic Church)"@en ,
                                             "namiestnictwo generalne - kryłos - oficjalat (Kościół katolicki ob. greckiego)"@pl ;
                                  ontohgis:hasExternalIdentifier 159 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_240 .
 
 
@@ -7149,7 +7165,6 @@ ontohgis:administrative_type_160 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_161
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  rdfs:label "eparchia (Kościół katolicki ob. greckiego)"@pl ,
                                             "eparchy (Greek Catholic Church)"@en ,
                                             "епархия"@ru ;
@@ -7160,13 +7175,13 @@ ontohgis:administrative_type_160 rdf:type owl:Class ;
                                                                                 "diocese"@en ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "biskupstwo"@pl ;
                                  ontohgis:hasExternalIdentifier 160 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_200 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_161
 ontohgis:administrative_type_161 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3012 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  rdfs:label "metropolia (Kościół katolicki ob. greckiego)"@pl ,
                                             "metropolis"@la ,
                                             "metropoly (Greek Catholic Church)"@en ,
@@ -7177,13 +7192,13 @@ ontohgis:administrative_type_161 rdf:type owl:Class ;
                                                                                 "metropolis"@en ,
                                                                                 "prowincja kościelna"@la ;
                                  ontohgis:hasExternalIdentifier 161 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_220 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_163
 ontohgis:administrative_type_163 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_158 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  rdfs:label "protopopia (Kościół katolicki ob. greckiego)"@pl ,
                                             "protopopy"@en ,
                                             "протопопия"@ru ;
@@ -7193,13 +7208,13 @@ ontohgis:administrative_type_163 rdf:type owl:Class ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "dekanat"@pl ,
                                                                                    "namiestnictwo"@pl ;
                                  ontohgis:hasExternalIdentifier 163 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_164
 ontohgis:administrative_type_164 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_158 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  rdfs:label "governorship (Greek Catholic Church)"@en ,
                                             "namiestnictwo (Kościół katolicki ob. greckiego)"@pl ,
                                             "наместничество"@ru ;
@@ -7207,13 +7222,13 @@ ontohgis:administrative_type_164 rdf:type owl:Class ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "dekanat"@pl ,
                                                                                    "protopopia"@pl ;
                                  ontohgis:hasExternalIdentifier 164 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_165
 ontohgis:administrative_type_165 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_158 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  rdfs:label "deanery (Greek Catholic Church)"@en ,
                                             "dekanat (Kościół katolicki ob. greckiego)"@pl ,
                                             "деканат"@ru ;
@@ -7223,13 +7238,13 @@ ontohgis:administrative_type_165 rdf:type owl:Class ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "namiestnictwo"@pl ,
                                                                                    "protopopia"@pl ;
                                  ontohgis:hasExternalIdentifier 165 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_166
 ontohgis:administrative_type_166 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_159 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  rdfs:label "general governorship (Greek Catholic Church)"@en ,
                                             "namiestnictwo generalne (Kościół katolicki ob. greckiego)"@pl ,
                                             "генеральное наместничество"@ru ;
@@ -7237,13 +7252,13 @@ ontohgis:administrative_type_166 rdf:type owl:Class ;
                                                                                    "kryłos"@pl ,
                                                                                    "oficjalat"@pl ;
                                  ontohgis:hasExternalIdentifier 166 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_240 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_167
 ontohgis:administrative_type_167 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_159 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  rdfs:label "kliros (Greek Catholic Church)"@en ,
                                             "kryłos (Kościół katolicki ob. greckiego)"@pl ,
                                             "клирос"@ru ,
@@ -7252,13 +7267,13 @@ ontohgis:administrative_type_167 rdf:type owl:Class ;
                                                                                    "namiestnictwo generalne"@pl ,
                                                                                    "oficjalat"@pl ;
                                  ontohgis:hasExternalIdentifier 167 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_240 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_168
 ontohgis:administrative_type_168 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_159 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  rdfs:label "officialate (Greek Catholic Church)"@en ,
                                             "oficjalat (Kościół katolicki ob. greckiego)"@pl ,
                                             "официалат"@ru ;
@@ -7266,6 +7281,7 @@ ontohgis:administrative_type_168 rdf:type owl:Class ;
                                                                                    "kryłos"@pl ,
                                                                                    "namiestnictwo generalne"@pl ;
                                  ontohgis:hasExternalIdentifier 168 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_27 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_240 .
 
 
@@ -7276,7 +7292,6 @@ ontohgis:administrative_type_169 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_170
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_28 ;
                                  rdfs:label "Pfarre"@de ,
                                             "parafia (Kościół prawosławny)"@pl ,
                                             "парафия"@ru ,
@@ -7287,6 +7302,7 @@ ontohgis:administrative_type_169 rdf:type owl:Class ;
                                               <https://www.wikidata.org/wiki/Q102496> ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "community"@en ;
                                  ontohgis:hasExternalIdentifier 169 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_28 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_210 .
 
 
@@ -7297,10 +7313,10 @@ ontohgis:administrative_type_170 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_171
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_28 ;
                                  rdfs:label "protopopia-namiestnictwo-okręg (Kościół prawosławny)"@pl ;
                                  rdfs:seeAlso "protopopy-governorship-deanery (Orthodox Church)"@en ;
                                  ontohgis:hasExternalIdentifier 170 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_28 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
@@ -7311,7 +7327,6 @@ ontohgis:administrative_type_171 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_172
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_28 ;
                                  rdfs:label "eparchia (Kościół prawosławny)"@pl ,
                                             "eparchy (Orthodox Church)"@en ,
                                             "епархия"@ru ;
@@ -7322,6 +7337,7 @@ ontohgis:administrative_type_171 rdf:type owl:Class ;
                                                                                 "diocese"@en ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "biskupstwo"@pl ;
                                  ontohgis:hasExternalIdentifier 171 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_28 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_200 .
 
 
@@ -7332,7 +7348,6 @@ ontohgis:administrative_type_172 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_173
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_28 ;
                                  rdfs:label "metropolia (Kościół prawosławny)"@pl ,
                                             "metropoly (Orthodox Church)"@en ,
                                             "митрополия"@ru ;
@@ -7342,13 +7357,13 @@ ontohgis:administrative_type_172 rdf:type owl:Class ;
                                                                                 "metropolis"@en ,
                                                                                 "prowincja kościelna"@pl ;
                                  ontohgis:hasExternalIdentifier 172 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_28 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_220 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_173
 ontohgis:administrative_type_173 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3012 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_28 ;
                                  rdfs:label "patriarchat (Kościół prawosławny)"@pl ,
                                             "patriarchate (Orthodox Church)"@en ,
                                             "патриархат"@ru ;
@@ -7356,13 +7371,13 @@ ontohgis:administrative_type_173 rdf:type owl:Class ;
                                               <https://www.wikidata.org/wiki/Q1282276> ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "patriarchy"@en ;
                                  ontohgis:hasExternalIdentifier 173 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_28 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_280 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_174
 ontohgis:administrative_type_174 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_170 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_28 ;
                                  rdfs:label "protopopia (Kościół prawosławny)"@pl ,
                                             "protopopy (Orthodox Church)"@en ,
                                             "протопопия"@ru ;
@@ -7372,13 +7387,13 @@ ontohgis:administrative_type_174 rdf:type owl:Class ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "namiestnictwo"@pl ,
                                                                                    "okręg"@pl ;
                                  ontohgis:hasExternalIdentifier 174 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_28 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_175
 ontohgis:administrative_type_175 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_170 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_28 ;
                                  rdfs:label "governorship (Orthodox Church)"@en ,
                                             "namiestnictwo (Kościół prawosławny)"@pl ,
                                             "наместничество"@ru ;
@@ -7386,13 +7401,13 @@ ontohgis:administrative_type_175 rdf:type owl:Class ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "okręg"@pl ,
                                                                                    "protopopia"@pl ;
                                  ontohgis:hasExternalIdentifier 175 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_28 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_176
 ontohgis:administrative_type_176 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_170 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_28 ;
                                  rdfs:label "okręg (Kościół prawosławny)"@pl ,
                                             "благочиние"@ru ;
                                  rdfs:seeAlso <http://dbpedia.org/page/Deanery> ,
@@ -7402,6 +7417,7 @@ ontohgis:administrative_type_176 rdf:type owl:Class ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "namiestnictwo"@pl ,
                                                                                    "protopopia"@pl ;
                                  ontohgis:hasExternalIdentifier 176 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_28 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
@@ -7412,7 +7428,6 @@ ontohgis:administrative_type_177 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_178
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_29 ;
                                  rdfs:label "Pfarre"@de ,
                                             "parafia (Kościół ewangelicko-augsburski w Rzeczypospolitej Obojga Narodów)"@pl ,
                                             "parish (Evangelical Augsburg Church in the Polish-Lithuanian Commonwealth)"@en ;
@@ -7425,6 +7440,7 @@ ontohgis:administrative_type_177 rdf:type owl:Class ;
                                                                                 "gmina"@pl ,
                                                                                 "zbór"@pl ;
                                  ontohgis:hasExternalIdentifier 177 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_29 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_210 .
 
 
@@ -7435,7 +7451,6 @@ ontohgis:administrative_type_178 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_179
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_29 ;
                                  rdfs:label "Distrikt"@de ,
                                             "Superintendentur"@de ,
                                             "district (Evangelical Augsburg Church in the Polish-Lithuanian Commonwealth)"@en ,
@@ -7444,13 +7459,13 @@ ontohgis:administrative_type_178 rdf:type owl:Class ;
                                                                                 "seniorat okręgowy"@pl ,
                                                                                 "superintendentura"@pl ;
                                  ontohgis:hasExternalIdentifier 178 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_29 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_179
 ontohgis:administrative_type_179 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3012 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_29 ;
                                  rdfs:label "Kirchenverband"@de ,
                                             "Union (Evangelical Augsburg Church in the Polish-Lithuanian Commonwealth)"@en ,
                                             "jednota (Kościół ewangelicko-augsburski w Rzeczypospolitej Obojga Narodów)"@pl ;
@@ -7458,6 +7473,7 @@ ontohgis:administrative_type_179 rdf:type owl:Class ;
                                                                                 "superintendentura generalna"@pl ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "konsystorz"@pl ;
                                  ontohgis:hasExternalIdentifier 179 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_29 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_200 .
 
 
@@ -7468,7 +7484,6 @@ ontohgis:administrative_type_180 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_181
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_30 ;
                                  rdfs:label "Pfarre"@de ,
                                             "parafia (Jednota Braci Czeskich w Polsce)"@pl ,
                                             "parish (Unity of Brethren in Poland)"@en ;
@@ -7481,6 +7496,7 @@ ontohgis:administrative_type_180 rdf:type owl:Class ;
                                                                                 "gmina"@pl ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "zbór"@pl ;
                                  ontohgis:hasExternalIdentifier 180 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_30 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_210 .
 
 
@@ -7491,7 +7507,6 @@ ontohgis:administrative_type_181 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_182
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_30 ;
                                  rdfs:label "Distrikt"@de ,
                                             "district (Unity of Brethren in Poland)"@en ,
                                             "dystrykt (Jednota Braci Czeskich w Polsce)"@pl ;
@@ -7500,13 +7515,13 @@ ontohgis:administrative_type_181 rdf:type owl:Class ;
                                                                                    "seniorat okręgowy"@pl ,
                                                                                    "superintendentura"@pl ;
                                  ontohgis:hasExternalIdentifier 181 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_30 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_182
 ontohgis:administrative_type_182 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3012 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_30 ;
                                  rdfs:label "Kirchenverband"@de ,
                                             "Union (Unity of Brethren in Poland)"@en ,
                                             "jednota (Jednota Braci Czeskich w Polsce)"@pl ;
@@ -7517,6 +7532,7 @@ ontohgis:administrative_type_182 rdf:type owl:Class ;
                                                                                    "seniorat generalny"@pl ,
                                                                                    "superintendentura generalna"@pl ;
                                  ontohgis:hasExternalIdentifier 182 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_30 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_200 .
 
 
@@ -7527,7 +7543,6 @@ ontohgis:administrative_type_183 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_184
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_31 ;
                                  rdfs:label "Pfarre"@de ,
                                             "parafia (Kościół kalwiński w Rzeczypospolitej Obojga Narodów)"@pl ,
                                             "parish (Calvinist Church in the Polish-Lithuanian Commonwealth)"@en ;
@@ -7540,6 +7555,7 @@ ontohgis:administrative_type_183 rdf:type owl:Class ;
                                                                                 "gmina"@pl ,
                                                                                 "zbór"@pl ;
                                  ontohgis:hasExternalIdentifier 183 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_31 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_210 .
 
 
@@ -7551,7 +7567,6 @@ ontohgis:administrative_type_184 rdf:type owl:Class ;
                                                    owl:someValuesFrom ontohgis:administrative_type_185
                                                  ] ;
                                  rdfs:comment "podział na dystrykty w Jednocie Małopolskiej został zniesiony w 1692 r."@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_31 ;
                                  rdfs:label "Distrikt"@de ,
                                             "district (Calvinist Church in the Polish-Lithuanian Commonwealth)"@en ,
                                             "dystrykt (Kościół kalwiński w Rzeczypospolitej Obojga Narodów)"@pl ;
@@ -7560,13 +7575,13 @@ ontohgis:administrative_type_184 rdf:type owl:Class ;
                                                                                 "seniorat okręgowy"@pl ,
                                                                                 "superintendentura"@pl ;
                                  ontohgis:hasExternalIdentifier 184 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_31 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_185
 ontohgis:administrative_type_185 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3012 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_31 ;
                                  rdfs:label "Kirchenverband"@de ,
                                             "Union (Calvinist Church in the Polish-Lithuanian Commonwealth)"@en ,
                                             "jednota (Kościół kalwiński w Rzeczypospolitej Obojga Narodów)"@pl ;
@@ -7574,6 +7589,7 @@ ontohgis:administrative_type_185 rdf:type owl:Class ;
                                                                                 "superintendentura generalna"@pl ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "konsystorz"@pl ;
                                  ontohgis:hasExternalIdentifier 185 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_31 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_200 .
 
 
@@ -7584,7 +7600,6 @@ ontohgis:administrative_type_186 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_187
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_32 ;
                                  rdfs:label "Pfarre"@de ,
                                             "parafia (Kościół ewangelicko-augsburski w Prusach 1525-1817)"@pl ,
                                             "parish (Evangelical Augsburg Church in Prussia 1525-1817)"@en ;
@@ -7598,6 +7613,7 @@ ontohgis:administrative_type_186 rdf:type owl:Class ;
                                                                                 "gmina"@pl ,
                                                                                 "zbór"@pl ;
                                  ontohgis:hasExternalIdentifier 186 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_32 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_210 .
 
 
@@ -7608,7 +7624,6 @@ ontohgis:administrative_type_187 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_188
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_32 ;
                                  rdfs:label "Seniorat (Evangelical Augsburg Church in Prussia 1525-1817)"@en ,
                                             "seniorat"@en ,
                                             "seniorat (Kościół ewangelicko-augsburski w Prusach 1525-1817)"@pl ;
@@ -7617,6 +7632,7 @@ ontohgis:administrative_type_187 rdf:type owl:Class ;
                                               <https://www.wikidata.org/wiki/Q897303> ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "Lutheran Church district"@en ;
                                  ontohgis:hasExternalIdentifier 187 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_32 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_270 .
 
 
@@ -7627,11 +7643,11 @@ ontohgis:administrative_type_188 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_189
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_32 ;
                                  rdfs:label "Inspektion-Superintendentur-Praepositur"@de ,
                                             "inspection-superintendency-provostry (Evangelical Augsburg Church in Prussia 1525-1817)"@en ,
                                             "inspekcja-superintendentura-prepozytura (Kościół ewangelicko-augsburski w Prusach 1525-1817)"@pl ;
                                  ontohgis:hasExternalIdentifier 188 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_32 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
@@ -7642,7 +7658,6 @@ ontohgis:administrative_type_189 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_190
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_32 ;
                                  rdfs:label "Konsistorium"@de ,
                                             "consistory (Evangelical Augsburg Church in Prussia 1525-1817)"@en ,
                                             "konsystorz prowincjonalny (Kościół ewangelicko-augsburski w Prusach 1525-1817)"@pl ;
@@ -7652,13 +7667,13 @@ ontohgis:administrative_type_189 rdf:type owl:Class ;
                                               <https://www.wikidata.org/wiki/Q5532221> ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "General Superintendentur"@de ;
                                  ontohgis:hasExternalIdentifier 189 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_32 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_200 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_190
 ontohgis:administrative_type_190 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3012 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_32 ;
                                  rdfs:label "Oberkonsistorium"@de ,
                                             "general consistory (Evangelical Augsburg Church in Prussia 1525-1817)"@en ,
                                             "konsystorz generalny (Kościół ewangelicko-augsburski w Prusach 1525-1817)"@pl ;
@@ -7666,13 +7681,13 @@ ontohgis:administrative_type_190 rdf:type owl:Class ;
                                               <https://www.wikidata.org/wiki/Q1381335> ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "nadkonsystorz"@pl ;
                                  ontohgis:hasExternalIdentifier 190 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_32 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_220 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_191
 ontohgis:administrative_type_191 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_188 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_32 ;
                                  rdfs:label "Inspektion"@de ,
                                             "inspection (Evangelical Augsburg Church in Prussia 1525-1817)"@en ,
                                             "inspekcja (Kościół ewangelicko-augsburski w Prusach 1525-1817)"@pl ;
@@ -7681,13 +7696,13 @@ ontohgis:administrative_type_191 rdf:type owl:Class ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "prepozytura"@pl ,
                                                                                    "superintendentura"@pl ;
                                  ontohgis:hasExternalIdentifier 191 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_32 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_192
 ontohgis:administrative_type_192 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_188 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_32 ;
                                  rdfs:label "Superintendentur"@de ,
                                             "superintendency (Evangelical Augsburg Church in Prussia 1525-1817)"@en ,
                                             "superintendentura (Kościół ewangelicko-augsburski w Prusach 1525-1817)"@pl ;
@@ -7697,13 +7712,13 @@ ontohgis:administrative_type_192 rdf:type owl:Class ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "inspekcja"@pl ,
                                                                                    "prepozytura"@pl ;
                                  ontohgis:hasExternalIdentifier 192 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_32 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_193
 ontohgis:administrative_type_193 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_188 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_32 ;
                                  rdfs:label "Praepositur"@de ,
                                             "prepozytura (Kościół ewangelicko-augsburski w Prusach 1525-1817)"@pl ,
                                             "provostry (Evangelical Augsburg Church in Prussia 1525-1817)"@en ;
@@ -7713,6 +7728,7 @@ ontohgis:administrative_type_193 rdf:type owl:Class ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "inspekcja"@pl ,
                                                                                    "superintendentura"@pl ;
                                  ontohgis:hasExternalIdentifier 193 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_32 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
@@ -7723,7 +7739,6 @@ ontohgis:administrative_type_194 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_195
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_33 ;
                                  rdfs:label "Pfarre"@de ,
                                             "parafia (Kościół ewangelicko-reformowany w Prusach 1713-1817)"@pl ,
                                             "parish (Evangelical Reformed Church in Prussia 1713-1817)"@en ;
@@ -7736,6 +7751,7 @@ ontohgis:administrative_type_194 rdf:type owl:Class ;
                                                                                 "gmina"@pl ,
                                                                                 "zbór"@pl ;
                                  ontohgis:hasExternalIdentifier 194 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_33 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_210 .
 
 
@@ -7746,7 +7762,6 @@ ontohgis:administrative_type_195 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_196
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_33 ;
                                  rdfs:label "Inspektion"@de ,
                                             "inspection (Evangelical Reformed Church in Prussia 1713-1817)"@en ,
                                             "inspekcja (Kościół ewangelicko-reformowany w Prusach 1713-1817)"@pl ;
@@ -7756,13 +7771,13 @@ ontohgis:administrative_type_195 rdf:type owl:Class ;
                                                                                 "Superintendentur"@de ,
                                                                                 "superintendency"@en ;
                                  ontohgis:hasExternalIdentifier 195 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_33 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_196
 ontohgis:administrative_type_196 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3012 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_33 ;
                                  rdfs:label "Oberkonsistorium"@de ,
                                             "general consistory (Evangelical Reformed Church in Prussia 1713-1817)"@en ,
                                             "konsystorz generalny (Kościół ewangelicko-reformowany w Prusach 1713-1817)"@pl ;
@@ -7772,6 +7787,7 @@ ontohgis:administrative_type_196 rdf:type owl:Class ;
                                                                                 "Kirchendirectorium"@de ,
                                                                                 "nadkonsystorz"@pl ;
                                  ontohgis:hasExternalIdentifier 196 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_33 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_220 .
 
 
@@ -7782,7 +7798,6 @@ ontohgis:administrative_type_197 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_198
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_34 ;
                                  rdfs:label "Pfarre"@de ,
                                             "parafia (Kościół ewangelicki w Prusach 1817-1939)"@pl ,
                                             "parish (Evangelical Church in Prussia 1817-1939)"@en ;
@@ -7796,6 +7811,7 @@ ontohgis:administrative_type_197 rdf:type owl:Class ;
                                                                                 "gmina"@pl ,
                                                                                 "zbór"@pl ;
                                  ontohgis:hasExternalIdentifier 197 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_34 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_210 .
 
 
@@ -7807,7 +7823,6 @@ ontohgis:administrative_type_198 rdf:type owl:Class ;
                                                    owl:someValuesFrom ontohgis:administrative_type_199
                                                  ] ;
                                  rdfs:comment "typ wprowadzony ze względu na podział niechtórych okręgów kościelnych (Kirchenkreis), np.  Tilsit-Ragnit, na dwa \"Superintendenturbezirke\" w 1937 r."@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_34 ;
                                  rdfs:label "Superintendentur"@de ,
                                             "superintendency (Evangelical Church in Prussia 1817-1939)"@en ,
                                             "superintendentura (Kościół ewangelicki w Prusach 1817-1939)"@pl ;
@@ -7816,6 +7831,7 @@ ontohgis:administrative_type_198 rdf:type owl:Class ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "Diözese"@de ,
                                                                                 "diocese"@en ;
                                  ontohgis:hasExternalIdentifier 198 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_34 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_270 .
 
 
@@ -7828,7 +7844,6 @@ ontohgis:administrative_type_199 rdf:type owl:Class ;
                                                  ] ;
                                  rdfs:comment "s. 369: Die ältere Theilung des Herzgothums, dann Königsreichs Preussen in geistlichen Inspectionen erlitt schon vor der neuen Kreiseintheilung -- eingerichtet werden"@de ,
                                               "s. XXVI: In Folge der Kreiseintheilung von 1816 wurde auch die Sprengel der Superintendenturen mehr nach den Kreisgrenzen festgesetz und zwar --."@de ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_34 ;
                                  rdfs:label <http://dbpedia.org/page/Superintendent_(ecclesiastical)> ,
                                             <https://de.wikipedia.org/wiki/Kirchenkreis> ,
                                             "Kirchenkreis"@de ,
@@ -7842,6 +7857,7 @@ ontohgis:administrative_type_199 rdf:type owl:Class ;
                                                                                 "inspection"@en ,
                                                                                 "superintendency"@en ;
                                  ontohgis:hasExternalIdentifier 199 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_34 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 [ rdf:type owl:Axiom ;
@@ -7863,10 +7879,10 @@ ontohgis:administrative_type_199 rdf:type owl:Class ;
 ontohgis:administrative_type_2 rdf:type owl:Class ;
                                rdfs:subClassOf ontohgis:administrative_type_9 ;
                                rdfs:comment "Zgodnie z treścią konstytucji marcowej (1921) \"Dla celów administracyjnych Państwo Polskie podzielone będzie w drodze ustawodawczej na województwa, powiaty i gminy miejskie i wiejskie, które będą równocześnie jednostkami samorządu terytorjalnego\". Faktycznie cały okres międzywojenny charakteryzuje proces unifikacji terytorialnej administracji ogólnej, której celem jest likwidacja różnic między byłymi zaborami. Ostatnim ważnym aktem była likwidacja obszarów dworskich na terenie woj. poznańskiego oraz pomorskiego na mocy tzw. ustawy scaleniowej z 1933 r."@pl ;
-                               ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                rdfs:label "gmina miejska"@pl ,
                                           "town commune"@en ;
                                ontohgis:hasExternalIdentifier 2 ;
+                               ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
@@ -7879,7 +7895,6 @@ ontohgis:administrative_type_200 rdf:type owl:Class ;
                                                  ] ;
                                  rdfs:comment "s. 114: urząd generalnego superintendenta równoważny z sakrą biskupią"@pl ,
                                               "s. 45-46: w latach 1776-1793 rozwiązano konsystorze i nadzór przejęły urzędy rejencyjne, powrót do konsystorzy nastąpił w 1815 r., zakres działań konsystorzy był bardzo ograniczony a rolę zarządzającą pełniły urzędy rejencyjne; s. 47: konsystorz był na poziomie prowincji a więc nad rejencją, np. urzędnicy konsystorza w Poznaniu ściśle współpracowali z rejencją poznańską ale już z bydgoską nie"@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_34 ;
                                  rdfs:label "Kirchenprovinz"@de ,
                                             "ecclesiastical province (Evangelical Church in Prussia 1817-1939)"@en ,
                                             "prowincja kościelna (Kościół ewangelicki w Prusach 1817-1939)"@pl ;
@@ -7896,6 +7911,7 @@ ontohgis:administrative_type_200 rdf:type owl:Class ;
                                                                                 "diocese"@en ,
                                                                                 "konsystorz prowincjonalny"@pl ;
                                  ontohgis:hasExternalIdentifier 200 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_34 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_200 .
 
 [ rdf:type owl:Axiom ;
@@ -7920,7 +7936,6 @@ ontohgis:administrative_type_201 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_202
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_34 ;
                                  rdfs:label "Landeskirche"@de ,
                                             "kościół krajowy (Kościół ewangelicki w Prusach 1817-1939)"@pl ,
                                             "state church (Evangelical Church in Prussia 1817-1939)"@en ;
@@ -7929,19 +7944,20 @@ ontohgis:administrative_type_201 rdf:type owl:Class ;
                                               <https://www.wikidata.org/wiki/Q565744> ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "national church"@en ;
                                  ontohgis:hasExternalIdentifier 201 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_34 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_220 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_202
 ontohgis:administrative_type_202 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3012 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_34 ;
                                  rdfs:label "Kirchenbund"@de ,
                                             "federation (Evangelical Church in Prussia 1817-1939)"@en ,
                                             "konfederacja (Kościół ewangelicki w Prusach 1817-1939)"@pl ;
                                  rdfs:seeAlso <http://gov.genealogy.net/types.owl#210> ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "union"@en ;
                                  ontohgis:hasExternalIdentifier 202 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_34 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_290 .
 
 
@@ -7952,7 +7968,6 @@ ontohgis:administrative_type_203 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_204
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_35 ;
                                  rdfs:label "Pfarre"@de ,
                                             "parafia (Kościół ewangelicki w Królestwie Polskim 1828-1849)"@pl ,
                                             "parish (Evangelical Church in Kingdom of Poland 1828-1849)"@en ;
@@ -7966,6 +7981,7 @@ ontohgis:administrative_type_203 rdf:type owl:Class ;
                                                                                 "gmina"@pl ,
                                                                                 "zbór"@pl ;
                                  ontohgis:hasExternalIdentifier 203 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_35 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_210 .
 
 
@@ -7976,7 +7992,6 @@ ontohgis:administrative_type_204 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_205
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_35 ;
                                  rdfs:label "Diözese"@de ,
                                             "diecezja (Kościół ewangelicki w Królestwie Polskim 1828-1849)"@pl ,
                                             "diocese (Evangelical Church in Kingdom of Poland 1828-1849)"@en ;
@@ -7987,6 +8002,7 @@ ontohgis:administrative_type_204 rdf:type owl:Class ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "Superintendentur"@de ,
                                                                                 "superintendentura"@pl ;
                                  ontohgis:hasExternalIdentifier 204 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_35 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_200 .
 
 
@@ -7995,13 +8011,13 @@ ontohgis:administrative_type_205 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3012 ;
                                  rdfs:comment "s. 15: Warszawski Okręg Konsystorski nie został włączony do konsystorza generalnego w Petersburgu po 1832 roku, nie wykonano też żadnych ruchów w tym kiierunku po 1849 r. Wg. autora byłoby to korzystne i część duchownych to dostrzegała"@pl ,
                                               "s. 29: Komisja Rządowa Wyznań Religijnych i Oświecenia publicznego zlikwidowała istniejące luterańskie konsystorze departamentowe utworzone po 1807 r."@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_35 ;
                                  rdfs:label "General Konsistorium"@de ,
                                             "general consistory (Evangelical Church in Kingdom of Poland 1828-1849)"@en ,
                                             "konsystorz generalny (Kościół ewangelicki w Królestwie Polskim 1828-1849)"@pl ;
                                  rdfs:seeAlso <http://dbpedia.org/page/Consistory_(Protestantism)> ,
                                               <https://www.wikidata.org/wiki/Q1381335> ;
                                  ontohgis:hasExternalIdentifier 205 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_35 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_220 .
 
 [ rdf:type owl:Axiom ;
@@ -8026,7 +8042,6 @@ ontohgis:administrative_type_206 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_207
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_36 ;
                                  rdfs:label "Pfarre"@de ,
                                             "parafia (Kościół ewangelicko-augsburski w Polsce 1849-1939)"@pl ,
                                             "parish (Evangelical Augsburg Church in Poland 1849-1939)"@en ;
@@ -8040,6 +8055,7 @@ ontohgis:administrative_type_206 rdf:type owl:Class ;
                                                                                 "gmina"@pl ,
                                                                                 "zbór"@pl ;
                                  ontohgis:hasExternalIdentifier 206 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_36 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_210 .
 
 
@@ -8051,7 +8067,6 @@ ontohgis:administrative_type_207 rdf:type owl:Class ;
                                                    owl:someValuesFrom ontohgis:administrative_type_208
                                                  ] ;
                                  rdfs:comment "od 1936 diecezja, seniorzy diecezji, seniorat"@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_36 ;
                                  rdfs:label "Superintendentur"@de ,
                                             "superintendecy (Evangelical Augsburg Church in Poland 1849-1939)"@en ,
                                             "superintendentura (Kościół ewangelicko-augsburski w Polsce 1849-1939)"@pl ;
@@ -8063,6 +8078,7 @@ ontohgis:administrative_type_207 rdf:type owl:Class ;
                                                                                 "diocese"@en ,
                                                                                 "seniorat"@pl ;
                                  ontohgis:hasExternalIdentifier 207 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_36 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_200 .
 
 [ rdf:type owl:Axiom ;
@@ -8076,7 +8092,6 @@ ontohgis:administrative_type_207 rdf:type owl:Class ;
 ###  https://onto.kul.pl/ontohgis/administrative_type_208
 ontohgis:administrative_type_208 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3012 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_36 ;
                                  rdfs:label "Oberkonsistorium"@de ,
                                             "general consistory (Evangelical Augsburg Church in Poland 1849-1939)"@en ,
                                             "konsystorz generalny (Kościół ewangelicko-augsburski w Polsce 1849-1939)"@pl ;
@@ -8090,6 +8105,7 @@ ontohgis:administrative_type_208 rdf:type owl:Class ;
                                                                                 "nadkonsystorz"@de ,
                                                                                 "superintendency"@en ;
                                  ontohgis:hasExternalIdentifier 208 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_36 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_220 .
 
 [ rdf:type owl:Axiom ;
@@ -8114,7 +8130,6 @@ ontohgis:administrative_type_209 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_210
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_37 ;
                                  rdfs:label "Pfarre"@de ,
                                             "parafia (Kościół ewangelicko-reformowany w Polsce 1849-1939)"@pl ,
                                             "parish (Evangelical Reformed Church in Poland 1849-1939)"@en ;
@@ -8127,6 +8142,7 @@ ontohgis:administrative_type_209 rdf:type owl:Class ;
                                                                                 "gmina"@pl ,
                                                                                 "zbór"@pl ;
                                  ontohgis:hasExternalIdentifier 209 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_37 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_210 .
 
 
@@ -8137,19 +8153,18 @@ ontohgis:administrative_type_210 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_211
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_37 ;
                                  rdfs:label "superintendency (Evangelical Reformed Church in Poland 1849-1939)"@en ,
                                             "superintendentura (Kościół ewangelicko-reformowany w Polsce 1849-1939)"@pl ;
                                  rdfs:seeAlso <http://dbpedia.org/page/Superintendent_(ecclesiastical)> ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "okręg parafialny"@pl ;
                                  ontohgis:hasExternalIdentifier 210 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_37 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_200 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_211
 ontohgis:administrative_type_211 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3012 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_37 ;
                                  rdfs:label "general consistory (Evangelical Reformed Church in Poland 1849-1939)"@en ,
                                             "konsystorz generalny (Kościół ewangelicko-reformowany w Polsce 1849-1939)"@pl ;
                                  rdfs:seeAlso <http://dbpedia.org/page/Consistory_(Protestantism)> ,
@@ -8157,6 +8172,7 @@ ontohgis:administrative_type_211 rdf:type owl:Class ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "generalna superintendentura"@pl ,
                                                                                 "nadkonsystorz"@pl ;
                                  ontohgis:hasExternalIdentifier 211 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_37 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_220 .
 
 
@@ -8167,7 +8183,6 @@ ontohgis:administrative_type_212 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_213
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_38 ;
                                  rdfs:label "Gemeinde"@de ,
                                             "Kirchspiel"@de ,
                                             "Pastorat"@de ,
@@ -8176,6 +8191,7 @@ ontohgis:administrative_type_212 rdf:type owl:Class ;
                                             "parafia"@pl ,
                                             "zbór"@pl ;
                                  ontohgis:hasExternalIdentifier 212 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_38 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_210 .
 
 
@@ -8186,10 +8202,10 @@ ontohgis:administrative_type_213 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_214
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_38 ;
                                  rdfs:label "Seniorat"@de ,
                                             "seniorat (Kościół ewangelicki w Galicji 1781-1918)"@pl ;
                                  ontohgis:hasExternalIdentifier 213 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_38 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
@@ -8200,21 +8216,21 @@ ontohgis:administrative_type_214 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_215
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_38 ;
                                  rdfs:label "Superintendentur"@de ,
                                             "superintendentura (Kościół ewangelicki w Galicji 1781-1918)"@pl ;
                                  ontohgis:hasExternalIdentifier 214 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_38 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_200 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_215
 ontohgis:administrative_type_215 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3012 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_38 ;
                                  rdfs:label "General Superintendentur"@de ,
                                             "Konsistorium"@de ,
                                             "konsystorz (Kościół ewangelicki w Galicji 1781-1918)"@pl ;
                                  ontohgis:hasExternalIdentifier 215 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_38 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_220 .
 
 
@@ -8225,9 +8241,9 @@ ontohgis:administrative_type_216 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_217
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_39 ;
                                  rdfs:label "przykahałek (Żydzi w Rzeczypospolitej Obojga Narodów)"@pl ;
                                  ontohgis:hasExternalIdentifier 216 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_39 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_260 .
 
 
@@ -8238,10 +8254,10 @@ ontohgis:administrative_type_217 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_218
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_39 ;
                                  rdfs:label "gmina (Żydzi w Rzeczypospolitej Obojga Narodów)"@pl ,
                                             "kahał"@pl ;
                                  ontohgis:hasExternalIdentifier 217 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_39 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_210 .
 
 
@@ -8252,11 +8268,11 @@ ontohgis:administrative_type_218 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_219
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_39 ;
                                  rdfs:label "galil"@he ,
                                             "kahał okręgowy (Żydzi w Rzeczypospolitej Obojga Narodów)"@pl ,
                                             "podokręg"@pl ;
                                  ontohgis:hasExternalIdentifier 218 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_39 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_270 .
 
 
@@ -8267,11 +8283,11 @@ ontohgis:administrative_type_219 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_220
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_39 ;
                                  rdfs:label "galil"@he ,
                                             "kahał okręgowy (Żydzi w Rzeczypospolitej Obojga Narodów)"@pl ,
                                             "okręg"@pl ;
                                  ontohgis:hasExternalIdentifier 219 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_39 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_230 .
 
 
@@ -8282,7 +8298,6 @@ ontohgis:administrative_type_220 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_221
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_39 ;
                                  rdfs:label "kahał główny (Żydzi w Rzeczypospolitej Obojga Narodów)"@pl ,
                                             "kahał na prawach ziemstwa"@pl ,
                                             "kahał pryncypialny"@pl ,
@@ -8290,16 +8305,17 @@ ontohgis:administrative_type_220 rdf:type owl:Class ;
                                             "rosz ha-kehila"@he ,
                                             "ziemstwo"@pl ;
                                  ontohgis:hasExternalIdentifier 220 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_39 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_200 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_221
 ontohgis:administrative_type_221 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3012 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_39 ;
                                  rdfs:label "prowincja (Żydzi w Rzeczypospolitej Obojga Narodów)"@pl ,
                                             "waad"@he ;
                                  ontohgis:hasExternalIdentifier 221 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_39 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_220 .
 
 
@@ -8310,12 +8326,12 @@ ontohgis:administrative_type_222 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_223
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_40 ;
                                  rdfs:label "wolost (The Grand Duchy of Lithuania)"@en ,
                                             "wołość (Wielkie Księstwo Litewskie (1385-1569))"@pl ;
                                  rdfs:seeAlso "http://dbpedia.org/page/Volost" ,
                                               "https://www.wikidata.org/wiki/Q687121" ;
                                  ontohgis:hasExternalIdentifier 222 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_40 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_40 .
 
 
@@ -8326,33 +8342,33 @@ ontohgis:administrative_type_223 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_224
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_40 ;
                                  rdfs:label "land (The Grand Duchy of Lithuania)"@en ,
                                             "ziemia (Wielkie Księstwo Litewskie (1385-1569))"@pl ;
                                  ontohgis:hasExternalIdentifier 223 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_40 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_40 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_224
 ontohgis:administrative_type_224 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_40 ;
                                  rdfs:label "duchy (The Grand Duchy of Lithuania)"@en ,
                                             "księstwo (Wielkie Księstwo Litewskie (1385-1569))"@pl ;
                                  rdfs:seeAlso "http://gov.genealogy.net/types.owl#60" ,
                                               "https://www.wikidata.org/wiki/Q208500" ;
                                  ontohgis:hasExternalIdentifier 224 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_40 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_40 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_226
 ontohgis:administrative_type_226 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_12 ;
                                  rdfs:label "Kreis"@de ,
                                             "district (The Kingdom of Saxony (1815-1918))"@en ,
                                             "powiat (Królestwo Saksonii (1815-1918))"@pl ;
                                  ontohgis:hasExternalIdentifier 226 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_12 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_12 .
 
 
@@ -8363,12 +8379,12 @@ ontohgis:administrative_type_227 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_226
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_12 ;
                                  rdfs:label "Amt"@de ,
                                             "okręg (Królestwo Saksonii (1815-1918))"@pl ,
                                             "shire district (The Kingdom of Saxony (1815-1918))"@en ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "county"@en ;
                                  ontohgis:hasExternalIdentifier 227 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_12 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_12 .
 
 
@@ -8379,7 +8395,6 @@ ontohgis:administrative_type_228 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_227
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_12 ;
                                  rdfs:label "Gemeinde"@de ,
                                             "gmina (Królestwo Saksonii (1815-1918))"@pl ,
                                             "municipality (The Kingdom of Saxony (1815-1918))"@en ;
@@ -8388,6 +8403,7 @@ ontohgis:administrative_type_228 rdf:type owl:Class ;
                                               "https://www.wikidata.org/wiki/Q262166" ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "commume"@en ;
                                  ontohgis:hasExternalIdentifier 228 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_12 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_12 .
 
 
@@ -8398,10 +8414,10 @@ ontohgis:administrative_type_229 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_230
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_42 ;
                                  rdfs:label "commune (The Duchy of Warsaw (1807-1815))"@en ,
                                             "gmina (Księstwo Warszawskie (1807-1815))"@pl ;
                                  ontohgis:hasExternalIdentifier 229 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_42 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_42 .
 
 
@@ -8412,10 +8428,10 @@ ontohgis:administrative_type_230 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_231
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_42 ;
                                  rdfs:label "district (The Duchy of Warsaw (1807-1815))"@en ,
                                             "powiat (Księstwo Warszawskie (1807-1815))"@pl ;
                                  ontohgis:hasExternalIdentifier 230 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_42 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_42 .
 
 
@@ -8426,22 +8442,22 @@ ontohgis:administrative_type_231 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_232
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_42 ;
                                  rdfs:label "departament (Księstwo Warszawskie (1807-1815))"@pl ,
                                             "department (The Duchy of Warsaw (1807-1815))"@en ;
                                  ontohgis:hasExternalIdentifier 231 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_42 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_42 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_232
 ontohgis:administrative_type_232 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_42 ;
                                  rdfs:label "Duchy (The Duchy of Warsaw (1807-1815))"@en ,
                                             "księstwo (Księstwo Warszawskie (1807-1815))"@pl ;
                                  rdfs:seeAlso "http://gov.genealogy.net/types.owl#60" ,
                                               "https://www.wikidata.org/wiki/Q208500" ;
                                  ontohgis:hasExternalIdentifier 232 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_42 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_42 .
 
 
@@ -8449,10 +8465,10 @@ ontohgis:administrative_type_232 rdf:type owl:Class ;
 ontohgis:administrative_type_234 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_229 ;
                                  rdfs:comment "najniższa jednostka administracyjna, bez rozróżnienia na miejską i wiejską (niewprowadzone w życie) (M. Kallas, s. 212)"@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_42 ;
                                  rdfs:label "municipality (The Duchy of Warsaw (1807-1815))"@en ,
                                             "municypalność (Księstwo Warszawskie (1807-1815))"@pl ;
                                  ontohgis:hasExternalIdentifier 234 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_42 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_42 .
 
 
@@ -8460,10 +8476,10 @@ ontohgis:administrative_type_234 rdf:type owl:Class ;
 ontohgis:administrative_type_235 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_229 ;
                                  rdfs:comment "dekret królewski z 19.12.1807 (J. Goclon, s. 107)"@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_42 ;
                                  rdfs:label "communal assembly (The Duchy of Warsaw (1807-1815))"@en ,
                                             "zgromadzenie gminne (Księstwo Warszawskie (1807-1815))"@pl ;
                                  ontohgis:hasExternalIdentifier 235 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_42 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_42 .
 
 
@@ -8471,10 +8487,10 @@ ontohgis:administrative_type_235 rdf:type owl:Class ;
 ontohgis:administrative_type_236 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_229 ;
                                  rdfs:comment "od 23.02.1809 (M. Kallas, s. 212)"@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_42 ;
                                  rdfs:label "gmina wiejska (Księstwo Warszawskie (1807-1815))"@pl ,
                                             "rural commune (The Duchy of Warsaw (1807-1815))"@en ;
                                  ontohgis:hasExternalIdentifier 236 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_42 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_42 .
 
 
@@ -8482,19 +8498,19 @@ ontohgis:administrative_type_236 rdf:type owl:Class ;
 ontohgis:administrative_type_237 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_229 ;
                                  rdfs:comment "od 23.02.1809 (M. Kallas, s. 212)"@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_42 ;
                                  rdfs:label "gmina miejska (Księstwo Warszawskie (1807-1815))"@pl ,
                                             "town commune (The Duchy of Warsaw (1807-1815))"@en ;
                                  ontohgis:hasExternalIdentifier 237 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_42 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_42 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_239
 ontohgis:administrative_type_239 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_46 ;
                                  rdfs:label "metropolia (Kościół katolicki ob. ormiańskiego)"@pl ;
                                  ontohgis:hasExternalIdentifier 239 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_46 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_46 .
 
 
@@ -8505,7 +8521,6 @@ ontohgis:administrative_type_24 rdf:type owl:Class ;
                                                   owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                   owl:someValuesFrom ontohgis:administrative_type_25
                                                 ] ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 rdfs:label "Gemeinde"@de ,
                                            "commune (The Free State of Prussia)"@en ,
                                            "gmina (Wolne Państwo Prusy (1920-1945))"@pl ;
@@ -8513,6 +8528,7 @@ ontohgis:administrative_type_24 rdf:type owl:Class ;
                                              "http://gov.genealogy.net/types.owl#group_31" ,
                                              "https://www.wikidata.org/wiki/Q262166" ;
                                 ontohgis:hasExternalIdentifier 24 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
@@ -8523,9 +8539,9 @@ ontohgis:administrative_type_240 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_239
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_46 ;
                                  rdfs:label "diecezja (Kościół katolicki ob. ormiańskiego)"@pl ;
                                  ontohgis:hasExternalIdentifier 240 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_46 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_46 .
 
 
@@ -8536,9 +8552,9 @@ ontohgis:administrative_type_241 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_240
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_46 ;
                                  rdfs:label "parafia (Kościół katolicki ob. ormiańskiego)"@pl ;
                                  ontohgis:hasExternalIdentifier 241 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_46 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_46 .
 
 
@@ -8549,21 +8565,21 @@ ontohgis:administrative_type_242 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_243
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_43 ;
                                  rdfs:label "commune (Kingdom of Poland (1815-1837))"@en ,
                                             "gmina (Królestwo Polskie (1815-1836))"@pl ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "municipality"@en ;
                                  ontohgis:hasExternalIdentifier 242 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_43 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_43 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_243
 ontohgis:administrative_type_243 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_43 ;
                                  rdfs:label "district (Kingdom of Poland (1815-1837))"@en ,
                                             "powiat (Królestwo Polskie (1815-1836))"@pl ;
                                  ontohgis:hasExternalIdentifier 243 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_43 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_43 .
 
 
@@ -8574,10 +8590,10 @@ ontohgis:administrative_type_244 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_245
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_43 ;
                                  rdfs:label "district (Kingdom of Poland (1815-1837))"@en ,
                                             "obwód (Królestwo Polskie (1815-1836))"@pl ;
                                  ontohgis:hasExternalIdentifier 244 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_43 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_43 .
 
 
@@ -8589,43 +8605,43 @@ ontohgis:administrative_type_245 rdf:type owl:Class ;
                                                    owl:someValuesFrom ontohgis:administrative_type_246
                                                  ] ;
                                  rdfs:comment "W 1815 wprowadzono podział na województwa, który pokrywał się z Departamentami z Księstwa Warszawskiego (M. Kallas, s. 238). W 1837 na mocy ukazu carskiego wprowadzono gubernie w miejsce województw."@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_43 ;
                                  rdfs:label "voivodeship (Kingdom of Poland (1815-1837))"@en ,
                                             "województwo (Królestwo Polskie (1815-1836))"@pl ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "province"@en ;
                                  ontohgis:hasExternalIdentifier 245 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_43 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_43 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_246
 ontohgis:administrative_type_246 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_43 ;
                                  rdfs:label "kingdom (Kingdom of Poland (1815-1837))"@en ,
                                             "królestwo (Królestwo Polskie (1815-1836)) (Królestwo Polskie (1815-1836))"@pl ;
                                  rdfs:seeAlso "http://gov.genealogy.net/types.owl#group_26" ,
                                               "https://www.wikidata.org/wiki/Q417175" ;
                                  ontohgis:hasExternalIdentifier 246 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_43 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_43 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_247
 ontohgis:administrative_type_247 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_242 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_43 ;
                                  rdfs:label "gmina miejska (Królestwo Polskie (1815-1836))"@pl ,
                                             "town commune (Kingdom of Poland (1815-1837))"@en ;
                                  ontohgis:hasExternalIdentifier 247 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_43 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_43 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_248
 ontohgis:administrative_type_248 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_242 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_43 ;
                                  rdfs:label "gmina wiejska (Królestwo Polskie (1815-1836))"@pl ,
                                             "rural commune (Kingdom of Poland (1815-1837))"@en ;
                                  ontohgis:hasExternalIdentifier 248 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_43 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_43 .
 
 
@@ -8638,13 +8654,13 @@ ontohgis:administrative_type_25 rdf:type owl:Class ;
                                                 ] ;
                                 rdfs:comment """\"Od 1.01. 1873 z wyłączeniem Prowincji Poznańskiej.
 W Prowincji Poznańskiej w l 1818-1833 w okręgach wiejskich (Bezirke), łączących kilka gmin, władzę wójtowską sprawowali właściciele dóbr ziemskich. Od 1833 roku do 1918 pełnili te funkcje okręgowi komisarze policji.\""""@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 rdfs:label "Amtsbezirk"@de ,
                                            "bailiwick (The Free State of Prussia)"@en ,
                                            "wójtostwo (Wolne Państwo Prusy (1920-1945))"@pl ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "administrative district"@en ,
                                                                                "bailwick"@en ;
                                 ontohgis:hasExternalIdentifier 25 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_20 .
 
 
@@ -8655,31 +8671,31 @@ ontohgis:administrative_type_250 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_253
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_47 ;
                                  rdfs:label "commune (Congress Poland (1867-1918))"@en ,
                                             "gmina (Królestwo Polskie (1867-1918))"@pl ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "municipality"@en ;
                                  ontohgis:hasExternalIdentifier 250 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_47 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_47 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_251
 ontohgis:administrative_type_251 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_250 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_47 ;
                                  rdfs:label "gmina miejska (Królestwo Polskie (1867-1918))"@pl ,
                                             "town commune (Congress Poland (1867-1918))"@en ;
                                  ontohgis:hasExternalIdentifier 251 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_47 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_47 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_252
 ontohgis:administrative_type_252 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_250 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_47 ;
                                  rdfs:label "gmina wiejska (Królestwo Polskie (1867-1918))"@pl ,
                                             "rural commune (Congress Poland (1867-1918))"@en ;
                                  ontohgis:hasExternalIdentifier 252 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_47 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_47 .
 
 
@@ -8690,10 +8706,10 @@ ontohgis:administrative_type_253 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_254
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_47 ;
                                  rdfs:label "district (Congress Poland (1867-1918))"@en ,
                                             "powiat (Królestwo Polskie (1867-1918))"@pl ;
                                  ontohgis:hasExternalIdentifier 253 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_47 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_47 .
 
 
@@ -8704,17 +8720,16 @@ ontohgis:administrative_type_254 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_255
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_47 ;
                                  rdfs:label "gubernia (Królestwo Polskie (1867-1918))"@pl ,
                                             "province (Congress Poland (1867-1918))"@en ;
                                  ontohgis:hasExternalIdentifier 254 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_47 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_47 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_255
 ontohgis:administrative_type_255 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_47 ;
                                  rdfs:label "general-governorate (Congress Poland (1867-1918))"@en ,
                                             "generał-gubernatorstwo (Królestwo Polskie (1867-1918))"@pl ,
                                             "land"@en ;
@@ -8722,6 +8737,7 @@ ontohgis:administrative_type_255 rdf:type owl:Class ;
                                                                                 "kraj"@pl ,
                                                                                 "królestwo"@pl ;
                                  ontohgis:hasExternalIdentifier 255 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_47 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_47 .
 
 
@@ -8732,36 +8748,36 @@ ontohgis:administrative_type_257 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_261
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_5 ;
                                  rdfs:label "commune (The Free City of Danzig (1920-1939))"@en ,
                                             "gmina (Wolne Miasto Gdańsk (1920-1939))"@pl ;
                                  rdfs:seeAlso "http://dbpedia.org/page/Gemeinde" ,
                                               "http://gov.genealogy.net/types.owl#group_31" ,
                                               "https://www.wikidata.org/wiki/Q262166" ;
                                  ontohgis:hasExternalIdentifier 257 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_5 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_258
 ontohgis:administrative_type_258 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_257 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_5 ;
                                  rdfs:label "commune (The Free City of Danzig (1920-1939))"@en ,
                                             "gmina miejska (Wolne Miasto Gdańsk (1920-1939))"@pl ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "municipality"@en ,
                                                                                 "town"@en ;
                                  ontohgis:hasExternalIdentifier 258 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_5 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_259
 ontohgis:administrative_type_259 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_257 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_5 ;
                                  rdfs:label "gmina wiejska (Wolne Miasto Gdańsk (1920-1939))"@pl ,
                                             "rural commune (The Free City of Danzig (1920-1939))"@en ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "rural municipality"@en ;
                                  ontohgis:hasExternalIdentifier 259 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_5 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_5 .
 
 
@@ -8772,58 +8788,58 @@ ontohgis:administrative_type_26 rdf:type owl:Class ;
                                                   owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                   owl:someValuesFrom ontohgis:administrative_type_29
                                                 ] ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 rdfs:label "Kreis"@de ,
                                            "district (The Free State of Prussia)"@en ,
                                            "powiat (Wolne Państwo Prusy (1920-1945))"@pl ;
                                 rdfs:seeAlso "http://gov.genealogy.net/types.owl#32" ,
                                              "https://www.wikidata.org/wiki/Q106658" ;
                                 ontohgis:hasExternalIdentifier 26 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_260
 ontohgis:administrative_type_260 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_257 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_5 ;
                                  rdfs:label "manorial demesne (The Free City of Danzig (1920-1939))"@en ,
                                             "obszar dworski (Wolne Miasto Gdańsk (1920-1939))"@pl ;
                                  rdfs:seeAlso "http://gov.genealogy.net/types.owl#109" ,
                                               "https://www.wikidata.org/wiki/Q451019" ;
                                  ontohgis:hasExternalIdentifier 260 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_5 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_261
 ontohgis:administrative_type_261 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_5 ;
                                  rdfs:label "district (The Free City of Danzig (1920-1939))"@en ,
                                             "powiat (Wolne Miasto Gdańsk (1920-1939))"@pl ;
                                  rdfs:seeAlso "http://gov.genealogy.net/types.owl#32" ,
                                               "https://www.wikidata.org/wiki/Q106658" ;
                                  ontohgis:hasExternalIdentifier 261 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_5 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_262
 ontohgis:administrative_type_262 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_261 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_5 ;
                                  rdfs:label "powiat miejski (Wolne Miasto Gdańsk (1920-1939))"@pl ,
                                             "urban district (The Free City of Danzig (1920-1939))"@en ;
                                  rdfs:seeAlso "http://gov.genealogy.net/types.owl#32" ;
                                  ontohgis:hasExternalIdentifier 262 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_5 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_263
 ontohgis:administrative_type_263 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_261 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_5 ;
                                  rdfs:label "powiat wiejski (Wolne Miasto Gdańsk (1920-1939))"@pl ,
                                             "rural district (The Free City of Danzig (1920-1939))"@en ;
                                  ontohgis:hasExternalIdentifier 263 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_5 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_5 .
 
 
@@ -8834,10 +8850,10 @@ ontohgis:administrative_type_264 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_265
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_44 ;
                                  rdfs:label "district (The Kingdom of Poland (1370-1568))"@en ,
                                             "powiat (Królestwo Polskie (1370-1568))"@pl ;
                                  ontohgis:hasExternalIdentifier 264 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_44 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_44 .
 
 
@@ -8848,10 +8864,10 @@ ontohgis:administrative_type_265 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_266
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_44 ;
                                  rdfs:label "land (The Kingdom of Poland (1370-1568))"@en ,
                                             "ziemia (Królestwo Polskie (1370-1568))"@pl ;
                                  ontohgis:hasExternalIdentifier 265 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_44 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_44 .
 
 
@@ -8862,22 +8878,22 @@ ontohgis:administrative_type_266 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_267
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_44 ;
                                  rdfs:label "palatinate (The Kingdom of Poland (1370-1568))"@en ,
                                             "województwo (Królestwo Polskie (1370-1568))"@pl ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "county"@en ,
                                                                                 "province"@en ;
                                  ontohgis:hasExternalIdentifier 266 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_44 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_44 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_267
 ontohgis:administrative_type_267 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_44 ;
                                  rdfs:label "province (The Kingdom of Poland (1370-1568))"@en ,
                                             "prowincja (Królestwo Polskie (1370-1568))"@pl ;
                                  ontohgis:hasExternalIdentifier 267 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_44 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_44 .
 
 
@@ -8888,22 +8904,22 @@ ontohgis:administrative_type_269 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_270
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_45 ;
                                  rdfs:label "komornictwo (Prusy Książęce (1525-1701))"@pl ;
                                  ontohgis:hasExternalIdentifier 269 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_45 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_45 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_27
 ontohgis:administrative_type_27 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_26 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 rdfs:label "Landkreis"@de ,
                                            "powiat ziemski (Wolne Państwo Prusy (1920-1945))"@pl ,
                                            "rural district (The Free State of Prussia) (The Duchy of Prussia (1525-1701))"@en ;
                                 rdfs:seeAlso "http://gov.genealogy.net/types.owl#32" ,
                                              "https://www.wikidata.org/wiki/Q106658" ;
                                 ontohgis:hasExternalIdentifier 27 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -8916,12 +8932,12 @@ ontohgis:administrative_type_270 rdf:type owl:Class ;
                                                  ] ;
                                  rdfs:comment """\"Ujednolicone (po 1499) wcześniejsze komturstwa, prokuratorie, wójtostwa; na ich czele stali starostowie (na czele starostwa Szaki stał tradycyjnie wójt krajowy Sambii (Landvogt von Samland), a starosta
 Rybaków nosił tytuł wójta Sambii (Vogt von Samland). Niektóre starostwa dzieliły się na komornictwa: komornictwo Dolno w starostwie Przezmark, komornictwo Orzysz w starostwie Ryn, komornictwo Laptau (i inne) w starostwie Rybaki. Wg ustaleń J. Skibińskiego \"\"Najniższymi ogniwami pruskiej administracji terenowej w pierwszej połowie XVII wieku były komornictwa (urzędy kameralne), zwane w późniejszym okresie urzędami domenalnymi (Domänenämter)\"\". Starostwo Wystruć ze względu na dużą powierzchnię i brak wielkiej własności ziemskiej podzielono na 13 starostw sołtysich (Schulzenämter). Liczba starostw nie była stała: Jerzy Skibiński wylicza, że wg recesu sejmu krajowego z 1566 roku było ich łącznie 39, dane z diariuszy sejmowych z 1663 roku wskazują 47 starostw, na początku XVIII wieku z kolei doliczono się 45 starostw.\""""@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_45 ;
                                  rdfs:label "Hauptamt"@de ,
                                             "county (The Duchy of Prussia (1525-1701))"@en ,
                                             "starostwo (Prusy Książęce (1525-1701))"@pl ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "Amt"@de ;
                                  ontohgis:hasExternalIdentifier 270 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_45 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_45 .
 
 
@@ -8933,11 +8949,11 @@ ontohgis:administrative_type_271 rdf:type owl:Class ;
                                                    owl:someValuesFrom ontohgis:administrative_type_272
                                                  ] ;
                                  rdfs:comment "Sambia, Natangia, Górne Prusy; podział ten miał charakter głównie polityczny, związany z organizacją zjazdów okręgu i wysyłaniem poselstw"@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_45 ;
                                  rdfs:label "Kreis"@de ,
                                             "district (The Duchy of Prussia (1525-1701))"@en ,
                                             "okręg (Prusy Książęce (1525-1701))"@pl ;
                                  ontohgis:hasExternalIdentifier 271 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_45 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_45 .
 
 
@@ -8945,24 +8961,24 @@ ontohgis:administrative_type_271 rdf:type owl:Class ;
 ontohgis:administrative_type_272 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
                                  rdfs:comment "lenno do 1657 - traktaty welawsko-bydgoskie zrywały stosunki lenne między Koroną i Prusami Książęcymi"@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_45 ;
                                  rdfs:label "Herzogtum"@de ,
                                             "fiefdom (The Duchy of Prussia (1525-1701))"@en ,
                                             "księstwo lenne (Prusy Książęce (1525-1701))"@pl ;
                                  rdfs:seeAlso "http://gov.genealogy.net/types.owl#60" ,
                                               "https://www.wikidata.org/wiki/Q208500" ;
                                  ontohgis:hasExternalIdentifier 272 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_45 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_45 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_274
 ontohgis:administrative_type_274 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_16 ;
                                  rdfs:label "cyrkuł (Gubernium Morawsko-Śląskie (1783-1848))"@pl ,
                                             "tsyrkul (Provincial government of Moravian-Silesian Region (1783-1848))"@en ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "circle"@en ;
                                  ontohgis:hasExternalIdentifier 274 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_16 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_16 .
 
 
@@ -8973,7 +8989,6 @@ ontohgis:administrative_type_275 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_276
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_9 ;
                                  rdfs:label "commune (The Duchy of Upper and Lower Silesia (1849-1918))"@en ,
                                             "gmina (Księstwo Górnego i Dolnego Śląska (1849-1918))"@pl ;
                                  rdfs:seeAlso "http://dbpedia.org/page/Gemeinde" ,
@@ -8981,6 +8996,7 @@ ontohgis:administrative_type_275 rdf:type owl:Class ;
                                               "https://www.wikidata.org/wiki/Q262166" ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "municipality"@en ;
                                  ontohgis:hasExternalIdentifier 275 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_9 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_9 .
 
 
@@ -8991,10 +9007,10 @@ ontohgis:administrative_type_276 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_277
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_9 ;
                                  rdfs:label "district (The Duchy of Upper and Lower Silesia (1849-1918))"@en ,
                                             "powiat sądowy (Księstwo Górnego i Dolnego Śląska (1849-1918))"@pl ;
                                  ontohgis:hasExternalIdentifier 276 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_9 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_9 .
 
 
@@ -9003,20 +9019,20 @@ ontohgis:administrative_type_277 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
                                  rdfs:comment "chodzi o miasta, które wcześniej, jeszcze w XIX wieku, miały samorząd miejski; na interesującym nas obszarze było to Bielsko"@pl ,
                                               "it pertains to the towns, which previously, as early as the 19th c., had a town council. In the area in question such city was Bielsko"@en ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_9 ;
                                  rdfs:label "political district (The Duchy of Upper and Lower Silesia (1849-1918))"@en ,
                                             "powiat polityczny (Księstwo Górnego i Dolnego Śląska (1849-1918))"@pl ;
                                  ontohgis:hasExternalIdentifier 277 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_9 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_278
 ontohgis:administrative_type_278 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_22 ;
                                  rdfs:label "county (The Duchy of Siewierz (1443-1790))"@en ,
                                             "starostwo (Księstwo Siewierskie (1443-1790))"@pl ;
                                  ontohgis:hasExternalIdentifier 278 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_22 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:administrative_system_22 .
 
 
@@ -9028,10 +9044,10 @@ ontohgis:administrative_type_279 rdf:type owl:Class ;
                                                    owl:someValuesFrom ontohgis:administrative_type_283
                                                  ] ;
                                  rdfs:comment "Niekiedy jako najniższą jednostkę administracyjną o charakterze pomocniczym podaje się dominia (wiejskie) i magistraty (miejskie). Rozporządzenia z 1848 r. uznały urzędy dominialne za organa tymczasowe sprawujące władzę na koszt i w imieniu państwa a nie dziedzica. Zniesiono je w 1855 r. a ich terytoria podzielono na gminy wiejskie i obszary dworskie."@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  rdfs:label "commune (the Kingdom of Galicia and Lodomeria (1849-1866))"@en ,
                                             "gmina (Królestwo Galicji i Lodomerii (1849-1866))"@pl ;
                                  ontohgis:hasExternalIdentifier 279 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
@@ -9039,45 +9055,45 @@ ontohgis:administrative_type_279 rdf:type owl:Class ;
 ontohgis:administrative_type_28 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_26 ;
                                 rdfs:comment "Równorzędny z powiatem ziemskim ale nie dzielił się już na mniejsze wójtostwa"@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 rdfs:label "Stadtkreis"@de ,
                                            "powiat miejski (Wolne Państwo Prusy (1920-1945))"@pl ,
                                            "urban district (The Free State of Prussia)"@en ;
                                 rdfs:seeAlso "http://gov.genealogy.net/types.owl#32" ;
                                 ontohgis:hasExternalIdentifier 28 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_280
 ontohgis:administrative_type_280 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_279 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  rdfs:label "gmina wiejska (Królestwo Galicji i Lodomerii (1849-1866))"@pl ,
                                             "rural commune (the Kingdom of Galicia and Lodomeria (1849-1866))"@en ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "village comune"@en ;
                                  ontohgis:hasExternalIdentifier 280 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_281
 ontohgis:administrative_type_281 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_279 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  rdfs:label "gmina miejska (Królestwo Galicji i Lodomerii (1849-1866))"@pl ,
                                             "town commune (the Kingdom of Galicia and Lodomeria (1849-1866))"@en ;
                                  ontohgis:hasExternalIdentifier 281 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_282
 ontohgis:administrative_type_282 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_279 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  rdfs:label "manorial demesne (the Kingdom of Galicia and Lodomeria (1849-1866))"@en ,
                                             "obszar dworski (Królestwo Galicji i Lodomerii (1849-1866))"@pl ;
                                  rdfs:seeAlso "http://gov.genealogy.net/types.owl#109" ,
                                               "https://www.wikidata.org/wiki/Q451019" ;
                                  ontohgis:hasExternalIdentifier 282 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
@@ -9088,10 +9104,10 @@ ontohgis:administrative_type_283 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_284
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  rdfs:label "district (the Kingdom of Galicia and Lodomeria (1849-1866))"@en ,
                                             "powiat (Królestwo Galicji i Lodomerii (1849-1866))"@pl ;
                                  ontohgis:hasExternalIdentifier 283 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -9102,21 +9118,21 @@ ontohgis:administrative_type_284 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_287
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  rdfs:label "cyrkuł-stolica obszaru dworskiego (Królestwo Galicji i Lodomerii (1849-1866))"@pl ,
                                             "tsyrkul-provincial capital (the Kingdom of Galicia and Lodomeria (1849-1866))"@en ;
                                  ontohgis:hasExternalIdentifier 284 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_40 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_285
 ontohgis:administrative_type_285 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_284 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  rdfs:label "cyrkuł (Królestwo Galicji i Lodomerii (1849-1866))"@pl ,
                                             "tsyrkul (the Kingdom of Galicia and Lodomeria (1849-1866))"@en ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "circle"@en ;
                                  ontohgis:hasExternalIdentifier 285 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_40 .
 
 
@@ -9124,10 +9140,10 @@ ontohgis:administrative_type_285 rdf:type owl:Class ;
 ontohgis:administrative_type_286 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:administrative_type_284 ;
                                  rdfs:comment "Kraków i Lwów podlegały odpowiednio namiestnictwu we Lwowie i rządowi krajowemu w Krakowie"@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  rdfs:label "provincial capital (the Kingdom of Galicia and Lodomeria (1849-1866))"@en ,
                                             "stolica obszaru administracyjnego (Królestwo Galicji i Lodomerii (1849-1866))"@pl ;
                                  ontohgis:hasExternalIdentifier 286 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_40 .
 
 
@@ -9135,10 +9151,10 @@ ontohgis:administrative_type_286 rdf:type owl:Class ;
 ontohgis:administrative_type_287 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
                                  rdfs:comment "Galicja była początkowo, w latach 1850-1854 podzielona na 3 okręgi (Regierungsbezirke): Lwów, Kraków, Stanisławów. Następnie po 1854 r. na dwa: Lwów (Statthalterei) oraz Kraków (Landesregierung). Rząd krajowy w Krakowie został zniesiony w 1867 r."@pl ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  rdfs:label "obszar administracyjny (Królestwo Galicji i Lodomerii (1849-1866))"@pl ,
                                             "province (the Kingdom of Galicia and Lodomeria (1849-1866))"@en ;
                                  ontohgis:hasExternalIdentifier 287 ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_41 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
@@ -9151,7 +9167,6 @@ ontohgis:administrative_type_29 rdf:type owl:Class ;
                                                     ] ;
                                 rdfs:subClassOf ontohgis:object_3014 ;
                                 rdfs:comment "Utworzona w 1808 roku jako pierwszy stopień reform administracyjnych państwa wprowadzonych przez Steina i Hardenberga"@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 rdfs:label "Regierung"@de ,
                                            "district government (The Free State of Prussia)"@en ,
                                            "rejencja (Wolne Państwo Prusy (1920-1945))"@pl ;
@@ -9159,19 +9174,20 @@ ontohgis:administrative_type_29 rdf:type owl:Class ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "okręg rejencyjny"@pl ,
                                                                                "regencja"@pl ;
                                 ontohgis:hasExternalIdentifier 29 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_291
 ontohgis:administrative_type_291 rdf:type owl:Class ;
                                  rdfs:subClassOf ontohgis:object_3014 ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_48 ;
                                  rdfs:label "kraj (Republika Słowacka (1996-2020))"@pl ,
                                             "kraj (štátna správa)"@sk ,
                                             "region (Slovak Republic (1996-2020))"@en ;
                                  rdfs:seeAlso <https://www.wikidata.org/wiki/Q15057583> ;
                                  <http://www.w3.org/2004/02/skos/core#hiddenLabel> "województwo"@pl ;
                                  ontohgis:hasExternalIdentifier "291"@sk ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_48 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
@@ -9182,13 +9198,13 @@ ontohgis:administrative_type_292 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_291
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_48 ;
                                  rdfs:label "district (Slovak Republic (1996-2020))"@en ,
                                             "okres"@sk ,
                                             "okres (Republika Słowacka (1996-2020))"@pl ;
                                  rdfs:seeAlso <https://www.wikidata.org/wiki/Q2264478> ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "powiat"@pl ;
                                  ontohgis:hasExternalIdentifier "292"@sk ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_48 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -9199,7 +9215,6 @@ ontohgis:administrative_type_293 rdf:type owl:Class ;
                                                    owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                    owl:someValuesFrom ontohgis:administrative_type_292
                                                  ] ;
-                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_48 ;
                                  rdfs:label "obec (Republika Słowacka (1996-2020))"@pl ;
                                  rdfs:seeAlso <https://www.wikidata.org/wiki/Q2183520> ;
                                  <http://www.w3.org/2004/02/skos/core#altLabel> "commune (Slovak Republic (1996-2020))"@en ,
@@ -9207,6 +9222,7 @@ ontohgis:administrative_type_293 rdf:type owl:Class ;
                                                                                 "obec"@en ,
                                                                                 "obec"@sk ;
                                  ontohgis:hasExternalIdentifier "293"@en ;
+                                 ontohgis:isDefinedByIRI ontohgis:administrative_system_48 ;
                                  ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
@@ -9214,10 +9230,10 @@ ontohgis:administrative_type_293 rdf:type owl:Class ;
 ontohgis:administrative_type_3 rdf:type owl:Class ;
                                rdfs:subClassOf ontohgis:administrative_type_9 ;
                                rdfs:comment "Zgodnie z treścią konstytucji marcowej (1921) \"Dla celów administracyjnych Państwo Polskie podzielone będzie w drodze ustawodawczej na województwa, powiaty i gminy miejskie i wiejskie, które będą równocześnie jednostkami samorządu terytorjalnego\". Faktycznie cały okres międzywojenny charakteryzuje proces unifikacji terytorialnej administracji ogólnej, której celem jest likwidacja różnic między byłymi zaborami. Ostatnim ważnym aktem była likwidacja obszarów dworskich na terenie woj. poznańskiego oraz pomorskiego na mocy tzw. ustawy scaleniowej z 1933 r."@pl ;
-                               ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                rdfs:label "gmina wiejska "@pl ,
                                           "rural commune"@en ;
                                ontohgis:hasExternalIdentifier 3 ;
+                               ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
@@ -9226,22 +9242,22 @@ ontohgis:administrative_type_30 rdf:type owl:Class ;
                                 owl:equivalentClass ontohgis:administrative_type_43 ,
                                                     ontohgis:administrative_type_78 ;
                                 rdfs:subClassOf ontohgis:object_3014 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 rdfs:label "Provinz"@de ,
                                            "province (The Free State of Prussia)"@en ,
                                            "prowincja (Wolne Państwo Prusy (1920-1945))"@pl ;
                                 ontohgis:hasExternalIdentifier 30 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_4 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_60 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_34
 ontohgis:administrative_type_34 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_37 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 rdfs:label "Stadtgemeinde"@de ,
                                            "gmina miejska (Królestwo Prus (1806-1919))"@pl ,
                                            "town commune (The Kingdom of Prussia (1806-1919))"@en ;
                                 ontohgis:hasExternalIdentifier 34 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
@@ -9249,12 +9265,12 @@ ontohgis:administrative_type_34 rdf:type owl:Class ;
 ontohgis:administrative_type_35 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_37 ;
                                 rdfs:comment "1818: Edykt o urzędach sołtysów w gminach wiejskich i obszarach dworskich."@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 rdfs:label "Landgemeinde"@de ,
                                            "gmina wiejska (Królestwo Prus (1806-1919))"@pl ,
                                            "rural commune (The Kingdom of Prussia (1806-1919))"@en ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "village community"@en ;
                                 ontohgis:hasExternalIdentifier 35 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
@@ -9263,7 +9279,6 @@ ontohgis:administrative_type_36 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_37 ;
                                 rdfs:comment """1818: Edykt o urzędach sołtysów w gminach wiejskich i obszarach dworskich.
 31.12.1842: Terytorialne rozgraniczenie gmin wiejskich i obszarów dworskich w prowincjach wschodnich"""@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 rdfs:label "Gutsbezirk"@de ,
                                            "manorial demesne (The Kingdom of Prussia (1806-1919))"@en ,
                                            "obszar dworski (Królestwo Prus (1806-1919))"@pl ;
@@ -9272,6 +9287,7 @@ ontohgis:administrative_type_36 rdf:type owl:Class ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "independent estate"@en ,
                                                                                "manorial land"@en ;
                                 ontohgis:hasExternalIdentifier 36 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
@@ -9282,7 +9298,6 @@ ontohgis:administrative_type_37 rdf:type owl:Class ;
                                                   owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                   owl:someValuesFrom ontohgis:administrative_type_38
                                                 ] ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 rdfs:label "Gemeinde"@de ,
                                            "commune (The Kingdom of Prussia (1806-1919))"@en ,
                                            "gmina (Królestwo Prus (1806-1919))"@pl ;
@@ -9291,6 +9306,7 @@ ontohgis:administrative_type_37 rdf:type owl:Class ;
                                              "https://www.wikidata.org/wiki/Q262166" ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "municipality"@en ;
                                 ontohgis:hasExternalIdentifier 37 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
@@ -9303,12 +9319,12 @@ ontohgis:administrative_type_38 rdf:type owl:Class ;
                                                 ] ;
                                 rdfs:comment """Od 1.01. 1873 z wyłączeniem Prowincji Poznańskiej.
 W Prowincji Poznańskiej w l 1818-1833 w okręgach wiejskich (Bezirke), łączących kilka gmin, władzę wójtowską sprawowali właściciele dóbr ziemskich. Od 1833 roku do 1918 pełnili te funkcje okręgowi komisarze policji."""@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 rdfs:label "Amtsbezirk"@de ,
                                            "bailiwick (The Kingdom of Prussia (1806-1919))"@en ,
                                            "wójtostwo (Królestwo Prus (1806-1919))"@pl ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "communal union"@en ;
                                 ontohgis:hasExternalIdentifier 38 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_20 .
 
 
@@ -9319,7 +9335,6 @@ ontohgis:administrative_type_39 rdf:type owl:Class ;
                                                   owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                   owl:someValuesFrom ontohgis:administrative_type_42
                                                 ] ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 rdfs:label "Kreis"@de ,
                                            "district (The Kingdom of Prussia (1806-1919))"@en ,
                                            "powiat (Królestwo Prus (1806-1919))"@pl ;
@@ -9327,6 +9342,7 @@ ontohgis:administrative_type_39 rdf:type owl:Class ;
                                              "https://www.wikidata.org/wiki/Q106658" ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "county"@en ;
                                 ontohgis:hasExternalIdentifier 39 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -9334,25 +9350,25 @@ ontohgis:administrative_type_39 rdf:type owl:Class ;
 ontohgis:administrative_type_4 rdf:type owl:Class ;
                                rdfs:subClassOf ontohgis:administrative_type_9 ;
                                rdfs:comment "Obszary dworskie utrzymały się najdłużej na Śląsku oraz w województwach zachodnich, pomorskim i poznańskim, gdzie zostały zniesione na podstawie tzw. ustawy scaleniowej z 1933 r. oraz rozporządzeń wykonawczych z 1934 r."@pl ;
-                               ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                rdfs:label "manorial demesne"@en ,
                                           "obszar dworski"@pl ;
                                rdfs:seeAlso "http://gov.genealogy.net/types.owl#108" ,
                                             "https://www.wikidata.org/wiki/Q451019" ;
                                ontohgis:hasExternalIdentifier 4 ;
+                               ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_40
 ontohgis:administrative_type_40 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_39 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 rdfs:label "Landkreis"@de ,
                                            "powiat ziemski (Królestwo Prus (1806-1919))"@pl ,
                                            "rural district (The Kingdom of Prussia (1806-1919))"@en ;
                                 rdfs:seeAlso "http://gov.genealogy.net/types.owl#32" ,
                                              "https://www.wikidata.org/wiki/Q106658" ;
                                 ontohgis:hasExternalIdentifier 40 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -9360,12 +9376,12 @@ ontohgis:administrative_type_40 rdf:type owl:Class ;
 ontohgis:administrative_type_41 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_39 ;
                                 rdfs:comment "Równorzędny z powiatem ziemskim ale nie dzielił się już na mniejsze wójtostwa"@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 rdfs:label "Stadtkreis"@de ,
                                            "powiat miejski (Królestwo Prus (1806-1919))"@pl ,
                                            "urban district (The Kingdom of Prussia (1806-1919))"@en ;
                                 rdfs:seeAlso "http://gov.genealogy.net/types.owl#32" ;
                                 ontohgis:hasExternalIdentifier 41 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -9377,7 +9393,6 @@ ontohgis:administrative_type_42 rdf:type owl:Class ;
                                                     ] ;
                                 rdfs:subClassOf ontohgis:object_3014 ;
                                 rdfs:comment "Utworzona w 1808 roku jako pierwszy stopień reform administracyjnych państwa wprowadzonych przez Steina i Hardenberga"@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 rdfs:label "Regierungsbezirk"@de ,
                                            "district government (The Kingdom of Prussia (1806-1919))"@en ,
                                            "rejencja (Królestwo Prus (1806-1919))"@pl ;
@@ -9386,17 +9401,18 @@ ontohgis:administrative_type_42 rdf:type owl:Class ;
                                                                                "okręg rejencyjny"@pl ,
                                                                                "regencja"@pl ;
                                 ontohgis:hasExternalIdentifier 42 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_43
 ontohgis:administrative_type_43 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:object_3014 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 rdfs:label "Provinz"@de ,
                                            "province (The Kingdom of Prussia (1806-1919))"@en ,
                                            "prowincja (Królestwo Prus (1806-1919))"@pl ;
                                 ontohgis:hasExternalIdentifier 43 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_7 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_60 .
 
 
@@ -9407,7 +9423,6 @@ ontohgis:administrative_type_45 rdf:type owl:Class ;
                                                   owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                   owl:someValuesFrom ontohgis:administrative_type_46
                                                 ] ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_3 ;
                                 rdfs:label "commune (The Republic of Poland (1999-2016))"@en ,
                                            "gmina (Rzeczpospolita Polska (1999-2016))"@pl ;
                                 rdfs:seeAlso <http://dbpedia.org/page/Gmina> ,
@@ -9417,6 +9432,7 @@ ontohgis:administrative_type_45 rdf:type owl:Class ;
                                 <http://www.w3.org/2004/02/skos/core#hiddenLabel> "district"@en ,
                                                                                   "municipality"@en ;
                                 ontohgis:hasExternalIdentifier 45 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_3 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 [ rdf:type owl:Axiom ;
@@ -9435,7 +9451,6 @@ ontohgis:administrative_type_46 rdf:type owl:Class ;
                                                   owl:someValuesFrom ontohgis:administrative_type_47
                                                 ] ;
                                 rdfs:comment "Do kategorii powiatów należą też miasta na prawach powiatu (66)"@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_3 ;
                                 rdfs:label "district (The Republic of Poland (1999-2016))"@en ,
                                            "powiat (Rzeczpospolita Polska (1999-2016))"@pl ;
                                 rdfs:seeAlso <http://dbpedia.org/page/Powiat> ,
@@ -9445,19 +9460,20 @@ ontohgis:administrative_type_46 rdf:type owl:Class ;
                                              <https://pzgik.geoportal.gov.pl/ontologies/prng/wojewodztwo> ,
                                              <https://www.wikidata.org/wiki/Q247073> ;
                                 ontohgis:hasExternalIdentifier 46 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_3 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_47
 ontohgis:administrative_type_47 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:object_3014 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_3 ;
                                 rdfs:label "voivodship (The Republic of Poland (1999-2016))"@en ,
                                            "województwo (Rzeczpospolita Polska (1999-2016))"@pl ;
                                 rdfs:seeAlso <http://dbpedia.org/page/Voivodeships_of_Poland> ,
                                              <https://www.wikidata.org/wiki/Q150093> ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "province"@en ;
                                 ontohgis:hasExternalIdentifier 47 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_3 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
@@ -9470,7 +9486,6 @@ ontohgis:administrative_type_49 rdf:type owl:Class ;
                                                 ] ;
                                 rdfs:comment "Jednostka najniższego rzędu wprowadzona na skutek reformy włościańskiej w 1861 r."@pl ,
                                              "small rural district"@en ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_8 ;
                                 rdfs:label "gmina (Cesarstwo Rosyjskie (1775-1917))"@pl ,
                                            "volost (Russian Empire (1775-1917))"@en ,
                                            "волость"@ru ;
@@ -9478,19 +9493,20 @@ ontohgis:administrative_type_49 rdf:type owl:Class ;
                                              <http://gov.genealogy.net/types.owl#241> ,
                                              <https://www.wikidata.org/wiki/Q687121> ;
                                 ontohgis:hasExternalIdentifier 49 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_8 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_5
 ontohgis:administrative_type_5 rdf:type owl:Class ;
                                rdfs:subClassOf ontohgis:administrative_type_10 ;
-                               ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                rdfs:label "district"@en ,
                                           "powiat"@pl ;
                                rdfs:seeAlso "http://gov.genealogy.net/types.owl#32" ,
                                             "https://www.wikidata.org/wiki/Q247073" ;
                                <http://www.w3.org/2004/02/skos/core#altLabel> "county"@en ;
                                ontohgis:hasExternalIdentifier 5 ;
+                               ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -9502,7 +9518,6 @@ ontohgis:administrative_type_50 rdf:type owl:Class ;
                                                   owl:someValuesFrom ontohgis:administrative_type_51
                                                 ] ;
                                 rdfs:comment "Niekiedy zamiasto określenia powiat używano określenia okręg"@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_8 ;
                                 rdfs:label "powiat (Cesarstwo Rosyjskie (1775-1917))"@pl ,
                                            "uyezd (Russian Empire (1775-1917))"@en ,
                                            "округ"@ru ,
@@ -9511,6 +9526,7 @@ ontohgis:administrative_type_50 rdf:type owl:Class ;
                                              <http://gov.genealogy.net/types.owl#240> ,
                                              <https://www.wikidata.org/wiki/Q1364324> ;
                                 ontohgis:hasExternalIdentifier 50 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_8 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -9522,7 +9538,6 @@ ontohgis:administrative_type_51 rdf:type owl:Class ;
                                                   owl:someValuesFrom ontohgis:administrative_type_52
                                                 ] ;
                                 rdfs:comment "Obwody występowały jako jednostka pośrednia między namiestnictwem lub gubernią a powiatem w przypadku rozległych jednostek terytorialnych"@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_8 ;
                                 rdfs:label "oblast (Russian Empire (1775-1917))"@en ,
                                            "obwód (Cesarstwo Rosyjskie (1775-1917))"@pl ,
                                            "область"@ru ;
@@ -9532,6 +9547,7 @@ ontohgis:administrative_type_51 rdf:type owl:Class ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "county"@en ,
                                                                                "region"@en ;
                                 ontohgis:hasExternalIdentifier 51 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_8 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_40 .
 
 
@@ -9542,7 +9558,6 @@ ontohgis:administrative_type_52 rdf:type owl:Class ;
                                                   owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                   owl:someValuesFrom ontohgis:administrative_type_56
                                                 ] ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_8 ;
                                 rdfs:label "gubernia (Cesarstwo Rosyjskie (1775-1917))"@pl ,
                                            "guberniya (Russian Empire (1775-1917))"@en ,
                                            "губерния"@ru ;
@@ -9551,13 +9566,13 @@ ontohgis:administrative_type_52 rdf:type owl:Class ;
                                              <https://www.wikidata.org/wiki/Q86622> ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "governorate"@en ;
                                 ontohgis:hasExternalIdentifier 52 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_8 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_53
 ontohgis:administrative_type_53 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_52 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_8 ;
                                 rdfs:label "gubernia (Cesarstwo Rosyjskie (1775-1917))"@pl ,
                                            "guberniya (Russian Empire (1775-1917))"@en ,
                                            "губерния"@ru ;
@@ -9566,6 +9581,7 @@ ontohgis:administrative_type_53 rdf:type owl:Class ;
                                              <https://www.wikidata.org/wiki/Q86622> ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "governorate"@en ;
                                 ontohgis:hasExternalIdentifier 53 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_8 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
@@ -9573,7 +9589,6 @@ ontohgis:administrative_type_53 rdf:type owl:Class ;
 ontohgis:administrative_type_54 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_52 ;
                                 rdfs:comment "Obwody na prawach guberni"@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_8 ;
                                 rdfs:label "oblast (Russian Empire (1775-1917))"@en ,
                                            "obwód (Cesarstwo Rosyjskie (1775-1917))"@pl ,
                                            "область"@ru ;
@@ -9583,6 +9598,7 @@ ontohgis:administrative_type_54 rdf:type owl:Class ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "county"@en ,
                                                                                "region"@en ;
                                 ontohgis:hasExternalIdentifier 54 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_8 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
@@ -9590,7 +9606,6 @@ ontohgis:administrative_type_54 rdf:type owl:Class ;
 ontohgis:administrative_type_55 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_52 ;
                                 rdfs:comment "Nazwa jednostki administracyjnej odpowiadającej guberni, która funkcjonowała głównie w latach 1775-1796"@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_8 ;
                                 rdfs:label "namiestnictwo (Cesarstwo Rosyjskie (1775-1917))"@pl ,
                                            "vicegerency (Russian Empire (1775-1917))"@en ,
                                            "наместничество"@ru ;
@@ -9598,6 +9613,7 @@ ontohgis:administrative_type_55 rdf:type owl:Class ;
                                              <https://www.wikidata.org/wiki/Q4312761> ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "viceroyalty"@en ;
                                 ontohgis:hasExternalIdentifier 55 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_8 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
@@ -9605,13 +9621,13 @@ ontohgis:administrative_type_55 rdf:type owl:Class ;
 ontohgis:administrative_type_56 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:object_3014 ;
                                 rdfs:comment "Była to jednostka skupiająca kilka guberni. Poziom ten nie obejmował całego państwa, gdyż generalne gubernatorstwa były organizowane głównie na teranach przygranicznych; jednostką równoważną na tym poziomie było namiestnictwo kaukaskie"@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_8 ;
                                 rdfs:label "generalne gubernatorstwo (Cesarstwo Rosyjskie (1775-1917))"@pl ,
                                            "governorate-general (Russian Empire (1775-1917))"@en ,
                                            "генерал-губернаторство"@ru ;
                                 rdfs:seeAlso <http://dbpedia.org/page/Governorate-General_(Russian_Empire)> ,
                                              <https://www.wikidata.org/wiki/Q671370> ;
                                 ontohgis:hasExternalIdentifier 56 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_8 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_60 ,
                                                                ontohgis:map_symbol_70 .
 
@@ -9623,67 +9639,67 @@ ontohgis:administrative_type_59 rdf:type owl:Class ;
                                                   owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                   owl:someValuesFrom ontohgis:administrative_type_63
                                                 ] ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_10 ;
                                 rdfs:label "commune (The Kingdom of Galicia and Lodomeria (1867-1918))"@en ,
                                            "gmina (Królestwo Galicji i Lodomerii (1867-1918))"@pl ;
                                 rdfs:seeAlso "http://dbpedia.org/page/Gemeinde" ,
                                              "http://gov.genealogy.net/types.owl#group_31" ,
                                              "https://www.wikidata.org/wiki/Q262166" ;
                                 ontohgis:hasExternalIdentifier 59 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_10 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_6
 ontohgis:administrative_type_6 rdf:type owl:Class ;
                                rdfs:subClassOf ontohgis:administrative_type_10 ;
-                               ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                rdfs:label "district city"@en ,
                                           "miasto na prawach powiatu"@pl ;
                                <http://www.w3.org/2004/02/skos/core#altLabel> "federal city"@en ;
                                ontohgis:hasExternalIdentifier 6 ;
+                               ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_60
 ontohgis:administrative_type_60 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_59 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_10 ;
                                 rdfs:label "gmina wiejska (Królestwo Galicji i Lodomerii (1867-1918))"@pl ,
                                            "rural commune (The Kingdom of Galicia and Lodomeria (1867-1918))"@en ;
                                 ontohgis:hasExternalIdentifier 60 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_10 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_61
 ontohgis:administrative_type_61 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_59 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_10 ;
                                 rdfs:label "gmina miejska (Królestwo Galicji i Lodomerii (1867-1918))"@pl ,
                                            "town commune (The Kingdom of Galicia and Lodomeria (1867-1918))"@en ;
                                 ontohgis:hasExternalIdentifier 61 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_10 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_62
 ontohgis:administrative_type_62 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_59 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_10 ;
                                 rdfs:label "manorial demesne (The Kingdom of Galicia and Lodomeria (1867-1918))"@en ,
                                            "obszar dworski (Królestwo Galicji i Lodomerii (1867-1918))"@pl ;
                                 rdfs:seeAlso "http://gov.genealogy.net/types.owl#109" ,
                                              "https://www.wikidata.org/wiki/Q451019" ;
                                 ontohgis:hasExternalIdentifier 62 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_10 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_63
 ontohgis:administrative_type_63 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:object_3014 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_10 ;
                                 rdfs:label "Bezirk"@de ,
                                            "district (The Kingdom of Galicia and Lodomeria (1867-1918))"@en ,
                                            "powiat (Królestwo Galicji i Lodomerii (1867-1918))"@pl ;
                                 ontohgis:hasExternalIdentifier 63 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_10 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -9694,31 +9710,31 @@ ontohgis:administrative_type_65 rdf:type owl:Class ;
                                                   owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                   owl:someValuesFrom ontohgis:administrative_type_68
                                                 ] ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_11 ;
                                 rdfs:label "commune (Congress Poland (1837-1866))"@en ,
                                            "gmina (Królestwo Polskie (1837-1866))"@pl ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "municipality"@en ;
                                 ontohgis:hasExternalIdentifier 65 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_11 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_66
 ontohgis:administrative_type_66 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_65 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_11 ;
                                 rdfs:label "gmina miejska (Królestwo Polskie (1837-1866))"@pl ,
                                            "town commune (Congress Poland (1837-1866))"@en ;
                                 ontohgis:hasExternalIdentifier 66 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_11 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_67
 ontohgis:administrative_type_67 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_65 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_11 ;
                                 rdfs:label "gmina wiejska (Królestwo Polskie (1837-1866))"@pl ,
                                            "rural commune (Congress Poland (1837-1866))"@en ;
                                 ontohgis:hasExternalIdentifier 67 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_11 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
@@ -9729,10 +9745,10 @@ ontohgis:administrative_type_68 rdf:type owl:Class ;
                                                   owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                   owl:someValuesFrom ontohgis:administrative_type_69
                                                 ] ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_11 ;
                                 rdfs:label "district (Congress Poland (1837-1866))"@en ,
                                            "okręg (Królestwo Polskie (1837-1866))"@pl ;
                                 ontohgis:hasExternalIdentifier 68 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_11 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_20 .
 
 
@@ -9743,32 +9759,32 @@ ontohgis:administrative_type_69 rdf:type owl:Class ;
                                                   owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                   owl:someValuesFrom ontohgis:administrative_type_70
                                                 ] ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_11 ;
                                 rdfs:label "district (Congress Poland (1837-1866))"@en ,
                                            "powiat (Królestwo Polskie (1837-1866))"@pl ;
                                 ontohgis:hasExternalIdentifier 69 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_11 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_7
 ontohgis:administrative_type_7 rdf:type owl:Class ;
                                rdfs:subClassOf ontohgis:administrative_type_11 ;
-                               ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                rdfs:label "city of Warsaw"@en ,
                                           "miasto Warszawa"@pl ;
                                ontohgis:hasExternalIdentifier 7 ;
+                               ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_70
 ontohgis:administrative_type_70 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:object_3014 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_11 ;
                                 rdfs:label "gubernia (Królestwo Polskie (1837-1866))"@pl ,
                                            "province (Congress Poland (1837-1866))"@en ;
                                 rdfs:seeAlso "http://dbpedia.org/page/Governorate_(Russia)" ,
                                              "https://www.wikidata.org/wiki/Q86622" ;
                                 ontohgis:hasExternalIdentifier 70 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_11 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
@@ -9779,13 +9795,13 @@ ontohgis:administrative_type_74 rdf:type owl:Class ;
                                                   owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                   owl:someValuesFrom ontohgis:administrative_type_77
                                                 ] ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_13 ;
                                 rdfs:label "Kreis"@de ,
                                            "district (The Kingdom of Prussia (1713-1805))"@en ,
                                            "powiat (Królestwo Prus (1713-1805))"@pl ;
                                 rdfs:seeAlso "http://gov.genealogy.net/types.owl#32" ,
                                              "https://www.wikidata.org/wiki/Q106658" ;
                                 ontohgis:hasExternalIdentifier 74 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_13 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -9793,13 +9809,13 @@ ontohgis:administrative_type_74 rdf:type owl:Class ;
 ontohgis:administrative_type_75 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_74 ;
                                 rdfs:comment "Od 1701 Landkreis jako jednostka administracyjna początkowo w Brandenburgii; od 1716 na Pomorzu, 1740 na Śląsku, 1752 w Prusach Wschodnich, 1772 Prusach Zachodnich, 1793 w Prusach Południowych i 1795 w Prusach Nowo Wschodnich"@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_13 ;
                                 rdfs:label "Landkreis"@de ,
                                            "powiat ziemski (Królestwo Prus (1713-1805))"@pl ,
                                            "rural district (The Kingdom of Prussia (1713-1805))"@en ;
                                 rdfs:seeAlso "http://gov.genealogy.net/types.owl#32" ,
                                              "https://www.wikidata.org/wiki/Q106658" ;
                                 ontohgis:hasExternalIdentifier 75 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_13 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -9807,10 +9823,10 @@ ontohgis:administrative_type_75 rdf:type owl:Class ;
 ontohgis:administrative_type_76 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_74 ;
                                 rdfs:comment "Dla miast utworzono okręgi inspekcji podatkowych, które nie pokrywały się z wiejskimi powiatami. Okręgi dominalne w Prusach Książęcych."@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_13 ;
                                 rdfs:label "circut (The Kingdom of Prussia (1713-1805))"@en ,
                                            "miejski okręg inspekcji podatkowej (Królestwo Prus (1713-1805))"@pl ;
                                 ontohgis:hasExternalIdentifier 76 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_13 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -9821,33 +9837,33 @@ ontohgis:administrative_type_77 rdf:type owl:Class ;
                                                   owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                   owl:someValuesFrom ontohgis:administrative_type_78
                                                 ] ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_13 ;
                                 rdfs:label "Kammerdepartment"@de ,
                                            "Wad and Domain chamber's department (The Kingdom of Prussia (1713-1805))"@en ,
                                            "departament kamery wojenno-skarbowej (Królestwo Prus (1713-1805))"@pl ;
                                 ontohgis:hasExternalIdentifier 77 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_13 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_40 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_78
 ontohgis:administrative_type_78 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:object_3014 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_13 ;
                                 rdfs:label "Provinz"@de ,
                                            "province (The Kingdom of Prussia (1713-1805))"@en ,
                                            "prowincja (Królestwo Prus (1713-1805))"@pl ;
                                 ontohgis:hasExternalIdentifier 78 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_13 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_60 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_8
 ontohgis:administrative_type_8 rdf:type owl:Class ;
                                rdfs:subClassOf ontohgis:administrative_type_11 ;
-                               ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                rdfs:label "voivodeship"@en ,
                                           "województwo"@pl ;
                                <http://www.w3.org/2004/02/skos/core#altLabel> "province"@en ;
                                ontohgis:hasExternalIdentifier 8 ;
+                               ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
@@ -9859,10 +9875,10 @@ ontohgis:administrative_type_80 rdf:type owl:Class ;
                                                   owl:someValuesFrom ontohgis:administrative_type_81
                                                 ] ;
                                 rdfs:comment "Korona: w celach skarbowych używano jeszcze niższego podziału - sieci parafialnej. Był on jednak czysto użytkowy i nieoficjalny"@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_14 ;
                                 rdfs:label "district (The Polish-Lithuanian Commonwealth (1569-1795))"@en ,
                                            "powiat (Rzeczpospolita Obojga Narodów (1569-1795))"@pl ;
                                 ontohgis:hasExternalIdentifier 80 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_14 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
@@ -9874,11 +9890,11 @@ ontohgis:administrative_type_81 rdf:type owl:Class ;
                                                   owl:someValuesFrom ontohgis:administrative_type_82
                                                 ] ;
                                 rdfs:comment "Korona: nie zawsze występuje; wedle literatury po około poł. XV w. ziemie, które zachowały cała strukturę urzędów ziemskich (razem z wojewodą) przekształciły się w województwa; te, których struktura była niepełna nie zmieniły się"@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_14 ;
                                 rdfs:label "land (The Polish-Lithuanian Commonwealth (1569-1795))"@en ,
                                            "ziemia (Rzeczpospolita Obojga Narodów (1569-1795))"@pl ;
                                 rdfs:seeAlso "https://www.wikidata.org/wiki/Q2560367" ;
                                 ontohgis:hasExternalIdentifier 81 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_14 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_40 .
 
 
@@ -9889,12 +9905,12 @@ ontohgis:administrative_type_82 rdf:type owl:Class ;
                                                   owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                   owl:someValuesFrom ontohgis:administrative_type_83
                                                 ] ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_14 ;
                                 rdfs:label "palatinate (The Polish-Lithuanian Commonwealth (1569-1795))"@en ,
                                            "województwo (Rzeczpospolita Obojga Narodów (1569-1795))"@pl ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "county"@en ,
                                                                                "province"@en ;
                                 ontohgis:hasExternalIdentifier 82 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_14 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
@@ -9906,10 +9922,10 @@ ontohgis:administrative_type_83 rdf:type owl:Class ;
                                                   owl:someValuesFrom ontohgis:administrative_type_84
                                                 ] ;
                                 rdfs:comment "Korona: prowincja wielkopolska i małopolska"@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_14 ;
                                 rdfs:label "province (The Polish-Lithuanian Commonwealth (1569-1795))"@en ,
                                            "prowincja (Rzeczpospolita Obojga Narodów (1569-1795))"@pl ;
                                 ontohgis:hasExternalIdentifier 83 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_14 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_60 .
 
 
@@ -9917,22 +9933,22 @@ ontohgis:administrative_type_83 rdf:type owl:Class ;
 ontohgis:administrative_type_84 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:object_3014 ;
                                 rdfs:comment "Korona Królestwa Polskiego / Wielkie Księstwo Litewskie. Wszystkie odrębności wynikające z aktu unii lubelskiej zostały zniesiona na mocy konstytucji 3 maja"@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_14 ;
                                 rdfs:label "dzielnica (Rzeczpospolita Obojga Narodów (1569-1795))"@pl ,
                                            "state (The Polish-Lithuanian Commonwealth (1569-1795))"@en ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "part"@en ;
                                 ontohgis:hasExternalIdentifier 84 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_14 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_70 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_86
 ontohgis:administrative_type_86 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:object_3014 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_15 ;
                                 rdfs:label "Markgrafschaft"@de ,
                                            "hrabstwo (Elektorat Saksonii (1545-1805))"@pl ,
                                            "margrabstwo"@pl ;
                                 ontohgis:hasExternalIdentifier 86 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_15 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_70 .
 
 
@@ -9944,10 +9960,10 @@ ontohgis:administrative_type_89 rdf:type owl:Class ;
                                                   owl:someValuesFrom ontohgis:administrative_type_92
                                                 ] ;
                                 rdfs:comment "Niekiedy jako najniższą jednostkę administracyjną o charakterze pomocniczym podaje się dominia (wiejskie) i magistraty (miejskie). Rozporządzenia z 1848 r. uznały urzędy dominialne za organa tymczasowe sprawujące władzę na koszt i w imieniu państwa a nie dziedzica. Zniesiono je w 1855 r. a ich terytoria podzielono na gminy wiejskie i obszary dworskie."@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_17 ;
                                 rdfs:label "dominium-magistrat (Królestwo Galicji i Lodomerii (1772-1848))"@pl ,
                                            "dominium-magistrate (The Kingdom of Galitia and Lodomeria (1772-1848))"@en ;
                                 ontohgis:hasExternalIdentifier 89 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_17 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
@@ -9958,21 +9974,21 @@ ontohgis:administrative_type_9 rdf:type owl:Class ;
                                                  owl:onProperty <http://www.cidoc-crm.org/cidoc-crm/P46i_forms_part_of> ;
                                                  owl:someValuesFrom ontohgis:administrative_type_10
                                                ] ;
-                               ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                rdfs:label "gmina"@pl ,
                                           "municipality"@en ;
                                <http://www.w3.org/2004/02/skos/core#altLabel> "community"@en ;
                                ontohgis:hasExternalIdentifier 9 ;
+                               ontohgis:isDefinedByIRI ontohgis:administrative_system_1 ;
                                ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_90
 ontohgis:administrative_type_90 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_89 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_17 ;
                                 rdfs:label "dominium (Królestwo Galicji i Lodomerii (1772-1848))"@pl ,
                                            "dominium (The Kingdom of Galitia and Lodomeria (1772-1848))"@en ;
                                 ontohgis:hasExternalIdentifier 90 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_17 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
@@ -9980,62 +9996,62 @@ ontohgis:administrative_type_90 rdf:type owl:Class ;
 ontohgis:administrative_type_91 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:administrative_type_89 ;
                                 rdfs:comment "Najniższa jednostka administracji państwowej na terenie miast"@pl ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_17 ;
                                 rdfs:label "magistrat (Królestwo Galicji i Lodomerii (1772-1848))"@pl ,
                                            "magistrate (The Kingdom of Galitia and Lodomeria (1772-1848))"@en ;
                                 ontohgis:hasExternalIdentifier 91 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_17 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_10 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_92
 ontohgis:administrative_type_92 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:object_3014 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_17 ;
                                 rdfs:label "Distrikt"@de ,
                                            "district (The Kingdom of Galitia and Lodomeria (1772-1848))"@en ,
                                            "okręg (Królestwo Galicji i Lodomerii (1772-1848))"@pl ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "Bezirk"@de ,
                                                                                "Kreisdistrikt"@de ;
                                 ontohgis:hasExternalIdentifier 92 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_17 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_93
 ontohgis:administrative_type_93 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:object_3014 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_17 ;
                                 rdfs:label "Direktoriat"@de ,
                                            "Kreis"@de ,
                                            "cyrkuł (Królestwo Galicji i Lodomerii (1772-1848))"@pl ,
                                            "tsyrkul (The Kingdom of Galitia and Lodomeria (1772-1848))"@en ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "circle"@en ;
                                 ontohgis:hasExternalIdentifier 93 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_17 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_40 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_96
 ontohgis:administrative_type_96 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:object_3014 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_18 ;
                                 rdfs:label "district (the Kingom of Hungary (1200-1918))"@en ,
                                            "powiat (Królestwo Węgier (1200-1918))"@pl ,
                                            "reambulatio"@la ,
                                            "szolgabírói járás"@hu ;
                                 <http://www.w3.org/2004/02/skos/core#altLabel> "processus"@la ;
                                 ontohgis:hasExternalIdentifier 96 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_18 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_30 .
 
 
 ###  https://onto.kul.pl/ontohgis/administrative_type_97
 ontohgis:administrative_type_97 rdf:type owl:Class ;
                                 rdfs:subClassOf ontohgis:object_3014 ;
-                                ontohgis:isDefinedByIRI ontohgis:administrative_system_18 ;
                                 rdfs:label "county (the Kingom of Hungary (1200-1918))"@en ,
                                            "komitat (Królestwo Węgier (1200-1918))"@pl ,
                                            "megye"@hu ;
                                 rdfs:seeAlso "http://gov.genealogy.net/types.owl#113" ,
                                              "https://www.wikidata.org/wiki/Q852231" ;
                                 ontohgis:hasExternalIdentifier 97 ;
+                                ontohgis:isDefinedByIRI ontohgis:administrative_system_18 ;
                                 ontohgis:isSymbolisedByMeansOf ontohgis:map_symbol_50 .
 
 
@@ -10246,11 +10262,11 @@ ontohgis:object_23 rdf:type owl:Class ;
                                          rdf:type owl:Class
                                        ] ;
                    rdfs:subClassOf ontohgis:object_1 ;
-                   ontohgis:isDefinedByLiteral "Budynek jest to przedmiot trwający w czasie, który został wytworzony lub wykorzystany w celu odgraniczenia pewnej przestrzeni (“wewnątrz\") od innej przestrzeni (“zewnątrz”)."@pl ;
                    rdfs:label "budynek"@pl ,
                               "building"@en ;
                    rdfs:seeAlso <http://gov.genealogy.net/types.owl#17> ,
-                                "http://encyklopedia.pwn.pl/szukaj/budynek.html" .
+                                "http://encyklopedia.pwn.pl/szukaj/budynek.html" ;
+                   ontohgis:isDefinedByLiteral "Budynek jest to przedmiot trwający w czasie, który został wytworzony lub wykorzystany w celu odgraniczenia pewnej przestrzeni (“wewnątrz\") od innej przestrzeni (“zewnątrz”)."@pl .
 
 
 ###  https://onto.kul.pl/ontohgis/object_30
@@ -10265,12 +10281,12 @@ ontohgis:object_30 rdf:type owl:Class ;
                                      owl:onProperty ontohgis:hasFunction ;
                                      owl:hasValue ontohgis:object_400
                                    ] ;
-                   ontohgis:isDefinedByLiteral """Jednostka osadnicza:
-1. obszar posiadający nazwę własną i
-2. obszar, który jest lub był w przeszłości miejscowością"""@pl ;
                    rdfs:label "human settlement"@en ,
                               "jednostka osadnicza"@pl ;
-                   rdfs:seeAlso <http://encyklopedia.pwn.pl/haslo/jednostka-osadnicza;3917491.html> .
+                   rdfs:seeAlso <http://encyklopedia.pwn.pl/haslo/jednostka-osadnicza;3917491.html> ;
+                   ontohgis:isDefinedByLiteral """Jednostka osadnicza:
+1. obszar posiadający nazwę własną i
+2. obszar, który jest lub był w przeszłości miejscowością"""@pl .
 
 
 ###  https://onto.kul.pl/ontohgis/object_3012
@@ -10351,6 +10367,9 @@ ontohgis:object_32 rdf:type owl:Class ;
                                          ontohgis:settlement_type_1000
                                        ) ;
                    rdfs:comment "Zakładamy, że każda podklasa miejscowości zawiera tylko zamieszkane jednostki osadnicze, np. klasa settlement_type_10 (rdfs:label='browar'@pl) obejmuje tylko zamieszkane browary."@pl ;
+                   rdfs:label "dwelling"@en ,
+                              "miejscowość"@pl ;
+                   rdfs:seeAlso <http://dbpedia.org/ontology/Settlement> ;
                    ontohgis:isDefinedByLiteral """A dwelling is an area such that:
 1. it is filled with buildings
 2. it is used for accommodation
@@ -10359,17 +10378,14 @@ ontohgis:object_32 rdf:type owl:Class ;
 a. having a distingushed function
 b. having a distingushed shape
 c. having a distingushed juridical status."""@en ,
-                                    """Miejscowość jest to
+                                               """Miejscowość jest to
 1. obszar zabudowany i
 2. obszar zamieszkany i
 3. obszar posiadający nazwę własną i
 4. obszar wyodrębniony:
 a. funkcjonalnie (ma funkcje, której żadna część nie ma, ani nie jest częścią czegoś co ma) lub 
 b. morfologicznie (ma wyraźne granice) lub 
-c. prawnie."""@pl ;
-                   rdfs:label "dwelling"@en ,
-                              "miejscowość"@pl ;
-                   rdfs:seeAlso <http://dbpedia.org/ontology/Settlement> .
+c. prawnie."""@pl .
 
 
 ###  https://onto.kul.pl/ontohgis/object_40
@@ -10416,10 +10432,10 @@ ontohgis:object_50 rdf:type owl:Class ;
                                          rdf:type owl:Class
                                        ] ;
                    rdfs:subClassOf ontohgis:object_23 ;
-                   ontohgis:isDefinedByLiteral "Budynek mieszkalny jest to budynek, w którym odgraniczona przestrzeń (“wewnątrz\") jest przeznaczona do przebywania ludzi."@pl ;
                    rdfs:label "budynek mieszkalny"@pl ,
                               "housing building"@en ;
-                   rdfs:seeAlso <http://linkedgeodata.org/ontology/BuildingResidential> .
+                   rdfs:seeAlso <http://linkedgeodata.org/ontology/BuildingResidential> ;
+                   ontohgis:isDefinedByLiteral "Budynek mieszkalny jest to budynek, w którym odgraniczona przestrzeń (“wewnątrz\") jest przeznaczona do przebywania ludzi."@pl .
 
 
 ###  https://onto.kul.pl/ontohgis/object_500
@@ -11061,9 +11077,9 @@ ontohgis:settlement_type_3003 rdf:type owl:Class ;
                                                 owl:hasValue <http://www.geonames.org/ontology#S.HSP>
                                               ] ;
                               rdfs:comment "Miejscowość jest (mereologicznie) prosta, gdy żadna jej część nie jest miejscowością."@pl ;
-                              ontohgis:isDefinedByLiteral "(Mereologically) simple human settlement has no part that is a human settlement."@en ;
                               rdfs:label "(mereologically) simple human settlement"@en ,
                                          "(mereologicznie) prosta miejscowość"@pl ;
+                              ontohgis:isDefinedByLiteral "(Mereologically) simple human settlement has no part that is a human settlement."@en ;
                               ontohgis:isPartOfPartition ontohgis:object_701 .
 
 
@@ -11080,9 +11096,9 @@ ontohgis:settlement_type_3004 rdf:type owl:Class ;
                                                   ] ;
                               rdfs:subClassOf ontohgis:object_32 ;
                               rdfs:comment "Miejscowość jest (mereologicznie) złożona, gdy niektóre jej części są miejscowościami."@pl ;
-                              ontohgis:isDefinedByLiteral "(Mereologically) complex human settlement has parts that are human settlements."@en ;
                               rdfs:label "(mereologically) complex human settlement"@en ,
                                          "(mereologicznie) złożona miejscowość"@pl ;
+                              ontohgis:isDefinedByLiteral "(Mereologically) complex human settlement has parts that are human settlements."@en ;
                               ontohgis:isPartOfPartition ontohgis:object_701 .
 
 
@@ -11099,9 +11115,9 @@ ontohgis:settlement_type_3007 rdf:type owl:Class ;
                                                   ] ;
                               rdfs:subClassOf ontohgis:object_32 ;
                               rdfs:comment "Miejscowość jest (mereologicznie) samodzielna, gdy nie jest częścią żadnej miejscowości." ;
-                              ontohgis:isDefinedByLiteral "(Mereologically) complete human settlement is not part of any settlement."@en ;
                               rdfs:label "(mereologically) complete human settlement"@en ,
                                          "(mereologicznie) samodzielna miejscowość"@pl ;
+                              ontohgis:isDefinedByLiteral "(Mereologically) complete human settlement is not part of any settlement."@en ;
                               ontohgis:isPartOfPartition ontohgis:object_700 .
 
 
@@ -11117,9 +11133,9 @@ ontohgis:settlement_type_3008 rdf:type owl:Class ;
                                                   ] ;
                               rdfs:subClassOf ontohgis:object_32 ;
                               rdfs:comment "Miejscowość jest (mereologicznie) niesamodzielna, gdy jest częścią pewnej miejscowości."@pl ;
-                              ontohgis:isDefinedByLiteral "(Mereologically) incomplete human settlement is part of some settlement."@en ;
                               rdfs:label "(mereologically) incomplete human settlement"@en ,
                                          "(mereologicznie) niesamodzielna miejscowość"@pl ;
+                              ontohgis:isDefinedByLiteral "(Mereologically) incomplete human settlement is part of some settlement."@en ;
                               ontohgis:isPartOfPartition ontohgis:object_700 .
 
 
@@ -11246,10 +11262,10 @@ ontohgis:settlement_type_45 rdf:type owl:Class ;
 ###  https://onto.kul.pl/ontohgis/settlement_type_46
 ontohgis:settlement_type_46 rdf:type owl:Class ;
                             rdfs:subClassOf ontohgis:object_100 ;
-                            ontohgis:isDefinedByLiteral "abandoned place"@en ;
                             rdfs:label "pustkowie" ;
                             rdfs:seeAlso <http://gov.genealogy.net/types.owl#90> ;
-                            ontohgis:hasExternalIdentifier "46" .
+                            ontohgis:hasExternalIdentifier "46" ;
+                            ontohgis:isDefinedByLiteral "abandoned place"@en .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_47
@@ -15715,445 +15731,709 @@ ontohgis:person_9 rdf:type owl:NamedIndividual ,
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_1
 ontohgis:settlement_type_1 rdf:type owl:NamedIndividual ;
-                           dct:creator ontohgis:person_2 .
+                           dct:creator ontohgis:person_2 ;
+                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                           ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_10
 ontohgis:settlement_type_10 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_4 .
+                            dct:creator ontohgis:person_4 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_100
 ontohgis:settlement_type_100 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_6 .
+                             dct:creator ontohgis:person_6 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_103
 ontohgis:settlement_type_103 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_6 .
+                             dct:creator ontohgis:person_6 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 ,
+                                                    ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_106
 ontohgis:settlement_type_106 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_3 .
+                             dct:creator ontohgis:person_3 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_11
 ontohgis:settlement_type_11 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_4 .
+                            dct:creator ontohgis:person_4 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_110
 ontohgis:settlement_type_110 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_3 .
+                             dct:creator ontohgis:person_3 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 ,
+                                                    ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_112
 ontohgis:settlement_type_112 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_8 .
+                             dct:creator ontohgis:person_8 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_113
 ontohgis:settlement_type_113 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_2 .
+                             dct:creator ontohgis:person_2 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_114
 ontohgis:settlement_type_114 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_2 .
+                             dct:creator ontohgis:person_2 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_115
 ontohgis:settlement_type_115 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_5 .
+                             dct:creator ontohgis:person_5 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 ,
+                                                    ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_117
 ontohgis:settlement_type_117 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_5 .
+                             dct:creator ontohgis:person_5 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_118
 ontohgis:settlement_type_118 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_5 .
+                             dct:creator ontohgis:person_5 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_119
 ontohgis:settlement_type_119 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_5 .
+                             dct:creator ontohgis:person_5 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_12
 ontohgis:settlement_type_12 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_4 .
+                            dct:creator ontohgis:person_4 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_120
 ontohgis:settlement_type_120 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_6 .
+                             dct:creator ontohgis:person_6 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_121
 ontohgis:settlement_type_121 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_6 .
+                             dct:creator ontohgis:person_6 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_122
 ontohgis:settlement_type_122 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_6 .
+                             dct:creator ontohgis:person_6 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_123
 ontohgis:settlement_type_123 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_6 .
+                             dct:creator ontohgis:person_6 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_124
 ontohgis:settlement_type_124 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_3 .
+                             dct:creator ontohgis:person_3 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_125
 ontohgis:settlement_type_125 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_3 .
+                             dct:creator ontohgis:person_3 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_126
 ontohgis:settlement_type_126 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_3 .
+                             dct:creator ontohgis:person_3 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_127
 ontohgis:settlement_type_127 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_3 .
+                             dct:creator ontohgis:person_3 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_128
 ontohgis:settlement_type_128 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_3 .
+                             dct:creator ontohgis:person_3 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_129
 ontohgis:settlement_type_129 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_5 .
+                             dct:creator ontohgis:person_5 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_130
 ontohgis:settlement_type_130 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_5 .
+                             dct:creator ontohgis:person_5 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_131
 ontohgis:settlement_type_131 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_5 .
+                             dct:creator ontohgis:person_5 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 ,
+                                                    ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_132
 ontohgis:settlement_type_132 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_6 .
+                             dct:creator ontohgis:person_6 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_133
 ontohgis:settlement_type_133 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_6 .
+                             dct:creator ontohgis:person_6 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_134
 ontohgis:settlement_type_134 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_6 .
+                             dct:creator ontohgis:person_6 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_135
 ontohgis:settlement_type_135 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_4 .
+                             dct:creator ontohgis:person_4 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_136
 ontohgis:settlement_type_136 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_4 .
+                             dct:creator ontohgis:person_4 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_137
 ontohgis:settlement_type_137 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_4 .
+                             dct:creator ontohgis:person_4 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_138
 ontohgis:settlement_type_138 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_4 .
+                             dct:creator ontohgis:person_4 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_139
 ontohgis:settlement_type_139 rdf:type owl:NamedIndividual ;
-                             dct:creator ontohgis:person_6 .
+                             dct:creator ontohgis:person_6 ;
+                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                             ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_17
 ontohgis:settlement_type_17 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_5 .
+                            dct:creator ontohgis:person_5 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_18
 ontohgis:settlement_type_18 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_4 .
+                            dct:creator ontohgis:person_4 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_19
 ontohgis:settlement_type_19 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_6 .
+                            dct:creator ontohgis:person_6 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_2
 ontohgis:settlement_type_2 rdf:type owl:NamedIndividual ;
-                           dct:creator ontohgis:person_3 .
+                           dct:creator ontohgis:person_3 ;
+                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                           ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_20
 ontohgis:settlement_type_20 rdf:type owl:NamedIndividual ;
                             dct:creator ontohgis:person_7 ,
-                                        ontohgis:person_8 .
+                                        ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_21
 ontohgis:settlement_type_21 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_4 .
+                            dct:creator ontohgis:person_4 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_23
 ontohgis:settlement_type_23 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_5 .
+                            dct:creator ontohgis:person_5 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 ,
+                                                   ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_25
 ontohgis:settlement_type_25 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_5 .
+                            dct:creator ontohgis:person_5 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 ,
+                                                   ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_27
 ontohgis:settlement_type_27 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_5 .
+                            dct:creator ontohgis:person_5 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_28
 ontohgis:settlement_type_28 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_2 .
+                            dct:creator ontohgis:person_2 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_3
 ontohgis:settlement_type_3 rdf:type owl:NamedIndividual ;
-                           dct:creator ontohgis:person_2 .
+                           dct:creator ontohgis:person_2 ;
+                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                           ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_33
 ontohgis:settlement_type_33 rdf:type owl:NamedIndividual ;
                             dct:creator ontohgis:person_7 ,
-                                        ontohgis:person_8 .
+                                        ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_34
 ontohgis:settlement_type_34 rdf:type owl:NamedIndividual ;
                             dct:creator ontohgis:person_7 ,
-                                        ontohgis:person_8 .
+                                        ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 ,
+                                                   ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_35
 ontohgis:settlement_type_35 rdf:type owl:NamedIndividual ;
                             dct:creator ontohgis:person_7 ,
-                                        ontohgis:person_8 .
+                                        ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_36
 ontohgis:settlement_type_36 rdf:type owl:NamedIndividual ;
                             dct:creator ontohgis:person_5 ,
                                         ontohgis:person_7 ,
-                                        ontohgis:person_8 .
+                                        ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 ,
+                                                   ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_37
 ontohgis:settlement_type_37 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_2 .
+                            dct:creator ontohgis:person_2 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_38
 ontohgis:settlement_type_38 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_7 .
+                            dct:creator ontohgis:person_7 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_41
 ontohgis:settlement_type_41 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_6 .
+                            dct:creator ontohgis:person_6 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_43
 ontohgis:settlement_type_43 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_2 .
+                            dct:creator ontohgis:person_2 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_44
 ontohgis:settlement_type_44 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_3 .
+                            dct:creator ontohgis:person_3 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_45
 ontohgis:settlement_type_45 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_5 .
+                            dct:creator ontohgis:person_5 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_47
 ontohgis:settlement_type_47 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_6 .
+                            dct:creator ontohgis:person_6 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_48
 ontohgis:settlement_type_48 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_5 .
+                            dct:creator ontohgis:person_5 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_50
 ontohgis:settlement_type_50 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_6 .
+                            dct:creator ontohgis:person_6 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_51
 ontohgis:settlement_type_51 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_6 .
+                            dct:creator ontohgis:person_6 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_52
 ontohgis:settlement_type_52 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_2 .
+                            dct:creator ontohgis:person_2 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_53
 ontohgis:settlement_type_53 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_5 .
+                            dct:creator ontohgis:person_5 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 ,
+                                                   ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_54
 ontohgis:settlement_type_54 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_6 .
+                            dct:creator ontohgis:person_6 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_56
 ontohgis:settlement_type_56 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_3 .
+                            dct:creator ontohgis:person_3 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_60
 ontohgis:settlement_type_60 rdf:type owl:NamedIndividual ;
                             dct:creator ontohgis:person_7 ,
-                                        ontohgis:person_8 .
+                                        ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_61
 ontohgis:settlement_type_61 rdf:type owl:NamedIndividual ;
                             dct:creator ontohgis:person_7 ,
-                                        ontohgis:person_8 .
+                                        ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_62
 ontohgis:settlement_type_62 rdf:type owl:NamedIndividual ;
                             dct:creator ontohgis:person_7 ,
-                                        ontohgis:person_8 .
+                                        ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_63
 ontohgis:settlement_type_63 rdf:type owl:NamedIndividual ;
                             dct:creator ontohgis:person_7 ,
-                                        ontohgis:person_8 .
+                                        ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_64
 ontohgis:settlement_type_64 rdf:type owl:NamedIndividual ;
                             dct:creator ontohgis:person_7 ,
-                                        ontohgis:person_8 .
+                                        ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_65
 ontohgis:settlement_type_65 rdf:type owl:NamedIndividual ;
                             dct:creator ontohgis:person_7 ,
-                                        ontohgis:person_8 .
+                                        ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_66
 ontohgis:settlement_type_66 rdf:type owl:NamedIndividual ;
                             dct:creator ontohgis:person_7 ,
-                                        ontohgis:person_8 .
+                                        ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_68
 ontohgis:settlement_type_68 rdf:type owl:NamedIndividual ;
                             dct:creator ontohgis:person_7 ,
-                                        ontohgis:person_8 .
+                                        ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_69
 ontohgis:settlement_type_69 rdf:type owl:NamedIndividual ;
                             dct:creator ontohgis:person_7 ,
-                                        ontohgis:person_8 .
+                                        ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_7
 ontohgis:settlement_type_7 rdf:type owl:NamedIndividual ;
-                           dct:creator ontohgis:person_3 .
+                           dct:creator ontohgis:person_3 ;
+                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                           ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_70
 ontohgis:settlement_type_70 rdf:type owl:NamedIndividual ;
                             dct:creator ontohgis:person_7 ,
-                                        ontohgis:person_8 .
+                                        ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_71
 ontohgis:settlement_type_71 rdf:type owl:NamedIndividual ;
                             dct:creator ontohgis:person_7 ,
-                                        ontohgis:person_8 .
+                                        ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_72
 ontohgis:settlement_type_72 rdf:type owl:NamedIndividual ;
                             dct:creator ontohgis:person_7 ,
-                                        ontohgis:person_8 .
+                                        ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 ,
+                                                   ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_73
 ontohgis:settlement_type_73 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_8 .
+                            dct:creator ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_74
 ontohgis:settlement_type_74 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_8 .
+                            dct:creator ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_75
 ontohgis:settlement_type_75 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_8 .
+                            dct:creator ontohgis:person_8 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_76
 ontohgis:settlement_type_76 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_5 .
+                            dct:creator ontohgis:person_5 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_8
 ontohgis:settlement_type_8 rdf:type owl:NamedIndividual ;
-                           dct:creator ontohgis:person_3 .
+                           dct:creator ontohgis:person_3 ;
+                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                           ontohgis:hasTranslator ontohgis:person_9 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_80
 ontohgis:settlement_type_80 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_3 .
+                            dct:creator ontohgis:person_3 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_82
 ontohgis:settlement_type_82 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_5 .
+                            dct:creator ontohgis:person_5 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 ###  https://onto.kul.pl/ontohgis/settlement_type_99
 ontohgis:settlement_type_99 rdf:type owl:NamedIndividual ;
-                            dct:creator ontohgis:person_3 .
+                            dct:creator ontohgis:person_3 ;
+                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
+                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
+                            ontohgis:hasTranslator ontohgis:person_5 .
 
 
 #################################################################
@@ -16569,8 +16849,6 @@ ontohgis:hasTranslator rdfs:label "deskrypcja została przetłumaczona przez"@pl
 
 ontohgis:settlement_type_1 rdfs:comment "A castle could be an independent settlement unit or an object within some other unit."@en ,
                                         "Zamek mógł być jednostką osadniczą lub obiektem w obrębie innej jednostki."@pl ;
-                           ontohgis:isDefinedByLiteral "A castle (a locality) is a locality comprising a castle (building) unless it is a part of another locality."@en ,
-                                            "Zamek (miejscowość) jest to miejscowość obejmująca zamek (obiekt), gdy nie jest on częścią innej miejscowości."@pl ;
                            rdfs:label "castle"@en ,
                                       "zamek"@pl ;
                            rdfs:seeAlso <http://gov.genealogy.net/types.owl#111> ,
@@ -16587,15 +16865,12 @@ ontohgis:settlement_type_1 rdfs:comment "A castle could be an independent settle
                            <http://www.w3.org/2004/02/skos/core#prefLabel> "castle"@en ,
                                                                            "zamek"@pl ;
                            ontohgis:hasExternalIdentifier "1" ;
-                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                           ontohgis:hasTranslator ontohgis:person_9 .
+                           ontohgis:isDefinedByLiteral "A castle (a locality) is a locality comprising a castle (building) unless it is a part of another locality."@en ,
+                                                       "Zamek (miejscowość) jest to miejscowość obejmująca zamek (obiekt), gdy nie jest on częścią innej miejscowości."@pl .
 
 
 ontohgis:settlement_type_10 rdfs:comment "A brewery might be a separate locality (rarely, before the WW II), both individual and a part of a cluster of localities sharing the same name, however most often it has been an integral part of a city or a town and has not been distinguished."@en ,
                                          "Browar może być odrębną miejscowością (rzadko, przed II wojną światową), zarówno samodzielną jak i częścią grupy miejscowości o tej samej nazwie, ale najczęściej znajduje się w obrębie miast i nie jest wyróżniony."@pl ;
-                            ontohgis:isDefinedByLiteral "Brewery (locality) is a settlement, where a brewery (a factory) plays the most important role."@en ,
-                                             "Browar (miejscowość) jest to osada, w której główna rolę pełni browar (obiekt)."@pl ;
                             rdfs:label "brewery"@en ,
                                        "browar"@pl ;
                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Bierbrauerei"@de ,
@@ -16609,15 +16884,12 @@ ontohgis:settlement_type_10 rdfs:comment "A brewery might be a separate locality
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "brewery"@en ,
                                                                             "browar"@pl ;
                             ontohgis:hasExternalIdentifier "10" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                            ontohgis:isDefinedByLiteral "Brewery (locality) is a settlement, where a brewery (a factory) plays the most important role."@en ,
+                                                        "Browar (miejscowość) jest to osada, w której główna rolę pełni browar (obiekt)."@pl .
 
 
 ontohgis:settlement_type_100 rdfs:comment "As a separate building, chapel could be a separate settlement unit in the past (rarely in the early modern era), but most often it is part of the village as a building."@en ,
                                           "Kaplica jako odrębny budynek mogła być w przeszłości odrębną jednostką osadniczą (rzadko, spotyka się w okresie staropolskim), najczęściej jednak wchodzi w skład miejscowości jako budowla."@pl ;
-                             ontohgis:isDefinedByLiteral "Chapel is a locality, where the main role is played by a chapel (sacral building)."@en ,
-                                              "Kaplica jest to miejscowość, w której główną rolę pełni kaplica jako obiekt sakralny."@pl ;
                              rdfs:label "chapel"@en ,
                                         "kaplica"@pl ;
                              rdfs:seeAlso <http://gov.genealogy.net/types.owl#245> ;
@@ -16638,15 +16910,12 @@ ontohgis:settlement_type_100 rdfs:comment "As a separate building, chapel could 
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "chapel"@en ,
                                                                              "kaplica"@pl ;
                              ontohgis:hasExternalIdentifier "100" ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
+                             ontohgis:isDefinedByLiteral "Chapel is a locality, where the main role is played by a chapel (sacral building)."@en ,
+                                                         "Kaplica jest to miejscowość, w której główną rolę pełni kaplica jako obiekt sakralny."@pl .
 
 
 ontohgis:settlement_type_103 rdfs:comment "A church could be a separate settlement in the past (rarely, one can note its existence during and early modern era), however usually it, understood as a building, constituted a part of a locality."@en ,
                                           "Kościół mógł być w przeszłości odrębną jednostką osadniczą (rzadko, spotyka się w okresie staropolskim), najczęściej jednak wchodzi w skład miejscowości jako budowla."@pl ;
-                             ontohgis:isDefinedByLiteral "Church is a locality, where the main role is played by the church (sacral building)."@en ,
-                                              "Kościół jest to miejscowość, w której główną rolę pełni kościół jako obiekt sakralny."@pl ;
                              rdfs:label "church"@en ,
                                         "kościół"@pl ;
                              <http://www.w3.org/2004/02/skos/core#altLabel> "ecclesia"@la ;
@@ -16661,16 +16930,12 @@ ontohgis:settlement_type_103 rdfs:comment "A church could be a separate settleme
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "church"@en ,
                                                                              "kościół"@pl ;
                              ontohgis:hasExternalIdentifier "103" ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 ,
-                                                    ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "Church is a locality, where the main role is played by the church (sacral building)."@en ,
+                                                         "Kościół jest to miejscowość, w której główną rolę pełni kościół jako obiekt sakralny."@pl .
 
 
 ontohgis:settlement_type_106 rdfs:comment "Although the category exists on maps - e.g. the Topographical Map of the Kingdom of Poland from 1843 - it is very rare. On the Map, one can notice the peculiar spelling of this category: \"romunek\"."@en ,
                                           "Kategoria występuje na mapach – np. Kwatermistrzostwie, to jednak jest to kategoria bardzo rzadka."@pl ;
-                             ontohgis:isDefinedByLiteral "\"Rumunek\" is an outlying settlement, situated in a cleared forest area (usually) or near the forest."@en ,
-                                              "Rumunek to odosobniona osada, położona w miejscu po wykarczowanym lesie (najczęściej) lub pod lasem."@pl ;
                              rdfs:label "\"rumunek\""@en ,
                                         "rumunek"@pl ;
                              <http://www.w3.org/2004/02/skos/core#altLabel> "pustkowie (pl)" ;
@@ -16679,15 +16944,12 @@ ontohgis:settlement_type_106 rdfs:comment "Although the category exists on maps 
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "\"rumunek\""@en ,
                                                                              "rumunek"@pl ;
                              ontohgis:hasExternalIdentifier "106" ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "\"Rumunek\" is an outlying settlement, situated in a cleared forest area (usually) or near the forest."@en ,
+                                                         "Rumunek to odosobniona osada, położona w miejscu po wykarczowanym lesie (najczęściej) lub pod lasem."@pl .
 
 
 ontohgis:settlement_type_11 rdfs:comment "A brickyard might be a separate locality, both individual and a part of a cluster of localities sharing the same name. It may also be an integral part of a bigger locality."@en ,
                                          "Cegielnia może być odrębną miejscowością, zarówno samodzielną jak i częścią grupy miejscowości o tej samej nazwie, może też znajdować się w obrębie większej miejscowości."@pl ;
-                            ontohgis:isDefinedByLiteral "Brickyard (locality) is a settlement, where a brickyard (a building and a factory) plays the most important role."@en ,
-                                             "Cegielnia (miejscowość) jest to osada, w której główną rolę odrywa cegielnia (obiekt)."@pl ;
                             rdfs:label "brickyard"@en ,
                                        "cegielnia"@pl ;
                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Ziegelei"@de ,
@@ -16697,15 +16959,12 @@ ontohgis:settlement_type_11 rdfs:comment "A brickyard might be a separate locali
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "brickyard"@en ,
                                                                             "cegielnia"@pl ;
                             ontohgis:hasExternalIdentifier "11" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                            ontohgis:isDefinedByLiteral "Brickyard (locality) is a settlement, where a brickyard (a building and a factory) plays the most important role."@en ,
+                                                        "Cegielnia (miejscowość) jest to osada, w której główną rolę odrywa cegielnia (obiekt)."@pl .
 
 
 ontohgis:settlement_type_110 rdfs:comment "O odrębności wójtostwa decyduje kryterium nazewnicze, które jest efektem jego statusu prawnego."@pl ,
                                           "Vogt-owned-settlement is distinguished on the basis of its name, which results from its legal status."@en ;
-                             ontohgis:isDefinedByLiteral "Vogt-owned-settlement is the area of land owned by the vogt (ger Schultheiß) which is either a separate locality or a separate part of another locality."@en ,
-                                              "Wójtostwo to obszar zajmowany przez ziemię należącą do sołtysa (wójta), będący osobną miejscowością lub wydzieloną częścią miejscowości."@pl ;
                              rdfs:label "vogt-owned-settlement"@en ,
                                         "wójtostwo"@pl ;
                              <http://www.w3.org/2004/02/skos/core#altLabel> "die Vogtei"@de ;
@@ -16717,32 +16976,25 @@ ontohgis:settlement_type_110 rdfs:comment "O odrębności wójtostwa decyduje kr
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "vogt-owned-settlement"@en ,
                                                                              "wójtostwo"@pl ;
                              ontohgis:hasExternalIdentifier "110" ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 ,
-                                                    ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "Vogt-owned-settlement is the area of land owned by the vogt (ger Schultheiß) which is either a separate locality or a separate part of another locality."@en ,
+                                                         "Wójtostwo to obszar zajmowany przez ziemię należącą do sołtysa (wójta), będący osobną miejscowością lub wydzieloną częścią miejscowości."@pl .
 
 
 ontohgis:settlement_type_112 rdfs:comment "Część przysiółka jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Części przysiółków to 6 obiektów: 3 w woj. małopolskim, po 1 w woj. mazowieckim, kujawsko-pomorskim i wielkopolskim."@pl ,
                                           "Part of a hamlet is a separate settlement unit, a kind of locality, it always has a particular name. There are 6 parts of the hamlets according to National Register of Geographic Names (pl \"Państwowy Rejestr Nazwy Geograficznych\"): 3 in Małopolskie voivodship, 1 in Mazowieckie , Kuyawsko-Pomorskie, and Wielkopolskie voivodships."@en ;
-                             ontohgis:isDefinedByLiteral "Część przysiółka jest to miejscowość stanowiąca integralną część miejscowości podstawowej przysiółka, jest wydzielona administracyjnie, ale należy do jednostki nadrzędnej."@pl ,
-                                              "Part of a hamlet is an integral part of the main locality a hamlet; it is administratively separated, but belongs to the superior locality."@en ;
                              rdfs:label "część przysiółka"@pl ,
                                         "part of a hamlet"@en ;
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "część przysiółka"@pl ,
                                                                              "part of a hamlet"@en ;
                              ontohgis:hasExternalIdentifier 112 ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
+                             ontohgis:isDefinedByLiteral "Część przysiółka jest to miejscowość stanowiąca integralną część miejscowości podstawowej przysiółka, jest wydzielona administracyjnie, ale należy do jednostki nadrzędnej."@pl ,
+                                                         "Part of a hamlet is an integral part of the main locality a hamlet; it is administratively separated, but belongs to the superior locality."@en .
 
 
 ontohgis:settlement_type_113 rdfs:comment "At least untill the 13th century, a gord was a central and usually the only element of a city or town indicated in written historical sources, which is why these may be considered as identical for this period; after location, the gord became one of many facilities in a city or a town, usually situated on peripheries, sometimes converted into a castle."@en ,
                                           "Gords are characteristic mostly for the High Middle Ages, when documents were written in Latin, despite the fact that Latin does not know a proper notion for this kind of settlement unit. Expressions with a different, relatively similar, meaning had been used to describe the gord, i.e. a city (lat civitas), or a castle (lat arx, castrum). In younger historical German sources “gród” was called Burg, the expression meaning both a gord and a castle. Researchers consider “gord” as an endemic and specifically Slavic phenomenon."@en ,
                                           "Grody są charakterystyczne przede wszystkim dla pełnego średniowiecza, gdy językiem źródeł była łacina - a w niej nie wykształcił się w ogóle termin odpowiadający tej jednostce osadniczej. Określano ją więc za pomocą pojęć o odmiennym, względnie podobnym znaczeniu, jak miasto (civitas), zamek (arx, castrum). Z kolei w późniejszych źródłach niemieckich odpowiadał mu termin Burg, oznaczający zarówno gród, jak również zamek. W literaturze przedmiotu gród jest traktowany jako zjawisko specyficznie słowiańskie."@pl ,
                                           "Przynamniej do XIII w. gród stanowił centralną i zwykle jedyną uchwytną źródłowo część miasta, więc dla tego okresu może być z nim utożsamiany; po lokacji stawał się jednym z obiektów w mieście, zwykle peryferyjnym, niejednokrotnie zamienianym w zamek."@pl ;
-                             ontohgis:isDefinedByLiteral "Gord is a medieval or – in eastern territories – early modern settlement with revetments and stockades."@en ,
-                                              "Średniowieczna lub, na terenach wschodnich, wczesnonowożytna osada z obwarowaniami drewniano-ziemnymi."@pl ;
                              rdfs:label "gord"@en ,
                                         "gród"@pl ;
                              rdfs:seeAlso <http://dbpedia.org/page/Gord_(archaeology)> ,
@@ -16761,9 +17013,8 @@ ontohgis:settlement_type_113 rdfs:comment "At least untill the 13th century, a g
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "gord"@en ,
                                                                              "gród"@pl ;
                              ontohgis:hasExternalIdentifier "113" ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "Gord is a medieval or – in eastern territories – early modern settlement with revetments and stockades."@en ,
+                                                         "Średniowieczna lub, na terenach wschodnich, wczesnonowożytna osada z obwarowaniami drewniano-ziemnymi."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_113 ;
@@ -16789,8 +17040,6 @@ ontohgis:settlement_type_113 rdfs:comment "At least untill the 13th century, a g
 
 ontohgis:settlement_type_114 rdfs:comment "Chronologically, a castle with its functions was preceded by a gord (non-brick, without buildings having both defensive and residential functions), while its successor was a palace (with defensive functions reduced), and a fortress (is was not necessarily a densely built-up structure, and there was no buildings with both defensive and residential functions). During the Early Modern era, military functions of castles were diminishing, but they continued to be residences. Newly established ones in their form imitated defensive buildings and due to this feature were called castles."@en ,
                                           "Chronologicznie funkcjonalnym poprzednikiem zamku był gród (niemurowany i bez budynków łączących funkcje obronne i rezydencjonalne), a następcą pałac (bez funkcji obronnych) i twierdza (nie musiała być założeniem zwartym i bez budynków łączących funkcje obronne i rezydencjonalne). W epoce nowożytnej i później zamki w coraz mniejszym stopniu pełniły funkcje militarne, ale zachowywały ciągłość funkcji rezydencjonalnych lub, nowopowstałe, w architekturze naśladowały budowle obronne i z tego względu były nazywane zamkami."@pl ;
-                             ontohgis:isDefinedByLiteral "Castle is a brick, densely built-up, closed, usually complex structure, within which at least some buildings have both defensive and residential functions; built in the Middle Ages or later but then in a form referring to that period."@en ,
-                                              "Murowane, zwarte, zamknięte, zwykle wieloczłonowe założenie, w którym przynajmniej część budynków pełni funkcje zarazem obronne i rezydencjonalne; powstałe w średniowieczu lub nawiązujące formą do tej epoki."@pl ;
                              rdfs:label "castle"@en ,
                                         "zamek - obiekt"@pl ;
                              rdfs:seeAlso <http://dbpedia.org/ontology/Castle> ,
@@ -16811,9 +17060,8 @@ ontohgis:settlement_type_114 rdfs:comment "Chronologically, a castle with its fu
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "castle"@en ,
                                                                              "zamek"@pl ;
                              ontohgis:hasExternalIdentifier "114"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "Castle is a brick, densely built-up, closed, usually complex structure, within which at least some buildings have both defensive and residential functions; built in the Middle Ages or later but then in a form referring to that period."@en ,
+                                                         "Murowane, zwarte, zamknięte, zwykle wieloczłonowe założenie, w którym przynajmniej część budynków pełni funkcje zarazem obronne i rezydencjonalne; powstałe w średniowieczu lub nawiązujące formą do tej epoki."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_114 ;
@@ -16832,8 +17080,6 @@ ontohgis:settlement_type_114 rdfs:comment "Chronologically, a castle with its fu
 
 ontohgis:settlement_type_115 rdfs:comment "Port morski określa funkcję, jako pełni miejscowość, np. Gdynia jest miastem portowym (określenie z Bystrzyckiego), ale „port” (niekoniecznie morski) również może być miejscowością (patrz: Koeniglicher Hafen k. Torunia). Niektóre portowe miasta niemieckie zawierają „port” (niem. „-hafen”) w nazwie własnej (np. Osternothafen dziś: Chorzelin, id prng: 178058)."@pl ,
                                           "Sea harbour defines the function of the locality, e.g. Gdynia is a \"harbour city\" (in Bystrzycki's register), but the \"harbour\" (not necessarily at sea) may also be a locality (see: Koeniglicher Hafen near Toruń). Some harbours in Germany contain a \"harbour\" (German \"-hafen\") suffix in their own name (e.g. Osternothafen today: Chorzelin, id :: prng 178058)."@en ;
-                             ontohgis:isDefinedByLiteral "Port morski to przybrzeżny obszar wodny wraz z infrastrukturą przeznaczony dla obsługi statków."@pl ,
-                                              "Sea harbour is an area consisting of coastal waters together with artificial structures designed for the ship service."@en ;
                              rdfs:label "port morski - obiekt"@pl ,
                                         "sea harbour"@en ;
                              rdfs:seeAlso <http://dbpedia.org/ontology/Port> ,
@@ -16843,10 +17089,8 @@ ontohgis:settlement_type_115 rdfs:comment "Port morski określa funkcję, jako p
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "port morski"@pl ,
                                                                              "sea harbour"@en ;
                              ontohgis:hasExternalIdentifier "115"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 ,
-                                                    ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "Port morski to przybrzeżny obszar wodny wraz z infrastrukturą przeznaczony dla obsługi statków."@pl ,
+                                                         "Sea harbour is an area consisting of coastal waters together with artificial structures designed for the ship service."@en .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_115 ;
@@ -16865,8 +17109,6 @@ ontohgis:settlement_type_115 rdfs:comment "Port morski określa funkcję, jako p
 
 ontohgis:settlement_type_117 rdfs:comment "Although tourist shelter is nowadays classified as a kind of village (PRNG, DBTO10k), it seems that the tourist shelters were not considered localites in the period of our interest. This is due to the lack of this category in Bystrzycki's register, as well as the way of presentation on the maps: without the particular name, only symbol and explanatory abbreviation. Conceptually, this category is similar to shepherd's huts and inns (see: example)."@en ,
                                           "Mimo że dziś figuruje jako rodzaj miejscowości (PRNG, BDOT10k), wydaje się, że schronisko turystyczne nie było w interesującym nas okresie uznawane za miejscowość. Świadczy o tym brak wyróżnienia tej kategorii w spisie Bystrzyckiego, jak również sposób prezentacji na mapach: bez nazwy własnej, jedynie sygnatura i skrótem objaśniającym. Pojęciowo kategoria zbliżona do szałasów pasterskich i karczem (patrz przykład)."@pl ;
-                             ontohgis:isDefinedByLiteral "Schronisko turystyczne to budynek na szlaku turystycznym służący jako miejsce odpoczynku i noclegu dla turystów."@pl ,
-                                              "Tourist shelter is a building on the tourist trail that serves as a place of rest and accommodation for tourists."@en ;
                              rdfs:label "schronisko turystyczne - obiekt"@pl ,
                                         "tourist shelter"@en ;
                              rdfs:seeAlso <http://dbpedia.org/page/Mountain_hut> ,
@@ -16883,9 +17125,8 @@ ontohgis:settlement_type_117 rdfs:comment "Although tourist shelter is nowadays 
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "schronisko turystyczne"@pl ,
                                                                              "tourist shelter"@en ;
                              ontohgis:hasExternalIdentifier "117"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
+                             ontohgis:isDefinedByLiteral "Schronisko turystyczne to budynek na szlaku turystycznym służący jako miejsce odpoczynku i noclegu dla turystów."@pl ,
+                                                         "Tourist shelter is a building on the tourist trail that serves as a place of rest and accommodation for tourists."@en .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_117 ;
@@ -16911,8 +17152,6 @@ ontohgis:settlement_type_117 rdfs:comment "Although tourist shelter is nowadays 
 
 ontohgis:settlement_type_118 rdfs:comment "Functional distinctivness - clearly defined (passenger services).Morphological distinctiveness - on the maps, mostly as a non-scale symbols and an explanatory annotation.Spatial distinctivness - depending on the location of the railway line with the respect of locality, stations are either at a distance (often they have a given name, such as a town and the number of houses) or in the area of the locality (without a proper name, only a symbol and an explanatory annotation).Railway station can be part of a locality (Czekanów) or a separate locality (Chrośnica), then spatially distinct. If the station is located far away from the locality, then on the MGI maps it can be supplemeted by information about number of houses, not just the explanatory annotation (pol \"st.\"). The name of the station is never a proper name name but only the name of the main locality."@en ,
                                           "Odrębność funkcjonalna – jasno określona (obsługa podróżnych).Odrębność morfologiczna – najczęściej na mapach jako znak nieskalowy i podpis objaśniający.Odrębność przestrzenna – w zależności od położenia linii kolejowej względem miejscowości stacje znajdują się albo w oddaleniu (wtedy często mają podaną nazwę, taką jak miejscowość oraz liczbę domów) lub na obszarze miejscowości (bez nazwy; tylko sygnatura i skrót objaśniający).Stacja kolejowa może być częścią miejscowości (Czekanów) albo osobną miejscowością (Chrośnica) wyodrębnioną przestrzennie. Jeżeli stacja leży w oddaleniu od głównej miejscowości (wówczas na mapie WIG ma podaną liczbę domów, a nie tylko skrót objaśniający „st.”). Nazwa stacji nigdy nie jest nazwą własną, a jedynie nazwą głównej miejscowości."@pl ;
-                             ontohgis:isDefinedByLiteral "Stacja kolejowa to obszar, gdzie rozmieszczone są budowle związane z obsługą pasażerów kolei naziemnych."@pl ,
-                                              "The railway station is an area where facilities related to the service of ground railway passengers are located."@en ;
                              rdfs:label "railway station"@en ,
                                         "stacja kolejowa - obiekt"@pl ;
                              rdfs:seeAlso "#BDOT10k, s. 154 – Obszar, na którym rozmieszczone są budowle (budynek stacyjny, magazyny, przechowalnia bagażu, perony, parkingi itp.), związane z obsługą pasażerów kolei naziemnych i przeładunkiem towarów (klasa obiektów: kompleks komunikacyjny)"@pl ,
@@ -16922,9 +17161,8 @@ ontohgis:settlement_type_118 rdfs:comment "Functional distinctivness - clearly d
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "railway station"@en ,
                                                                              "stacja kolejowa"@pl ;
                              ontohgis:hasExternalIdentifier "118"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
+                             ontohgis:isDefinedByLiteral "Stacja kolejowa to obszar, gdzie rozmieszczone są budowle związane z obsługą pasażerów kolei naziemnych."@pl ,
+                                                         "The railway station is an area where facilities related to the service of ground railway passengers are located."@en .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_118 ;
@@ -16936,8 +17174,6 @@ ontohgis:settlement_type_118 rdfs:comment "Functional distinctivness - clearly d
 
 ontohgis:settlement_type_119 rdfs:comment "Functional distinctivness - clearly defined (passenger services).Morphological distinctiveness - most often on topographic maps as a non-scale symbol or an explanatory annotation, usually without a proper name (only an abbreviation).Spatial distinctivness - depending on the location of the railway line with respect to the locality, the stops are either located at a distance (then they often have a proper name, the same as a locality) or within the area of the locality (no particular name, only symbol or an explanatory annotation). A railway station should rather not be treated as a locality, unless in exceptional cases, when all the constitutive conditions of localities are met."@en ,
                                           "Odrębność funkcjonalna – jasno określona (obsługa podróżnych).Odrębność morfologiczna – najczęściej na mapach jako znak nieskalowy obszaru przystanku i podpis objaśniający, przeważnie bez nazwy własnej (jedynie skrót).Odrębność przestrzenna – w zależności od położenia linii kolejowej względem miejscowości przystanki znajdują się albo w oddaleniu (wtedy często mają podaną nazwę, taką jak miejscowość) lub na obszarze miejscowości (bez nazwy; tylko sygnatura i skrót objaśniający). Przystanek kolejowy raczej nie powinien być traktowany jako miejscowość, chyba że w wyjątkowych przypadkach, gdy spełnione są wszystkie warunki konstytutywne miejscowości."@pl ;
-                             ontohgis:isDefinedByLiteral "A train stop is a stopping place for trains enabling travelers to enter or leave the train."@en ,
-                                              "Przystanek kolejowy to miejsce zatrzymywania się pociągów umożliwiające podróżnym wejście lub opuszczenie pociągu."@pl ;
                              rdfs:label "przystanek kolejowy - obiekt"@pl ,
                                         "train stop"@en ;
                              rdfs:seeAlso "#BDOT10k, s. 166 – miejsce zatrzymywania się pociągów, umożliwiające podróżnym wejście lub opuszczenie pociągu (klasa obiektów: obiekt związany z komunikacją)"@pl ,
@@ -16947,9 +17183,8 @@ ontohgis:settlement_type_119 rdfs:comment "Functional distinctivness - clearly d
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "przystanek kolejowy"@pl ,
                                                                              "train stop"@en ;
                              ontohgis:hasExternalIdentifier "119"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
+                             ontohgis:isDefinedByLiteral "A train stop is a stopping place for trains enabling travelers to enter or leave the train."@en ,
+                                                         "Przystanek kolejowy to miejsce zatrzymywania się pociągów umożliwiające podróżnym wejście lub opuszczenie pociągu."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_119 ;
@@ -16961,8 +17196,6 @@ ontohgis:settlement_type_119 rdfs:comment "Functional distinctivness - clearly d
 
 ontohgis:settlement_type_12 rdfs:comment "It is very unusual to classify a sugar factory or refinery as a separate locality, most often it is a part of a locality."@en ,
                                          "W niezwykle rzadkich przypadkach cukrownia może być odrębną miejscowością, zazwyczaj jest częścią miejscowości."@pl ;
-                            ontohgis:isDefinedByLiteral "Cukrownia (miejscowość) jest to osada, w której główną rolę odgrywa cukrownia (obiekt)."@pl ,
-                                             "Sugar rafinery (a locality) is a settlement with a sugar factory or refinery (a factory) as the most important element."@en ;
                             rdfs:label "cukrownia"@pl ,
                                        "sugar factory"@en ;
                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "die Zuckerfabrik"@de ,
@@ -16971,15 +17204,12 @@ ontohgis:settlement_type_12 rdfs:comment "It is very unusual to classify a sugar
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "cukrownia"@pl ,
                                                                             "sugar factory"@en ;
                             ontohgis:hasExternalIdentifier "12" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                            ontohgis:isDefinedByLiteral "Cukrownia (miejscowość) jest to osada, w której główną rolę odgrywa cukrownia (obiekt)."@pl ,
+                                                        "Sugar rafinery (a locality) is a settlement with a sugar factory or refinery (a factory) as the most important element."@en .
 
 
 ontohgis:settlement_type_120 rdfs:comment "A church could be a separate unit (from adjacent settlements) distinguished by a particular name and morphology."@en ,
                                           "W analizowanych przypadkach kościół mógł stanowić odrębną (od sąsiadujących) nazewniczo i morfologicznie jednostkę osadniczą."@pl ;
-                             ontohgis:isDefinedByLiteral "A church (in architecture) is a building used by a religious community to meet and listen to the Word of God, for preaching, private prayers or to celebrate rituals."@en ,
-                                              "Kościół (w kontekście architektonicznym) jest to budynek, gdzie wspólnota religijna gromadzi się na słuchanie słowa Bożego, wspólną lub prywatną modlitwę oraz celebrację sakramentów."@pl ;
                              rdfs:label "church"@en ,
                                         "kościół - obiekt"@pl ;
                              rdfs:seeAlso <http://linkedgeodata.org/ontology/BuildingChurch> ,
@@ -16994,16 +17224,15 @@ ontohgis:settlement_type_120 rdfs:comment "A church could be a separate unit (fr
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "church"@en ,
                                                                              "kościół"@pl ;
                              ontohgis:hasExternalIdentifier "120"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "A church (in architecture) is a building used by a religious community to meet and listen to the Word of God, for preaching, private prayers or to celebrate rituals."@en ,
+                                                         "Kościół (w kontekście architektonicznym) jest to budynek, gdzie wspólnota religijna gromadzi się na słuchanie słowa Bożego, wspólną lub prywatną modlitwę oraz celebrację sakramentów."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_120 ;
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "2. «budynek, miejsce modlitwy chrześcijan»"@pl ;
    ontohgis:isDefinedByIRI ontohgis:document_3 ,
-                    <https://sjp.pwn.pl/sjp/kosciol;2474550.html>
+                           <https://sjp.pwn.pl/sjp/kosciol;2474550.html>
  ] .
 
 [ rdf:type owl:Axiom ;
@@ -17030,8 +17259,6 @@ ontohgis:settlement_type_120 rdfs:comment "A church could be a separate unit (fr
 
 ontohgis:settlement_type_121 rdfs:comment "In each analysed case, a rectory being a separate settlement, lays in a vicinity of a village, or a town/city with the same name. In cartographical sources, one can find it presented separately, with its proper name, an abbreviation of a category (i.e. pol “pleb.”, which is “rect.”), and distinguished by its morphology. A rectory differs slightly from the house of a provost, but we leave this difference aside."@en ,
                                           "We wszystkich analizowanych przypadkach jeżeli plebania jest odrębną miejscowością, to znajduje się w pobliżu wsi, miasta lub osady o tej samej nazwie. W ujęciu kartograficznym wyodrębniona przez nazwę własną, skrót kategorii (np. pleb.) oraz morfologicznie. Plebania różni się nieco od probostwa, gdyż pleban nie jest tożsamy z proboszczem, ale różnicę tę pomijamy."@pl ;
-                             ontohgis:isDefinedByLiteral "A rectory is a house or a group of buildings organised for a home for a provost supervising other priests living with him together with other people responsible for its maintenance."@en ,
-                                              "Plebania jest to dom lub zespół zabudowań przeznaczony do mieszkania dla plebana, podległych mu księży i innych osób zajmujących się jego obsługą."@pl ;
                              rdfs:label "plebania - obiekt"@pl ,
                                         "rectory"@en ;
                              rdfs:seeAlso <http://dbpedia.org/page/Clergy_house> ,
@@ -17056,9 +17283,8 @@ ontohgis:settlement_type_121 rdfs:comment "In each analysed case, a rectory bein
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "plebania"@pl ,
                                                                              "rectory"@en ;
                              ontohgis:hasExternalIdentifier "121"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "A rectory is a house or a group of buildings organised for a home for a provost supervising other priests living with him together with other people responsible for its maintenance."@en ,
+                                                         "Plebania jest to dom lub zespół zabudowań przeznaczony do mieszkania dla plebana, podległych mu księży i innych osób zajmujących się jego obsługą."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_121 ;
@@ -17084,8 +17310,6 @@ ontohgis:settlement_type_121 rdfs:comment "In each analysed case, a rectory bein
 
 ontohgis:settlement_type_122 rdfs:comment "Kryterium wyróżniającym kościół od kaplicy jest wielkość oraz znaczenie instytucjonalne. Kościół ma charakter świątyni głównej dla wspólnoty wiernych, natomiast kaplica ma znaczenie pomocnicze. Niewielkie wspólnoty wiernych mogły funkcjonować przy kaplicy, kiedy z różnych powodów (brak środków, ograniczenia prawne) nie mogły wybudować lub utrzymać kościoła."@pl ,
                                           "The criterion that distinguishes the church from the chapel is its size and institutional significance. The church serves as a main temple for the community, while the chapel's role is rather auxiliary. Small communities could use a chapel, when for various reasons (lack of resources, legal restrictions) they could not build or afford a church."@en ;
-                             ontohgis:isDefinedByLiteral "Chapel is a separate building (small church) or a separate room with an altar in a church or another building, devoted to religious worship (prayer, worship)."@en ,
-                                              "Kaplica jest to odrębny budynek (mały kościół) lub oddzielne pomieszczenie z ołtarzem w kościele lub innym budynku, przeznaczone do sprawowania kultu religijnego (modlitwy, nabożeństwa)."@pl ;
                              rdfs:label "chapel"@en ,
                                         "kaplica - obiekt"@pl ;
                              rdfs:seeAlso <http://linkedgeodata.org/ontology/BuildingChapel> ,
@@ -17100,16 +17324,15 @@ ontohgis:settlement_type_122 rdfs:comment "Kryterium wyróżniającym kościół
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "chapel"@en ,
                                                                              "kaplica"@pl ;
                              ontohgis:hasExternalIdentifier "122"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
+                             ontohgis:isDefinedByLiteral "Chapel is a separate building (small church) or a separate room with an altar in a church or another building, devoted to religious worship (prayer, worship)."@en ,
+                                                         "Kaplica jest to odrębny budynek (mały kościół) lub oddzielne pomieszczenie z ołtarzem w kościele lub innym budynku, przeznaczone do sprawowania kultu religijnego (modlitwy, nabożeństwa)."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_122 ;
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "1. «niewielka budowla sakralna», 2. «oddzielne pomieszczenie z ołtarzem do odprawiania nabożeństw»"@pl ;
    ontohgis:isDefinedByIRI ontohgis:document_3 ,
-                    <https://sjp.pwn.pl/szukaj/kaplica.html>
+                           <https://sjp.pwn.pl/szukaj/kaplica.html>
  ] .
 
 [ rdf:type owl:Axiom ;
@@ -17136,8 +17359,6 @@ ontohgis:settlement_type_122 rdfs:comment "Kryterium wyróżniającym kościół
 
 ontohgis:settlement_type_123 rdfs:comment "In most analysed cases, if the tar pitch was morphologically distinct, it had the same name as the neighbouring village or another locality. Occasionally it had its proper name."@en ,
                                           "W większości analizowanych przypadków, jeżeli smolarnia była odrębna morfologicznie, to miała tę samą nazwę, co sąsiadująca wieś lub inna miejscowość. Sporadycznie cechowała ją odrębność nazewnicza."@pl ;
-                             ontohgis:isDefinedByLiteral "Obiekt lub zespół obiektów gospodarczych zlokalizowanych w lesie lub jego pobliżu, gdzie w procesie prażenia drewna pozyskiwano smołę i inne produkty np. terpentynę, węgiel drzewny."@pl ,
-                                              "Tar pitch is a facility or a complex of industrial facilities located in or near the forest, where tar was sourced in the process of wood roasting, along with other products, e.g. turpentine, charcoal."@en ;
                              rdfs:label "smolarnia - obiekt"@pl ,
                                         "tar pitch"@en ;
                              rdfs:seeAlso "huta smolana, t. 3, s. 519:"@pl ,
@@ -17148,9 +17369,8 @@ ontohgis:settlement_type_123 rdfs:comment "In most analysed cases, if the tar pi
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "smolarnia"@pl ,
                                                                              "tar pitch"@en ;
                              ontohgis:hasExternalIdentifier "123"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
+                             ontohgis:isDefinedByLiteral "Obiekt lub zespół obiektów gospodarczych zlokalizowanych w lesie lub jego pobliżu, gdzie w procesie prażenia drewna pozyskiwano smołę i inne produkty np. terpentynę, węgiel drzewny."@pl ,
+                                                         "Tar pitch is a facility or a complex of industrial facilities located in or near the forest, where tar was sourced in the process of wood roasting, along with other products, e.g. turpentine, charcoal."@en .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_123 ;
@@ -17164,7 +17384,7 @@ ontohgis:settlement_type_123 rdfs:comment "In most analysed cases, if the tar pi
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "prymitywny zakład przemysłowy, gdzie wypraża się z drewna (tzw. karpowin) smołę i otrzymuje terpentynę, spirytus drzewny i inne chemikalia"@pl ;
    ontohgis:isDefinedByIRI ontohgis:document_4 ,
-                    <https://sjp.pwn.pl/doroszewski/smolarnia;5498496.html>
+                           <https://sjp.pwn.pl/doroszewski/smolarnia;5498496.html>
  ] .
 
 [ rdf:type owl:Axiom ;
@@ -17172,14 +17392,12 @@ ontohgis:settlement_type_123 rdfs:comment "In most analysed cases, if the tar pi
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "«dawny zakład, w którym się wyprażało z drewna smołę»"@pl ;
    ontohgis:isDefinedByIRI ontohgis:document_3 ,
-                    <https://sjp.pwn.pl/sjp/smolarnia;2522097.html>
+                           <https://sjp.pwn.pl/sjp/smolarnia;2522097.html>
  ] .
 
 
 ontohgis:settlement_type_124 rdfs:comment "Inns (localities) are distinguished on the old maps, which is mainly the result of their function. In the historiography, inns are distinguished from \"zajazd\" and \"gościniec\".The former usually served local customers - residents of the village or city, whereas the latter was supposed to serve supra-regional traffic. On the maps, inns are also distinguished by their proper names - e.g. Wygoda or Ostatni Grosz."@en ,
                                           "Karczmy wyróżniane są na dawnej kartografii, co wynika głównie z pełnionej przez nie funkcji. Warto jednak pamiętać o tym, że w historiografii rozróżnia się pojęcie karczmy oraz zajazdu lub gościńca. Pierwszy obiekt zazwyczaj miał na celu obsługę lokalnych klientów – mieszkańców wsi lub miasta, drugi zaś miał obsługiwać ruch ponadregionalny. Na mapach karczmy wyróżniają także specyficzne nazwy – np. Wygoda lub Ostatni Grosz."@pl ;
-                             ontohgis:isDefinedByLiteral "Budynek służący celom gastronomiczno-hotelarskim, zlokalizowany na przedmieściach miast, obrzeżach wsi lub ważnych szlakach komunikacyjnych."@pl ,
-                                              "Inn is a building serving catering and accomodation purposes, located in the suburbs, outskirts of villages, or on important communication routes."@en ;
                              rdfs:label "inn"@en ,
                                         "karczma - obiekt"@pl ;
                              rdfs:seeAlso <http://dbpedia.org/page/Inn> ,
@@ -17207,9 +17425,8 @@ t. 8, s. 106 hasło zajazd, gdzie ‘dom zajezdny, gospoda, austerja, karczma, d
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "inn"@en ,
                                                                              "karczma"@pl ;
                              ontohgis:hasExternalIdentifier "124"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
+                             ontohgis:isDefinedByLiteral "Budynek służący celom gastronomiczno-hotelarskim, zlokalizowany na przedmieściach miast, obrzeżach wsi lub ważnych szlakach komunikacyjnych."@pl ,
+                                                         "Inn is a building serving catering and accomodation purposes, located in the suburbs, outskirts of villages, or on important communication routes."@en .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_124 ;
@@ -17256,9 +17473,7 @@ t. 8, s. 106 hasło zajazd, gdzie ‘dom zajezdny, gospoda, austerja, karczma, d
  ] .
 
 
-ontohgis:settlement_type_125 ontohgis:isDefinedByLiteral "Ironworks (locality) is a settlement, where the main role is played by an ironworks, an industrial facility."@en ,
-                                              "Osada kuźnicza jest to osada, w której główną rolę pełni kuźnica jako obiekt gospodarczy."@pl ;
-                             rdfs:label "ironworks"@en ,
+ontohgis:settlement_type_125 rdfs:label "ironworks"@en ,
                                         "osada kuźnicza"@pl ;
                              <http://www.w3.org/2004/02/skos/core#altLabel> "Hammer (de), minera (lat), ruda (pl), Hütte (de), Ofen (de), Schmelze (de)" ;
                              <http://www.w3.org/2004/02/skos/core#hiddenLabel> "kuźnica"@pl ,
@@ -17266,14 +17481,11 @@ ontohgis:settlement_type_125 ontohgis:isDefinedByLiteral "Ironworks (locality) i
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "ironworks"@en ,
                                                                              "osada kuźnicza"@pl ;
                              ontohgis:hasExternalIdentifier "125"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "Ironworks (locality) is a settlement, where the main role is played by an ironworks, an industrial facility."@en ,
+                                                         "Osada kuźnicza jest to osada, w której główną rolę pełni kuźnica jako obiekt gospodarczy."@pl .
 
 
-ontohgis:settlement_type_126 ontohgis:isDefinedByLiteral "Ironworks is a cluster of manufacturing workshops, the main puprpose of which is to melt and manufacture iron."@en ,
-                                              "Zespół warsztatów przemysłowych, których głównym zadaniem jest przetop i obróbka żelaza."@pl ;
-                             rdfs:label "ironworks"@en ,
+ontohgis:settlement_type_126 rdfs:label "ironworks"@en ,
                                         "kuźnica - obiekt"@pl ;
                              rdfs:seeAlso "#Zientara B., Dzieje małopolskiego hutnictwa żelaznego, Warszaw 1954, s. 64‘zespół połączonych warsztatów – dymarki, młotów, kowalichy (piec kowalski i urządzenia służące do produkcji różnych przedmiotów z żelaza)’#Praktyczny słownik współczesnej polszczyzny, red. H. Zgłówkowa, t. 18, s. 369‘dawny typ zakładu hutniczego, w którym żelazo z rud wytapiano za pomocą dymarki i młota napędzanego kołem wodnym’ – dodatkowo inf., że „kuźnice zostały wyparte przez zakłady stosujące procesy wielkopiecowe”#Encyklopedia historii gospodarczej Polski do 1945 r., t. 1, red. A. Mączak:‘w XIII–XVIII w. zespół warsztatów zakładu hutniczego, składający się w zasadzie z dymarki, młota mechanicznego i pieca kowalskiego (kowalichy), niekiedy także ze stęp do drobienia rudy; wszystkie te warsztaty (czasem podwójne) poruszane były energią wodną, uzyskiwaną dzięki budowie zapór na niewielkich rzeczkach. Hamrem (hamernią) zwano wchodzący w skład każdej kuźnicy warsztat obróbki metali, którego głównym urządzeniem był młot mechaniczny z kowadłem; niekiedy jednak przez hamer rozumiano całą kuźnicę. Upowszechnione w Polsce od przełomu XIII/XIV w., stanowiły kuźnice do XVIII w. dominujący typ zakładu hutniczego, tworzącego jednocześnie odrębne przedsiębiorstwo prowadzone przez kuźnika [...]”. Autor hasła B. Zientara"@pl ,
                                           "t. 11, s. 598: ‘zakład przetapiający i obrabiający żelazo’, ‘warsztat kowalski; miejsce, gdzie się kuje’"@pl ,
@@ -17286,9 +17498,8 @@ ontohgis:settlement_type_126 ontohgis:isDefinedByLiteral "Ironworks is a cluster
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "ironworks"@en ,
                                                                              "kuźnica"@pl ;
                              ontohgis:hasExternalIdentifier "126"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "Ironworks is a cluster of manufacturing workshops, the main puprpose of which is to melt and manufacture iron."@en ,
+                                                         "Zespół warsztatów przemysłowych, których głównym zadaniem jest przetop i obróbka żelaza."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_126 ;
@@ -17328,8 +17539,6 @@ ontohgis:settlement_type_126 ontohgis:isDefinedByLiteral "Ironworks is a cluster
 
 ontohgis:settlement_type_127 rdfs:comment "Glasswork settlement (ger Hütte) was considered a separate locality, which emerged as consequence of a process in which common names (i.e. huta) gained new meaning, associated with a particular locality. Glasswork settlements were temporary settlements, very often, these were very unstable. When all local resources became exhausted (i.e. woods, sand, limestone), these settlements were moved into a new place. The result was frequent disappearing of glasswork settlements."@en ,
                                           "Odrębność osadnicza osady hutniczej (od ger Hütte) wynika przede wszystkim z procesu onimizacji, czyli przekształcania nazwy pospolitej (huta) w nazwę własną. Osady hutnicze były często osadami czasowymi, tzn. cechowały się dużą mobilnością. Po wyczerpaniu się pobliskich surowców (drewno, piasek, wapień) przenoszone były w inne miejsca. W związku z tym były to osady zanikające z krajobrazu osadniczego."@pl ;
-                             ontohgis:isDefinedByLiteral "Glassworks is a settlement in which the most importan role is played by a glassworks (considered as an factory building)."@en ,
-                                              "Osada hutnicza jest to osada, w której główną rolę pełni huta jako obiekt gospodarczy."@pl ;
                              rdfs:label "glassworks"@en ,
                                         "osada hutnicza"@pl ;
                              <http://www.w3.org/2004/02/skos/core#altLabel> "Hütte (de), Ofen (de), Schmelze (de), Hammer (de)" ;
@@ -17338,15 +17547,12 @@ ontohgis:settlement_type_127 rdfs:comment "Glasswork settlement (ger Hütte) was
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "glassworks"@en ,
                                                                              "osada hutnicza"@pl ;
                              ontohgis:hasExternalIdentifier "127"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "Glassworks is a settlement in which the most importan role is played by a glassworks (considered as an factory building)."@en ,
+                                                         "Osada hutnicza jest to osada, w której główną rolę pełni huta jako obiekt gospodarczy."@pl .
 
 
 ontohgis:settlement_type_128 rdfs:comment "Legal status - ownership diveded between a land lord and a hereditary tenant or an annual tenant."@en ,
                                           "Status prawny - własność podzielona między pana gruntowego a dzierżawcę dziedzicznego lub dzierżawcę rocznego."@pl ;
-                             ontohgis:isDefinedByLiteral "Glassworks is an industrial facility, where major production was glasswork, and later mainly casting and manufacturing metals, e.g. lead, zinc, iron."@en ,
-                                              "Zakład przemysłowy, którego głównym celem była produkcja szkła, a w późniejszym okresie wytop i przetwórstwo rud metali np. ołowiu, cynku, żelaza."@pl ;
                              rdfs:label "glassworks"@en ,
                                         "huta - obiekt"@pl ;
                              rdfs:seeAlso "#J. Olczak, Późnośrednowieczne i nowożytne hutnictwo szkła w Polsce w perspektywie źródeł archeologicznych, „Archeologia Historia Polona”, t.1, 1995, s. 79-86#Wyrobisz A., Szkło w Polsce od XIV do XVII w., Warszawa 1968"@pl ,
@@ -17358,9 +17564,8 @@ ontohgis:settlement_type_128 rdfs:comment "Legal status - ownership diveded betw
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "glassworks"@en ,
                                                                              "huta"@pl ;
                              ontohgis:hasExternalIdentifier "128"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "Glassworks is an industrial facility, where major production was glasswork, and later mainly casting and manufacturing metals, e.g. lead, zinc, iron."@en ,
+                                                         "Zakład przemysłowy, którego głównym celem była produkcja szkła, a w późniejszym okresie wytop i przetwórstwo rud metali np. ołowiu, cynku, żelaza."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_128 ;
@@ -17386,8 +17591,6 @@ ontohgis:settlement_type_128 rdfs:comment "Legal status - ownership diveded betw
 
 ontohgis:settlement_type_129 rdfs:comment "Morphological distinctiveness - usually clear (location in the forest), but there are lodges located in the immediate vicinity of some other localities. Naming distinctiveness - clear from the second half of the 19th c. (previously forester's lodges had no proper names, later not always). Functional distinctiveness - the forester's lodge plays a role in the economy and forest administration."@en ,
                                           "Odrębność morfologiczna – przeważnie wyraźna (położenie w lesie), ale zdarzają się leśniczówki położone w bezpośrednim sąsiedztwie innych miejscowości. Odrębność nazewnicza – od drugiej połowy XIX wieku (wcześniej bez nazw; później nie zawsze). Odrębność funkcjonalna – leśniczówka pełni rolę związaną z gospodarką i administracją leśną."@pl ;
-                             ontohgis:isDefinedByLiteral "Forester's lodge is an area where there is a complex of buildings including a house in which a forester lives, which is the seat of the Forest District's authorities, located in a forest area. Apart from forest management, forester's lodge performs residential functions. Forester's lodge is a locality as long as it has a proper name and is not in the vicinity of another locality."@en ,
-                                              "Leśniczówka (obiekt) to obszar, na którym znajduje się zespół zabudowań obejmujący dom, w którym mieszka leśniczy, stanowiący siedzibę leśnictwa, znajdujący się na terenie leśnym, pełniący oprócz mieszkalnych funkcje związane z gospodarką leśną. Leśniczówka jest miejscowością o ile posiada nazwę własną i nie znajduje się w bezpośrednim sąsiedztwie innej miejscowości."@pl ;
                              rdfs:label "forester's lodge"@en ,
                                         "leśniczówka - obiekt"@pl ;
                              rdfs:seeAlso <http://gov.genealogy.net/types.owl#102> ,
@@ -17406,9 +17609,8 @@ ontohgis:settlement_type_129 rdfs:comment "Morphological distinctiveness - usual
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "forester's lodge"@en ,
                                                                              "leśniczówka"@pl ;
                              ontohgis:hasExternalIdentifier "129"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
+                             ontohgis:isDefinedByLiteral "Forester's lodge is an area where there is a complex of buildings including a house in which a forester lives, which is the seat of the Forest District's authorities, located in a forest area. Apart from forest management, forester's lodge performs residential functions. Forester's lodge is a locality as long as it has a proper name and is not in the vicinity of another locality."@en ,
+                                                         "Leśniczówka (obiekt) to obszar, na którym znajduje się zespół zabudowań obejmujący dom, w którym mieszka leśniczy, stanowiący siedzibę leśnictwa, znajdujący się na terenie leśnym, pełniący oprócz mieszkalnych funkcje związane z gospodarką leśną. Leśniczówka jest miejscowością o ile posiada nazwę własną i nie znajduje się w bezpośrednim sąsiedztwie innej miejscowości."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_129 ;
@@ -17434,8 +17636,6 @@ ontohgis:settlement_type_129 rdfs:comment "Morphological distinctiveness - usual
 
 ontohgis:settlement_type_130 rdfs:comment "Morphological distinctiveness - usually clear (location in the forest), but there are lodges located in the immediate vicinity of some other localities.Naming distinctiveness - clear from the second half of the 19th century (previously forester's lodges had no proper names, later not always).Functional distinctiveness - the forester's lodge plays a role in the economy and forest administration."@en ,
                                           "Odrębność morfologiczna – przeważnie wyraźna (położenie w lesie), ale zdarzają się gajówki położone w bezpośrednim sąsiedztwie innych miejscowości.Odrębność nazewnicza – od drugiej połowy XIX wieku (wcześniej bez nazw; później nie zawsze). Odrębność funkcjonalna – gajówka pełni rolę związaną z gospodarką leśną."@pl ;
-                             ontohgis:isDefinedByLiteral "Forest-guard's lodge is an area comprising a set of buildings including a house in which a forest-guard lives, located in a forest area, performing residential as well as forest management functions. Forest-guard's lodge is a locality as long as it has its own name and is not located in the immediate vicinity of another locality."@en ,
-                                              "Gajówka to obszar na którym znajduje się zespół zabudowań obejmujący dom, w którym mieszka gajowy, znajdujący się na terenie leśnym, pełniący oprócz mieszkalnych funkcje związane z gospodarką leśną. Gajówka jest miejscowością o ile posiada nazwę własną i nie znajduje się w bezpośrednim sąsiedztwie innej miejscowości."@pl ;
                              rdfs:label "forest-guard's lodge"@en ,
                                         "gajówka - obiekt"@pl ;
                              rdfs:seeAlso <http://vocab.getty.edu/aat/300250342> ,
@@ -17453,9 +17653,8 @@ ontohgis:settlement_type_130 rdfs:comment "Morphological distinctiveness - usual
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "forest-guard's lodge"@en ,
                                                                              "gajówka"@pl ;
                              ontohgis:hasExternalIdentifier "130"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
+                             ontohgis:isDefinedByLiteral "Forest-guard's lodge is an area comprising a set of buildings including a house in which a forest-guard lives, located in a forest area, performing residential as well as forest management functions. Forest-guard's lodge is a locality as long as it has its own name and is not located in the immediate vicinity of another locality."@en ,
+                                                         "Gajówka to obszar na którym znajduje się zespół zabudowań obejmujący dom, w którym mieszka gajowy, znajdujący się na terenie leśnym, pełniący oprócz mieszkalnych funkcje związane z gospodarką leśną. Gajówka jest miejscowością o ile posiada nazwę własną i nie znajduje się w bezpośrednim sąsiedztwie innej miejscowości."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_130 ;
@@ -17483,8 +17682,6 @@ ontohgis:settlement_type_131 rdfs:comment """Functional distinctivness - disting
 Morphological and spatial distinctivness - usually a lightouse is a building (structure) within the area of the locality or in its vicinity. 
 If it has its a particular (proper) name, it can be treated as a separate locality (interpretation of maps is necessary, see: Rozewie). Otherwise it is either part of another locality or an object (building/structure) in it (see: Hel, Jastarnia)."""@en ,
                                           "Odrębność funkcjonalna – wyróżniana jako rodzaj miejscowości u Bystrzyckiego, a na mapach topograficznych odrębnym znakiem, niekiedy z nazwą własną. Odrębność morfologiczna/przestrzenna – przeważnie jest obiektem na obszarze miejscowości lub w niewielkim od niej oddaleniu. Jeżeli posiada nazwę własną może być traktowana jako osobna miejscowość (konieczna interpretacja map; patrz: Rozewie). W przeciwnym razie jest albo częścią innej, większej miejscowości lub obiektem terenowym (budowlą) w niej (patrz: Hel, Jastarnia)."@pl ;
-                             ontohgis:isDefinedByLiteral "A lighthouse (a facility) is a building, usually a high tower with a beacon light to guide ships."@en ,
-                                              "Latarnia morska (obiekt) to budowla, najczęściej wysoka wieża służąca jako punkt orientacyjny dla statków."@pl ;
                              rdfs:label "latarnia morska - obiekt"@pl ,
                                         "lighthouse"@en ;
                              rdfs:seeAlso <http://dbpedia.org/ontology/Lighthouse> ,
@@ -17496,10 +17693,8 @@ If it has its a particular (proper) name, it can be treated as a separate locali
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "latarnia morska"@pl ,
                                                                              "lighthouse"@en ;
                              ontohgis:hasExternalIdentifier "131"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 ,
-                                                    ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "A lighthouse (a facility) is a building, usually a high tower with a beacon light to guide ships."@en ,
+                                                         "Latarnia morska (obiekt) to budowla, najczęściej wysoka wieża służąca jako punkt orientacyjny dla statków."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_131 ;
@@ -17511,8 +17706,6 @@ If it has its a particular (proper) name, it can be treated as a separate locali
 
 ontohgis:settlement_type_132 rdfs:comment "In the analysed cases, the monastery could have been a locality which was separate in terms of name and mophology from the neighbouring ones. The monastery could have been a beginning (a stem) of a larger locality, which would develop around it and transform into a monastery settlement, village, city etc."@en ,
                                           "W analizowanych przypadkach klasztor mógł stanowić całkowicie odrębną (od sąsiadujących) nazewniczo i morfologicznie miejscowość. Klasztor mógł stanowić zalążek większej miejscowości, która rozwinęła się wokół niego i przekształciła się w osadę klasztorną, wieś, miasto etc."@pl ;
-                             ontohgis:isDefinedByLiteral "Klasztor jest to budynek lub zespół budynków przeznaczony do mieszkania dla zakonników lub zakonnic."@pl ,
-                                              "Monastery is a building or a group of buildings where monks and nuns live"@en ;
                              rdfs:label "klasztor - obiekt"@pl ,
                                         "monastery"@en ;
                              rdfs:seeAlso <http://dbpedia.org/ontology/Monastery> ,
@@ -17534,16 +17727,15 @@ ontohgis:settlement_type_132 rdfs:comment "In the analysed cases, the monastery 
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "klasztor"@pl ,
                                                                              "monastery"@en ;
                              ontohgis:hasExternalIdentifier "132"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
+                             ontohgis:isDefinedByLiteral "Klasztor jest to budynek lub zespół budynków przeznaczony do mieszkania dla zakonników lub zakonnic."@pl ,
+                                                         "Monastery is a building or a group of buildings where monks and nuns live"@en .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_132 ;
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "1. budynek lub kompleks budynków stanowiących wspólne miejsce zamieszkiwania zakonnic lub zakonników; 2. wspólnota zakonna o określonej regule"@pl ;
    ontohgis:isDefinedByIRI ontohgis:document_3 ,
-                    <https://sjp.pwn.pl/slowniki/klasztor.html>
+                           <https://sjp.pwn.pl/slowniki/klasztor.html>
  ] .
 
 [ rdf:type owl:Axiom ;
@@ -17584,8 +17776,6 @@ ontohgis:settlement_type_132 rdfs:comment "In the analysed cases, the monastery 
 
 ontohgis:settlement_type_133 rdfs:comment "In most analysed cases, if the sawmill was morphologically distinct, it had the same name as the neighboring village or another locality, such as: forester's lodge. Occasionally it had its particular name."@en ,
                                           "W większości analizowanych przypadków, jeżeli tartak był odrębny morfologicznie, to miał tę samą nazwę, co sąsiadująca wieś lub inna miejscowość, np. leśniczówka. Sporadycznie cechowała go odrębność nazewnicza."@pl ;
-                             ontohgis:isDefinedByLiteral "Obiekt lub zespół obiektów gospodarczych często zlokalizowanych w lesie lub jego pobliżu, gdzie dokonuje się przerobu drewna okrągłego na tarcicę w procesie przecierania (tarcia)."@pl ,
-                                              "Sawmill is an industrial facility often located within or near the forest, where wood is processed into sawn timber in the wiping process."@en ;
                              rdfs:label "sawmill"@en ,
                                         "tartak - obiekt"@pl ;
                              rdfs:seeAlso "#Orgelbrand, t. 14, s. 412: pilarnia, machina do piłowania drzewa, której główną częścią składową jest piła, poruszana siłą wody lub pary. Tartaki istnieją już od wieku XIV, a obecnie stanowią machiny niekiedy bardzo zawiłe, które robotę wykonywają szybko i dokładnie"@pl ,
@@ -17598,9 +17788,8 @@ ontohgis:settlement_type_133 rdfs:comment "In most analysed cases, if the sawmil
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "sawmill"@en ,
                                                                              "tartak"@pl ;
                              ontohgis:hasExternalIdentifier "133"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
+                             ontohgis:isDefinedByLiteral "Obiekt lub zespół obiektów gospodarczych często zlokalizowanych w lesie lub jego pobliżu, gdzie dokonuje się przerobu drewna okrągłego na tarcicę w procesie przecierania (tarcia)."@pl ,
+                                                         "Sawmill is an industrial facility often located within or near the forest, where wood is processed into sawn timber in the wiping process."@en .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_133 ;
@@ -17621,7 +17810,7 @@ ontohgis:settlement_type_133 rdfs:comment "In most analysed cases, if the sawmil
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "zakład przemysłowy zajmujący się przecieraniem drewna na tarcicę"@pl ;
    ontohgis:isDefinedByIRI ontohgis:document_4 ,
-                    <https://sjp.pwn.pl/doroszewski/tartak;5506829.html>
+                           <https://sjp.pwn.pl/doroszewski/tartak;5506829.html>
  ] .
 
 [ rdf:type owl:Axiom ;
@@ -17629,14 +17818,12 @@ ontohgis:settlement_type_133 rdfs:comment "In most analysed cases, if the sawmil
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "«zakład zajmujący się rozpiłowywaniem kłód na tarcicę oraz przerobem tarcicy na różne elementy»"@pl ;
    ontohgis:isDefinedByIRI ontohgis:document_3 ,
-                    <https://sjp.pwn.pl/sjp/tartak;2528864.html>
+                           <https://sjp.pwn.pl/sjp/tartak;2528864.html>
  ] .
 
 
 ontohgis:settlement_type_134 rdfs:comment "In all the analysed cases, in Bystrzycki's register, peat mines had the same names as the locality nearby: village and peat mine, manor and peat mine."@en ,
                                           "We wszystkich analizowanych przypadkach z tzw. skorowidza Bystrzyckiego z 1931 r. torfiarnie posiadały takie same nazwy jak osada lub osady leżąca obok niej (wieś i torfiarnia, folwark i torfiarnia)."@pl ;
-                             ontohgis:isDefinedByLiteral "Peat mine is a mine where a peat is mined"@en ,
-                                              "Torfiarnia (obiekt) jest to kopalnia torfu."@pl ;
                              rdfs:label "peat mine"@en ,
                                         "torfiarnia - obiekt"@pl ;
                              rdfs:seeAlso "kopalnia torfu"@pl ,
@@ -17645,16 +17832,15 @@ ontohgis:settlement_type_134 rdfs:comment "In all the analysed cases, in Bystrzy
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "peat mine"@en ,
                                                                              "torfiarnia"@pl ;
                              ontohgis:hasExternalIdentifier "134"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_5 .
+                             ontohgis:isDefinedByLiteral "Peat mine is a mine where a peat is mined"@en ,
+                                                         "Torfiarnia (obiekt) jest to kopalnia torfu."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_134 ;
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "kopalnia torfu"@pl ;
    ontohgis:isDefinedByIRI ontohgis:document_4 ,
-                    <https://sjp.pwn.pl/doroszewski/torfiarnia>
+                           <https://sjp.pwn.pl/doroszewski/torfiarnia>
  ] .
 
 [ rdf:type owl:Axiom ;
@@ -17667,8 +17853,6 @@ ontohgis:settlement_type_134 rdfs:comment "In all the analysed cases, in Bystrzy
 
 ontohgis:settlement_type_135 rdfs:comment "At the very beginning, breweries had been situated only within bigger settlement unit and had not had an individual name. Some of these had only a name corresponding to the owner's name, which was frequently changed. Subsequently, particular names were assigned to breweries; often in the form of trademarks, however the process of integrating the breweries under one trademark originated relatively early/ quickly. One may not find a difference between brewery and distillery in historical sources."@en ,
                                           "Browary początkowo mieściły się wyłącznie w obrębie większych jednostek osadniczych i nie miały własnej nazwy, ew. nazwę wywiedzioną od nazwiska właściciela, często zmienianą. Z czasem browary zaczęły mieć własne nazwy, często w postaci znaków handlowych, jednakże dość szybko zaczął się proces łączenia się browarów pod wspólną nazwą. Źródłowo zdarza się brak rozróżnienia gorzelni i browaru."@pl ;
-                             ontohgis:isDefinedByLiteral "Brewery is a factory producing beer, as well as a complex of buildings established for production and accomodation for factory workers."@en ,
-                                              "Browar jest to zakład wytwarzający piwo jak również zespół budynków przeznaczonych na cele produkcyjne i mieszkalne dla obsługi zakladu."@pl ;
                              rdfs:label "brewery"@en ,
                                         "browar - obiekt"@pl ;
                              rdfs:seeAlso <http://dbpedia.org/ontology/Brewery> ,
@@ -17689,9 +17873,8 @@ ontohgis:settlement_type_135 rdfs:comment "At the very beginning, breweries had 
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "brewery"@en ,
                                                                              "browar - obiekt"@pl ;
                              ontohgis:hasExternalIdentifier "135"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "Brewery is a factory producing beer, as well as a complex of buildings established for production and accomodation for factory workers."@en ,
+                                                         "Browar jest to zakład wytwarzający piwo jak również zespół budynków przeznaczonych na cele produkcyjne i mieszkalne dla obsługi zakladu."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_135 ;
@@ -17712,7 +17895,7 @@ ontohgis:settlement_type_135 rdfs:comment "At the very beginning, breweries had 
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "zakład produkujący piwo"@pl ;
    ontohgis:isDefinedByIRI <http://sjp.pwn.pl/slowniki/browar.html> ,
-                    ontohgis:document_3
+                           ontohgis:document_3
  ] .
 
 [ rdf:type owl:Axiom ;
@@ -17725,8 +17908,6 @@ ontohgis:settlement_type_135 rdfs:comment "At the very beginning, breweries had 
 
 ontohgis:settlement_type_136 rdfs:comment "In each case analysed, a brickyard with a particular name has been located near a village, a city or a town, or a settlement with the same name. If it was an integral part of a superior locality, it had not been given a proper name. (One should remember that exporting produced goods outside the area of production was difficult)."@en ,
                                           "We wszystkich analizowanych przypadkach jeżeli cegielnia jest odrębną miejscowością, to znajduje się w pobliżu wsi, miasta lub osady o tej samej nazwie. Jeśli znajduje się w obrębie większej miejscowości to dość długo nie ma nazwy własnej. (Trudności w eksporcie towaru poza miejsce wyrobu.)"@pl ;
-                             ontohgis:isDefinedByLiteral "Brickyard is a factory where bricks and other ceramic building materials and elements are being produced together with a complex of buildings established for production and houses for factory workers."@en ,
-                                              "Cegielnia jest to zakład wytwarzający cegły oraz ew. inne ceramiczne elementy budowlane jak również zespół budynków przeznaczonych na cele produkcyjne i mieszkalne dla obsługi zakładu."@pl ;
                              rdfs:label "brickyard"@en ,
                                         "cegielnia - obiekt"@pl ;
                              rdfs:seeAlso <http://vocab.getty.edu/aat/300006278> ,
@@ -17742,9 +17923,8 @@ ontohgis:settlement_type_136 rdfs:comment "In each case analysed, a brickyard wi
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "brickyard"@en ,
                                                                              "cegielnia"@pl ;
                              ontohgis:hasExternalIdentifier "136"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "Brickyard is a factory where bricks and other ceramic building materials and elements are being produced together with a complex of buildings established for production and houses for factory workers."@en ,
+                                                         "Cegielnia jest to zakład wytwarzający cegły oraz ew. inne ceramiczne elementy budowlane jak również zespół budynków przeznaczonych na cele produkcyjne i mieszkalne dla obsługi zakładu."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_136 ;
@@ -17772,14 +17952,12 @@ ontohgis:settlement_type_136 rdfs:comment "In each case analysed, a brickyard wi
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "wytwórnia cegły oraz innych materiałów budowlanych z gliny"@pl ;
    ontohgis:isDefinedByIRI <http://sjp.pwn.pl/sjp/cegielnia.html> ,
-                    ontohgis:document_3
+                           ontohgis:document_3
  ] .
 
 
 ontohgis:settlement_type_137 rdfs:comment "Mines presented on majority of analysed maps had their individual symbol."@en ,
                                           "Na wszystkich badanych mapach kopalnie miały własny znak umowny."@pl ;
-                             ontohgis:isDefinedByLiteral "A mine is a factory extracting minerals from the earth. It may be connected with a settlement, it may be inhabited by the personnel."@en ,
-                                              "Kopalnia jest to zakład wydobywający z ziemi kopaliny. Może być połączony z osadą, miewa stale zamieszkujący personel."@pl ;
                              rdfs:label "kopalnia - obiekt"@pl ,
                                         "mine"@en ;
                              rdfs:seeAlso <http://dbpedia.org/ontology/Mine> ,
@@ -17800,9 +17978,8 @@ ontohgis:settlement_type_137 rdfs:comment "Mines presented on majority of analys
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "kopalnia"@pl ,
                                                                              "mine"@en ;
                              ontohgis:hasExternalIdentifier "137"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "A mine is a factory extracting minerals from the earth. It may be connected with a settlement, it may be inhabited by the personnel."@en ,
+                                                         "Kopalnia jest to zakład wydobywający z ziemi kopaliny. Może być połączony z osadą, miewa stale zamieszkujący personel."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_137 ;
@@ -17823,7 +18000,7 @@ ontohgis:settlement_type_137 rdfs:comment "Mines presented on majority of analys
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "zakład górniczy zajmujący się wydobywaniem z ziemi kopalin"@pl ;
    ontohgis:isDefinedByIRI ontohgis:document_3 ,
-                    <https://sjp.pwn.pl/sjp/kopalnia;2473819.html>
+                           <https://sjp.pwn.pl/sjp/kopalnia;2473819.html>
  ] .
 
 [ rdf:type owl:Axiom ;
@@ -17836,8 +18013,6 @@ ontohgis:settlement_type_137 rdfs:comment "Mines presented on majority of analys
 
 ontohgis:settlement_type_138 rdfs:comment "Cukrownia może mieć własną nazwę, najczęściej powiązaną z nazwą firmy lub znakiem firmowym, ale nie musi. Rzadko zaznaczana na mapach."@pl ,
                                           "Sugar factory or refinery may have its own name - usually related to the factory name or a trademark - however it is not nocessary. Very seldom, it has been indicated on maps."@en ;
-                             ontohgis:isDefinedByLiteral "A sugar factory or refinery is a factory producing sugar, as well as a complex of buildings established for production and accomodation for factory workers."@en ,
-                                              "Cukrownia jest to zakład wytwarzający cukier jak również zespół budynków przeznaczonych na cele produkcyjne i mieszkalne dla obsługi zakładu."@pl ;
                              rdfs:label "cukrownia - obiekt"@pl ,
                                         "sugar factory"@en ;
                              rdfs:seeAlso "fabryka cukru"@pl ,
@@ -17848,9 +18023,8 @@ ontohgis:settlement_type_138 rdfs:comment "Cukrownia może mieć własną nazwę
                                                                              "sugar factory"@en ;
                              ontohgis:hasExternalIdentifier "138"^^xsd:int ,
                                                             "138" ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "A sugar factory or refinery is a factory producing sugar, as well as a complex of buildings established for production and accomodation for factory workers."@en ,
+                                                         "Cukrownia jest to zakład wytwarzający cukier jak również zespół budynków przeznaczonych na cele produkcyjne i mieszkalne dla obsługi zakładu."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_138 ;
@@ -17871,14 +18045,12 @@ ontohgis:settlement_type_138 rdfs:comment "Cukrownia może mieć własną nazwę
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "zakład przemysłowy produkujący cukier"@pl ;
    ontohgis:isDefinedByIRI <http://sjp.pwn.pl/sjp/cukrownia.html> ,
-                    ontohgis:document_3
+                           ontohgis:document_3
  ] .
 
 
 ontohgis:settlement_type_139 rdfs:comment "Distillery may have its own name - usually related to the factory name or a trademark - however it is not nocessary. As a separate locality, it may - however it is not obligatory - be located near a village, a city or a town, or a settlement sharing the same name. One may not find a difference between brewery and distillery in historical sources."@en ,
                                           "Gorzelnie znajdujące się w obrębie miast mogą, ale nie muszą mieć własnej nazwy, zazwyczaj nazwa ta powiązana jest z nazwą firmy, znakiem firmowym. Jeśli jest odrębną miejscowością to może ale nie musi znajdować się w pobliżu wsi, miasta lub osady o tej samej nazwie. Źródłowo zdarza się brak rozróżnienia gorzelni i browaru."@pl ;
-                             ontohgis:isDefinedByLiteral "Distillery is a factory where alcohol and spirits requiring distillation whilst manufacturing are produced."@en ,
-                                              "Gorzelnia jest to zakład wytwarzający spirytus oraz napoje alkoholowe o wysokiej zawartości alkoholu, wymagające w trakcie procesu produkcyjnego destylacji."@pl ;
                              rdfs:label "distillery"@en ,
                                         "gorzelnia - obiekt"@pl ;
                              rdfs:seeAlso <http://vocab.getty.edu/aat/300006346> ,
@@ -17897,9 +18069,8 @@ ontohgis:settlement_type_139 rdfs:comment "Distillery may have its own name - us
                              <http://www.w3.org/2004/02/skos/core#prefLabel> "distillery"@en ,
                                                                              "gorzelnia"@pl ;
                              ontohgis:hasExternalIdentifier "139"^^xsd:int ;
-                             ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                             ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                             ontohgis:hasTranslator ontohgis:person_9 .
+                             ontohgis:isDefinedByLiteral "Distillery is a factory where alcohol and spirits requiring distillation whilst manufacturing are produced."@en ,
+                                                         "Gorzelnia jest to zakład wytwarzający spirytus oraz napoje alkoholowe o wysokiej zawartości alkoholu, wymagające w trakcie procesu produkcyjnego destylacji."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_139 ;
@@ -17913,7 +18084,7 @@ ontohgis:settlement_type_139 rdfs:comment "Distillery may have its own name - us
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "zakład przemysłowy produkujący alkohol etylowy"@pl ;
    ontohgis:isDefinedByIRI <http://sjp.pwn.pl/slowniki/gorzelnia.html> ,
-                    ontohgis:document_3
+                           ontohgis:document_3
  ] .
 
 [ rdf:type owl:Axiom ;
@@ -17926,8 +18097,6 @@ ontohgis:settlement_type_139 rdfs:comment "Distillery may have its own name - us
 
 ontohgis:settlement_type_17 rdfs:comment "Forest-guard's lodge is a kind of forester's lodge; criteria for distinguishing a forester's lodge, forestry and forest-guard's lodge are unknown (in the context of topographic maps); the term forest-guard's lodge is very rarely used in Bystrzycki's register 1931 (Forest-guard's lodges depicted on MGI maps are forester's lodges in Bystrzycki's register 1931 or are not included in Bystrzycki's register 1931 whereas depicted on MGI maps)."@en ,
                                          "Gajówka jest rodzajem leśniczówki; kryteria odróżniania leśniczówki, leśnictwa i gajówki są nieznane (w świetle kartografii); termin bardzo rzadko stosowany w skorowidzu Bystrzyckiego z 1931 r. (gajówki na mapach WIG to często leśniczówki w skorowidzu Bystrzyckiego z 1931 r.; gajówki nie ujęte w skorowidzu Bystrzyckiego z 1931 r. występują na mapach WIG)"@pl ;
-                            ontohgis:isDefinedByLiteral "Forest-guard's lodge (a locality) is a settlement in which the main role is played by a forest-guard's lodge (a facility). Forest-guard's lodge is a locality as long as it has its own name and is not located in the immediate vicinity of another locality."@en ,
-                                             "Gajówka (miejscowość) to miejscowość, w której główną rolę pełni gajówka (obiekt). Gajówka jest miejscowością jeżeli posiada nazwę własną i jest przestrzennie wyodrębniona od innej miejscowości."@pl ;
                             rdfs:label "forest-guard's lodge"@en ,
                                        "gajówka"@pl ;
                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Forestrey"@de ,
@@ -17940,15 +18109,12 @@ ontohgis:settlement_type_17 rdfs:comment "Forest-guard's lodge is a kind of fore
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "forest-guard's lodge"@en ,
                                                                             "gajówka"@pl ;
                             ontohgis:hasExternalIdentifier "17" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Forest-guard's lodge (a locality) is a settlement in which the main role is played by a forest-guard's lodge (a facility). Forest-guard's lodge is a locality as long as it has its own name and is not located in the immediate vicinity of another locality."@en ,
+                                                        "Gajówka (miejscowość) to miejscowość, w której główną rolę pełni gajówka (obiekt). Gajówka jest miejscowością jeżeli posiada nazwę własną i jest przestrzennie wyodrębniona od innej miejscowości."@pl .
 
 
 ontohgis:settlement_type_18 rdfs:comment "A distillery may be a separate locality, both individual and a part of a cluster of localities sharing the same name, however most often it has been an integral part of a city or a town and has not been distinguished."@en ,
                                          "Gorzelnia może być odrębną miejscowością, zarówno samodzielną jak i częścią grupy miejscowości o tej samej nazwie, ale najczęściej znajduje się w obrębie miasta i nie jest wyróżniona."@pl ;
-                            ontohgis:isDefinedByLiteral "A distillery (locality) is a settlement, where a distillery (a factory) plays the most important role."@en ,
-                                             "Gorzelnia (miejscowość) jest to osada, w której główną role odgrywa gorzelnia (obiekt)."@pl ;
                             rdfs:label "distillery"@en ,
                                        "gorzelnia"@pl ;
                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Brantweinbrennerei"@de ,
@@ -17961,15 +18127,12 @@ ontohgis:settlement_type_18 rdfs:comment "A distillery may be a separate localit
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "distillery"@en ,
                                                                             "gorzelnia"@pl ;
                             ontohgis:hasExternalIdentifier "18" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                            ontohgis:isDefinedByLiteral "A distillery (locality) is a settlement, where a distillery (a factory) plays the most important role."@en ,
+                                                        "Gorzelnia (miejscowość) jest to osada, w której główną role odgrywa gorzelnia (obiekt)."@pl .
 
 
 ontohgis:settlement_type_19 rdfs:comment "Klasztor może być odrębną miejscowością (rzadko, przed II wojną światową) lub częścią miejscowości."@pl ,
                                          "Monastery can be a separate locality (rarely, before the Second World War) or a part of a locality."@en ;
-                            ontohgis:isDefinedByLiteral "Monastery (locality) is a settlement in which the main role is played by a monastery (facility)."@en ,
-                                             "Osada klasztorna jest to osada, w której główą rolę odgrywa klasztor (obiekt)."@pl ;
                             rdfs:label "monastery"@en ,
                                        "osada klasztorna"@pl ;
                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Kloster"@de ,
@@ -17981,17 +18144,14 @@ ontohgis:settlement_type_19 rdfs:comment "Klasztor może być odrębną miejscow
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "monastery"@en ,
                                                                             "osada klasztorna"@pl ;
                             ontohgis:hasExternalIdentifier "19" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Monastery (locality) is a settlement in which the main role is played by a monastery (facility)."@en ,
+                                                        "Osada klasztorna jest to osada, w której główą rolę odgrywa klasztor (obiekt)."@pl .
 
 
 ontohgis:settlement_type_2 rdfs:comment """A development in a village may be dense (i.e. villages established according to a German law introducing a linear development) or scattered (i.e. Hauländer colonies, Dutch settlement, from 18th century or early medieval single manor settlements). A village may preponderate (be a superior settlement) any other units, such as: a hamlet or a mill settlement; it is also dependent on a manor, which supervises a village in legal and administrative issues. Inhabitants from all units forming a village comprise a village community. Studies on this type of localities distinguish an abandoned village, a settlement that lost its functions due to environmental, political, or economic incidents. In historiography, one can find an expression a lost village, which stands for a village, where settlement was not re-established.
 In German language in the nineteenth century, two terms could coexist - Pfarrdorf and Kirchdorf. The first meant a larger village with a parish church, and a second smaller village with an auxiliary (filial) church, but these criteria of distinction were not strict and neither used consistently. For example on the Gilly map (1802-1803), only the following categories exist: Kirchdorf and Dorf ohne Kirche."""@en ,
                                         """Wieś może posiadać zwartą (np. wsie lokowane na prawie niemieckim np. ulicówki, łańcuchówki) lub rozproszoną zabudowę (często kolonie olęderskie w XVIII w. lub wczesnośredniowieczne osady jednodworcze). Wieś może dominować (być jednostką nadrzędną osadniczo) w stosunku do innych jednostek takich jak np. przysiółek, osada młyńska; jest także zależna od pana gruntowego, który sprawuje nad nią nadzór własnościowy. Mieszkańcy wszystkich jednostek składających się na wieś tworzą jedną wspólnotę wiejską. W badaniach nad wsią rozróżnia się także pojęcie wsi opustoszałej, czyli takiej, która fizycznie przestała pełnić swoje funkcje w wyniku zdarzeń o charakterze losowym, środowiskowym, politycznym lub gospodarczym. W literaturze przedmiotu funkcjonuje także określenie wieś zaginiona, które odnosi się do wsi, w których nie wznowiono osadnictwa.
 W języku niemieckim w XIX wieku mogły funkcjonować równolegle dwa terminy – Pfarrdorf i Kirchdorf.  Pierwszy oznaczał raczej większą wieś z kościołem parafialnym, zaś drugi mniejszą wieś z kościołem pomocniczym. Terminy te nie były jednak ścisłe i używane konsekwentnie, np. na mapie Gilly’ego z lat 1802-1803 występują tylko kategorie: Kirchdorf oraz Dorf ohne Kirche."""@pl ;
-                           ontohgis:isDefinedByLiteral "Village is a locality composed of a group of buildings, mostly of residential and economic character, but sometimes, also industrial ones (i.e. ironworks, mill) as well as a belonging land, inhabited by people involved particularly in agricultural and construction activities or in farming industry (i.e. blacksmith or mill work), and not having city rights nor a status of a city or a town. Some villages in Early Middle Ages had a right to organise a fair and a market."@en ,
-                                            "Wieś jest to miejscowość składająca się z zabudowań mieszkalno-gospodarczych, niekiedy przemysłowych (np. kuźnia, młyn) wraz z przynależnymi do nich gruntami (rozłogi), zamieszkała przez ludność zajmującą się w większości zajęciami rolniczo-hodowlanymi oraz przemysłem wiejskim (np. kowalstwo, młynarstwo), nieposiadająca praw miejskich ani statusu miasta. Niekiedy we wczesnym średniowieczu posiadająca prawo odbywania targu."@pl ;
                            rdfs:label "village"@en ,
                                       "wieś"@pl ;
                            rdfs:seeAlso <http://dbpedia.org/page/Village> ,
@@ -18030,9 +18190,8 @@ W języku niemieckim w XIX wieku mogły funkcjonować równolegle dwa terminy �
                            <http://www.w3.org/2004/02/skos/core#prefLabel> "village"@en ,
                                                                            "wieś"@pl ;
                            ontohgis:hasExternalIdentifier "2" ;
-                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                           ontohgis:hasTranslator ontohgis:person_9 .
+                           ontohgis:isDefinedByLiteral "Village is a locality composed of a group of buildings, mostly of residential and economic character, but sometimes, also industrial ones (i.e. ironworks, mill) as well as a belonging land, inhabited by people involved particularly in agricultural and construction activities or in farming industry (i.e. blacksmith or mill work), and not having city rights nor a status of a city or a town. Some villages in Early Middle Ages had a right to organise a fair and a market."@en ,
+                                                       "Wieś jest to miejscowość składająca się z zabudowań mieszkalno-gospodarczych, niekiedy przemysłowych (np. kuźnia, młyn) wraz z przynależnymi do nich gruntami (rozłogi), zamieszkała przez ludność zajmującą się w większości zajęciami rolniczo-hodowlanymi oraz przemysłem wiejskim (np. kowalstwo, młynarstwo), nieposiadająca praw miejskich ani statusu miasta. Niekiedy we wczesnym średniowieczu posiadająca prawo odbywania targu."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_2 ;
@@ -18100,8 +18259,6 @@ W języku niemieckim w XIX wieku mogły funkcjonować równolegle dwa terminy �
 
 ontohgis:settlement_type_20 rdfs:comment "Colony is usually a part of another locality, more rarely, although these are not exceptional cases, it can have the status of a separate locality, usually a village. Both in the case where the colony is a separate locality or it is apart of another one, it is always located near the village (village or - sometimes - small town) from which its name is derived. On topographic maps, a colony is distinguished mainly by the explanatory abbreviation (pol.: kol.), by its own name, and morphologically."@en ,
                                          "Kolonia jest przeważnie częścią miejscowości, rzadziej, choć nie są to wyjątkowe przypadki, ma obecnie status odrębnej miejscowości, z reguły wsi. Zarówno w przypadku, gdy kolonia jest odrębną miejscowością jak i częścią miejscowości, zawsze znajduje się w pobliżu miejscowości (wsi a wyjątkowo małego miasta) od której pochodzi jej nazwa. W ujęciu kartograficznym wyodrębniona przede wszystkim przez skrót kategorii (kol.), nazwę własną, oraz morfologicznie."@pl ;
-                            ontohgis:isDefinedByLiteral "Colony (pol. kolonia) is a built-up area located away from previously existing buildings (locality) to which it is related. It is created on newly developed land allocated as a result of enfranchisement, parceling, consolidation, or internal migration."@en ,
-                                             "Kolonia jest to obszar zabudowany oddalony od wcześniej istniejącej zabudowy, od której jest zależna, powstały na nowo zagospodarowanych gruntach przydzielonych w wyniku uwłaszczenia, parcelacji, komasacji lub migracji wewnętrznej."@pl ;
                             rdfs:label "colony"@en ,
                                        "kolonia"@pl ;
                             rdfs:seeAlso <http://gov.genealogy.net/types.owl#121> ,
@@ -18130,9 +18287,8 @@ ontohgis:settlement_type_20 rdfs:comment "Colony is usually a part of another lo
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "colony"@en ,
                                                                             "kolonia"@pl ;
                             ontohgis:hasExternalIdentifier "20" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Colony (pol. kolonia) is a built-up area located away from previously existing buildings (locality) to which it is related. It is created on newly developed land allocated as a result of enfranchisement, parceling, consolidation, or internal migration."@en ,
+                                                        "Kolonia jest to obszar zabudowany oddalony od wcześniej istniejącej zabudowy, od której jest zależna, powstały na nowo zagospodarowanych gruntach przydzielonych w wyniku uwłaszczenia, parcelacji, komasacji lub migracji wewnętrznej."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_20 ;
@@ -18186,8 +18342,6 @@ ontohgis:settlement_type_20 rdfs:comment "Colony is usually a part of another lo
 
 ontohgis:settlement_type_21 rdfs:comment "A mine may be a separate locality, an individual one or a part of a cluster of localities sharing the same name, however, even if a mine is an integral part of a bigger locality, it has its particular name."@en ,
                                          "Kopalnia może być odrębną miejscowością, zarówno samodzielną jak i częścią grupy miejscowości o tej samej nazwie, ale najczęściej, nawet jeśli znajduje się w obrębie większej miejscowości, ma własną nazwę."@pl ;
-                            ontohgis:isDefinedByLiteral "A mine (a locality) is a settlement with a mine (a factory) as the most important element."@en ,
-                                             "Kopalnia (miejscowość) jest to osada, w której główną rolę odgrywa kopalnia (obiekt)."@pl ;
                             rdfs:label "mining settlement"@en ,
                                        "osada górnicza"@pl ;
                             rdfs:seeAlso <http://vocab.getty.edu/aat/300008464> ,
@@ -18210,9 +18364,8 @@ ontohgis:settlement_type_21 rdfs:comment "A mine may be a separate locality, an 
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "mining settlement"@en ,
                                                                             "osada górnicza"@pl ;
                             ontohgis:hasExternalIdentifier "21" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                            ontohgis:isDefinedByLiteral "A mine (a locality) is a settlement with a mine (a factory) as the most important element."@en ,
+                                                        "Kopalnia (miejscowość) jest to osada, w której główną rolę odgrywa kopalnia (obiekt)."@pl .
 
 
 ontohgis:settlement_type_23 rdfs:comment """Included as a kind of locality in Bystrzycki's register as abbreviation (\"lat. mor.\"); dinstinct symbol on topographic maps; included in DBTO10k as a \"communication buildings, stations and terminals\" (BUBD feature class).
@@ -18221,18 +18374,14 @@ Morphological and spatial distinctivness - usually a lightouse is a building (st
 If it has its a particular (proper) name, it can be treated as a separate locality (interpretation of maps is necessary, see: Rozewie). Otherwise it is either part of another locality or an object (building/structure) in it (see: Hel, Jastarnia)."""@en ,
                                          """Występuje jako rodzaj miejscowości u Bystrzyckiego w spisie (\"lat. mor.\"); na mapach osobna sygnatura. W BDOT10k jako budynek łączności, dworców i terminali.
 Odrębność funkcjonalna – wyróżniana jako rodzaj miejscowości u Bystrzyckiego, a na mapach topograficznych odrębnym znakiem, niekiedy z nazwą własną. Odrębność morfologiczna/przestrzenna – przeważnie jest obiektem na obszarze miejscowości lub w niewielkim od niej oddaleniu. Jeżeli posiada nazwę własną może być traktowana jako osobna miejscowość (konieczna interpretacja map; patrz: Rozewie). W przeciwnym razie jest albo częścią innej, większej miejscowości lub obiektem terenowym (budowlą) w niej (patrz: Hel, Jastarnia)."""@pl ;
-                            ontohgis:isDefinedByLiteral "A lighthouse (a locality) is a settlement in which a main role is played by a lighthouse (building)."@en ,
-                                             "Latarnia morska (miejscowość) to osada obejmująca latarnię morską (obiekt)."@pl ;
                             rdfs:label "latarnia morska"@pl ,
                                        "lighthouse"@en ;
                             <http://www.w3.org/2004/02/skos/core#altLabel> "Leuchtturm"@de ;
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "latarnia morska"@pl ,
                                                                             "lighthouse"@en ;
                             ontohgis:hasExternalIdentifier "23" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 ,
-                                                   ontohgis:person_9 .
+                            ontohgis:isDefinedByLiteral "A lighthouse (a locality) is a settlement in which a main role is played by a lighthouse (building)."@en ,
+                                                        "Latarnia morska (miejscowość) to osada obejmująca latarnię morską (obiekt)."@pl .
 
 
 ontohgis:settlement_type_25 rdfs:comment """It can be either a separate locality (e.g. Celestynów) or a part of another locality, morphologically it is most often a complex of (summer) houses (Chylice, Skolimów), but also a typical (based on the interpretation of the topographic map drawing) non-urban built-up area (Choszczówka).
@@ -18242,8 +18391,6 @@ Included on topographic maps as a part of a place name annotation (\"letn.\"), b
 Występuje jako rodzaj miejscowości u Bystrzyckiego w spisie (\"letn.\"). 
 Wszystkie letniska u Bystrzyckiego znajdują się w okolicach Warszawy. Wyjątek: Wisła, Zełmianka (pow. Stryj).
 Występuje na mapach w nazwach miejscowości (letn.), ale nie w kluczach znaków. W legendach map WIG jest to jeden z rodzajów osiedli. W BDOT10k („dom letniskowy”) w klasie budynki mieszkalne jednorodzinne (BUBD01)."""@pl ;
-                            ontohgis:isDefinedByLiteral "Letnisko to miejscowość o charakterze wypoczynkowym, złożona z domków letniskowych lub posiadająca zwartą zabudowę"@pl ,
-                                             "Summer resort is a holiday locality consisting of holiday houses or densely built-up"@en ;
                             rdfs:label "letnisko"@pl ,
                                        "summer resort"@en ;
                             rdfs:seeAlso <http://vocab.getty.edu/aat/300000547> ,
@@ -18263,10 +18410,8 @@ Występuje na mapach w nazwach miejscowości (letn.), ale nie w kluczach znaków
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "letnisko"@pl ,
                                                                             "summer resort"@en ;
                             ontohgis:hasExternalIdentifier "25" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 ,
-                                                   ontohgis:person_9 .
+                            ontohgis:isDefinedByLiteral "Letnisko to miejscowość o charakterze wypoczynkowym, złożona z domków letniskowych lub posiadająca zwartą zabudowę"@pl ,
+                                                        "Summer resort is a holiday locality consisting of holiday houses or densely built-up"@en .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_25 ;
@@ -18278,8 +18423,6 @@ Występuje na mapach w nazwach miejscowości (letn.), ale nie w kluczach znaków
 
 ontohgis:settlement_type_27 rdfs:comment "Dziś leśniczówka jest miejscowością lub budynkiem (BDOT10k), ale nie wszystkie leśniczówki-budynki (BUBD01) to leśniczówki-miejscowości (ADMS11). Przed wojną leśniczówka prawie zawsze była wyróżniana jako odrębna miejscowość."@pl ,
                                          "Today, the forester's lodge is a locality or a building (DBTO10k), but not all forester's lodges (feature class: BUBD01) which are buildings are forester's lodges (feature class: ADMS11) understood as localities. Before the second world war, forester's lodge was almost always distinguished as a separate locality."@en ;
-                            ontohgis:isDefinedByLiteral "Forester's lodge (a locality) is a locality in which the main role is played by a forester's lodge (an area). Forester's lodge is a locality as long as it has a particular (proper) name and is not located in the immediate vicinity of another locality."@en ,
-                                             "Leśniczówka (miejscowość) to miejscowość, w której główną rolę pełni leśniczówka (obiekt). Leśniczówka jest miejscowością jeżeli posiada nazwę własną i jest przestrzennie wyodrębniona od innej miejscowości."@pl ;
                             rdfs:label "forester's lodge"@en ,
                                        "leśniczówka"@pl ;
                             rdfs:seeAlso <http://gov.genealogy.net/types.owl#115> ,
@@ -18294,15 +18437,12 @@ ontohgis:settlement_type_27 rdfs:comment "Dziś leśniczówka jest miejscowości
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "forester's lodge"@en ,
                                                                             "leśniczówka"@pl ;
                             ontohgis:hasExternalIdentifier "27" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Forester's lodge (a locality) is a locality in which the main role is played by a forester's lodge (an area). Forester's lodge is a locality as long as it has a particular (proper) name and is not located in the immediate vicinity of another locality."@en ,
+                                                        "Leśniczówka (miejscowość) to miejscowość, w której główną rolę pełni leśniczówka (obiekt). Leśniczówka jest miejscowością jeżeli posiada nazwę własną i jest przestrzennie wyodrębniona od innej miejscowości."@pl .
 
 
 ontohgis:settlement_type_28 rdfs:comment "Miasteczko z zasady jest odrębną miejscowością. Na ziemiach polskich nie istniało rozróżnienie formalne między miastem i miasteczkiem, funkcjonowało ono natomiast na niektórych obszarach Rzeszy Niemieckiej (Flecken, Marktsiedlung - Stadt)."@pl ,
                                          "Town is always (ex definitione) a separate locality. On the Polish lands, there was no formal distinction between the city and the town, but such distinction was present in some areas of the German Reich (Flecken, Marktsiedlung - Stadt)."@en ;
-                            ontohgis:isDefinedByLiteral "Miasteczko to małe miasto, odróżniające się od dużych miast wielkością (liczoną według miary właściwej dla danej epoki i regionu) i stopniem złożoności."@pl ,
-                                             "Town (pol. miasteczko) is a small city, distniguished from larger cities by it size (estimated by standards appropriate for given period and region) and complexity."@en ;
                             rdfs:label "miasteczko"@pl ,
                                        "town"@en ;
                             rdfs:seeAlso <http://dbpedia.org/ontology/Town> ,
@@ -18322,16 +18462,15 @@ ontohgis:settlement_type_28 rdfs:comment "Miasteczko z zasady jest odrębną mie
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "miasteczko"@pl ,
                                                                             "town"@en ;
                             ontohgis:hasExternalIdentifier "28" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Miasteczko to małe miasto, odróżniające się od dużych miast wielkością (liczoną według miary właściwej dla danej epoki i regionu) i stopniem złożoności."@pl ,
+                                                        "Town (pol. miasteczko) is a small city, distniguished from larger cities by it size (estimated by standards appropriate for given period and region) and complexity."@en .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_28 ;
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "małe miasto, -- przen. ludność małego miasta"@pl ;
    ontohgis:isDefinedByIRI ontohgis:document_4 ,
-                    <https://sjp.pwn.pl/doroszewski/miasteczko;5451005.html>
+                           <https://sjp.pwn.pl/doroszewski/miasteczko;5451005.html>
  ] .
 
 [ rdf:type owl:Axiom ;
@@ -18339,7 +18478,7 @@ ontohgis:settlement_type_28 rdfs:comment "Miasteczko z zasady jest odrębną mie
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "małe miasto; pot. mieszkańcy małego miasta"@pl ;
    ontohgis:isDefinedByIRI ontohgis:document_3 ,
-                    <https://sjp.pwn.pl/sjp/miasteczko;2482785.html>
+                           <https://sjp.pwn.pl/sjp/miasteczko;2482785.html>
  ] .
 
 [ rdf:type owl:Axiom ;
@@ -18352,8 +18491,6 @@ ontohgis:settlement_type_28 rdfs:comment "Miasteczko z zasady jest odrębną mie
 
 ontohgis:settlement_type_3 rdfs:comment "During those periods, when legal status of localities was established and defined, cities/towns were granted specific municipal rights (location bill), which should be considered as an auxiliary indicator for distinguishing cities/towns. A city/town may consists of other settlement units, like: a core city/town (a founded one), a district, a suburb, a castle, a gord. At least from the 13th to the 18th century, two parallel notions existed: general (meaning the whole settlement unit with its own society, economy, and urban structure, perceived mostly by intuition), and a city in its political and legal meaning, as a community with an extensive autonomy. As a consequence, cities within other city or units lying partly in and partly outside the city existed. For these complex structures, in this project, first explanations of the city should be applied."@en ,
                                         "W okresach, w których status prawny miejscowości był ukształtowany miasta posiadały szczególne prawa miejskie (lokacyjne), które stanowią postawowe kryterium pomocnicze odróżniania miast. W skład miasta mogą wchodzić inne jednostki osadnicze, jak miasto właściwe (lokacyjne), dzielnica, przedmieście, zamek, gród. Przynamniej w okresie od XIII do XVIII w. funkcjonowały równolegle dwa pojęcia miasta: ogólne, obejmujące cały zespół osadniczy o odrębności społecznej, gospodarczej i urbanistycznej, postrzegane przede wszystkim intuicyjnie oraz miasto w sensie polityczno-prawnym, obdarzona względnie szeroką autonomią gmina. W konsekwencji mogły istnieć miasta w mieście i obiekty leżące jednocześnie w mieście i poza nim. Dla takich złożonych struktur w niniejszym projekcie należy się posługiwać pierwszym znaczeniem miasta."@pl ;
-                           ontohgis:isDefinedByLiteral "A city/town is a superior locality, distinguished from others, surrounding basic units by size (measured differently in different periods of time and regions), a level of complexity, and central functions provided for those units."@en ,
-                                            "Miasto jest to miejscowość wyższego rzędu, odróżniająca się od otaczających je podstawowych wielkością (liczoną według miary właściwej dla danej epoki i regionu), stopniem złożoności i funkcjami centralnymi względem nich."@pl ;
                            rdfs:label "city / town"@en ,
                                       "miasto"@pl ;
                            rdfs:seeAlso <http://dbpedia.org/ontology/City> ,
@@ -18379,9 +18516,8 @@ ontohgis:settlement_type_3 rdfs:comment "During those periods, when legal status
                            <http://www.w3.org/2004/02/skos/core#prefLabel> "city / town"@en ,
                                                                            "miasto"@pl ;
                            ontohgis:hasExternalIdentifier "3" ;
-                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                           ontohgis:hasTranslator ontohgis:person_9 .
+                           ontohgis:isDefinedByLiteral "A city/town is a superior locality, distinguished from others, surrounding basic units by size (measured differently in different periods of time and regions), a level of complexity, and central functions provided for those units."@en ,
+                                                       "Miasto jest to miejscowość wyższego rzędu, odróżniająca się od otaczających je podstawowych wielkością (liczoną według miary właściwej dla danej epoki i regionu), stopniem złożoności i funkcjami centralnymi względem nich."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_3 ;
@@ -18415,8 +18551,6 @@ ontohgis:settlement_type_3 rdfs:comment "During those periods, when legal status
 ontohgis:settlement_type_33 rdfs:comment "A small locality organised in relation to a workplace or a particular occupation of its inhabitants. Settlement had usually been established as a separate locality, later on – especially in case of industrial settlements – particular settlements could develop into a city, merge with other settlement to create a new locality, or it could be incorporated into another locality. Depending on the type of inhabitants’ occupations one can, or could in the past, indicate a fair (market), craft, industrial, fishing, forestry, and railway settlements."@en ,
                                          "Niewielka miejscowość zorganizowana w związku z miejscem lub rodzajem pracy mieszkańców. Osada powstawała z reguły jako odrębna miejscowość, później, dość często, szczególnie w przypadku osad przemysłowych, rozwijała się do rangi miasta, łączyła się z inną osadą jako odrębna miejscowość, lub była włączana do innej miejscowości. W zależności od rodzaju wykonywanej pracy wyróżnia lub wyróżniało się osady targowe, rzemieślnicze, przemysłowe, rybackie, leśne, kolejowe."@pl ,
                                          "„W ten sposób termin 'osada' może tutaj oznaczać nie tylko małe osiedla, złożone z jednego lub kilku wyodrębnionych terytorialnie gospodarstw włościańskich, jak to miało miejsce na innych ziemiach polskich, lecz i większe, o charakterze kolonii, t. j. osiedli rozrzuconych na większej przestrzeni, a powstałych zazwyczaj na gruntach rozparcelowanych przez władze zaborcze”"@pl ;
-                            ontohgis:isDefinedByLiteral "Niewielka miejscowość zamieszkała przez ludność związaną z określonym typem lokalizacji lub rodzajem pracy nierolniczej i usytuowana z reguły w bezpośrednim sąsiedztwie miejsca pracy."@pl ,
-                                             "Settlement is a small locality inhabited by people associated with a particular type of location or a type of a non-agricultural work and lying mostly in the vicinity of a workplace."@en ;
                             rdfs:label "osada"@pl ,
                                        "settlement"@en ;
                             rdfs:seeAlso <http://dbpedia.org/page/Hamlet_(place)> ,
@@ -18443,9 +18577,8 @@ ontohgis:settlement_type_33 rdfs:comment "A small locality organised in relation
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "osada"@pl ,
                                                                             "settlement"@en ;
                             ontohgis:hasExternalIdentifier "33" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                            ontohgis:isDefinedByLiteral "Niewielka miejscowość zamieszkała przez ludność związaną z określonym typem lokalizacji lub rodzajem pracy nierolniczej i usytuowana z reguły w bezpośrednim sąsiedztwie miejsca pracy."@pl ,
+                                                        "Settlement is a small locality inhabited by people associated with a particular type of location or a type of a non-agricultural work and lying mostly in the vicinity of a workplace."@en .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_33 ;
@@ -18473,7 +18606,7 @@ ontohgis:settlement_type_33 rdfs:comment "A small locality organised in relation
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "niewielka miejscowość, niemająca praw osiedla czy miasta; też: mieszkańcy takiej miejscowości"@pl ;
    ontohgis:isDefinedByIRI ontohgis:document_3 ,
-                    <https://sjp.pwn.pl/sjp/osada;2496282.html>
+                           <https://sjp.pwn.pl/sjp/osada;2496282.html>
  ] .
 
 [ rdf:type owl:Axiom ;
@@ -18481,7 +18614,7 @@ ontohgis:settlement_type_33 rdfs:comment "A small locality organised in relation
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "osiedle typu wiejskiego pośrednie między wsią a miasteczkiem; kolonia, mieszkańcy tego osiedla"@pl ;
    ontohgis:isDefinedByIRI ontohgis:document_4 ,
-                    <https://sjp.pwn.pl/doroszewski/osada;5467524.html>
+                           <https://sjp.pwn.pl/doroszewski/osada;5467524.html>
  ] .
 
 [ rdf:type owl:Axiom ;
@@ -18512,8 +18645,6 @@ In cartography, it may be distinguished by its own name preceded by an abbreviat
                                          """W znaczeniu ogólnym, rzadko obecnie stosowanym, określenie każdej jednostki osadniczej (osiedle miejskie, osiedle wiejskie). W tym znaczeniu jest to osobna miejscowość.
 W urbanistyce (planowaniu przestrzennym) pojęcie osiedla wywodzi się z koncepcji „jednostki sąsiedzkiej”, na którą składa się zespół budynków mieszkalnych wraz z zapleczem obiektów usługowych oraz terenów zielonych. Jako część miejscowości osiedle wyróżnia się poprzez nazwę, swoją fizjonomię (np. osiedle bloków mieszkalnych, domków jednorodzinnych), topografię (jest wyodrębnione przestrzennie), a także przez okres powstania.
 W ujęciu kartograficznym wyodrębnione przez nazwę własną, poprzedzoną  skrótem  kategorii (np. Os. Zdobycz Robotnicza) oraz morfologicznie."""@pl ;
-                            ontohgis:isDefinedByLiteral "Housing estate is an area covering a group of residential buildings, being an integral part of a city ( a town), or - rarely - a village."@en ,
-                                             "Obszar obejmujący zespół budynków mieszkalnych, stanowiący integralną część miasta, a niekiedy wsi."@pl ;
                             rdfs:label "housing developments"@en ,
                                        "osiedle"@pl ;
                             rdfs:seeAlso <http://dbpedia.org/page/Housing_development> ,
@@ -18545,10 +18676,8 @@ W ujęciu kartograficznym wyodrębnione przez nazwę własną, poprzedzoną  skr
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "housing developments"@en ,
                                                                             "osiedle"@pl ;
                             ontohgis:hasExternalIdentifier "34" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 ,
-                                                   ontohgis:person_9 .
+                            ontohgis:isDefinedByLiteral "Housing estate is an area covering a group of residential buildings, being an integral part of a city ( a town), or - rarely - a village."@en ,
+                                                        "Obszar obejmujący zespół budynków mieszkalnych, stanowiący integralną część miasta, a niekiedy wsi."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_34 ;
@@ -18616,8 +18745,6 @@ W ujęciu kartograficznym wyodrębnione przez nazwę własną, poprzedzoną  skr
 
 ontohgis:settlement_type_35 rdfs:comment "Industrial settlement usually emerged as a separate locality, later, quite often, it developed to the rank of the city, merged with another locality creating a separate one, or was incorporated into another locality."@en ,
                                          "Osada fabryczna powstawała z reguły jako odrębna miejscowość, później, dość często rozwijała się do rangi miasta, łączyła się z inną osadą jako odrębna miejscowość, lub była włączana do innej miejscowości."@pl ;
-                            ontohgis:isDefinedByLiteral "Industrial settlement is a settlement in which a main role is played by a factory."@en ,
-                                             "Osada fabryczna jest to osada, w której główną rolę pełni fabryka."@pl ;
                             rdfs:label "industrial settlement"@en ,
                                        "osada fabryczna"@pl ;
                             <http://www.w3.org/2004/02/skos/core#altLabel> "osada przemysłowa (pl)" ;
@@ -18636,15 +18763,12 @@ ontohgis:settlement_type_35 rdfs:comment "Industrial settlement usually emerged 
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "industrial settlement"@en ,
                                                                             "osada fabryczna"@pl ;
                             ontohgis:hasExternalIdentifier "35" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Industrial settlement is a settlement in which a main role is played by a factory."@en ,
+                                                        "Osada fabryczna jest to osada, w której główną rolę pełni fabryka."@pl .
 
 
 ontohgis:settlement_type_36 rdfs:comment "Osada leśna powstawała z reguły jako odrębna, niewielka miejscowość, położona w obrębie lub na skraju obszaru leśnego."@pl ,
                                          "The forest settlements were usually formed as a separate, small locality, located within or near the forest."@en ;
-                            ontohgis:isDefinedByLiteral "A forest settlement is a small settlement located within or at the boundaries of a forest area, inhabited by people involved in administration, exploitation, or availing the surrounding forest areas."@en ,
-                                             "Osada leśna jest to niewielka osada położona w obrębie lub na skraju obszaru leśnego, zamieszkała przez ludność związaną z administrowaniem, eksploatacją lub wykorzystywaniem otaczających obszarów leśnych."@pl ;
                             rdfs:label "forest settlement"@en ,
                                        "osada leśna"@pl ;
                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Forestrey"@de ,
@@ -18657,18 +18781,14 @@ ontohgis:settlement_type_36 rdfs:comment "Osada leśna powstawała z reguły jak
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "forest settlement"@en ,
                                                                             "osada leśna"@pl ;
                             ontohgis:hasExternalIdentifier "36" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 ,
-                                                   ontohgis:person_9 .
+                            ontohgis:isDefinedByLiteral "A forest settlement is a small settlement located within or at the boundaries of a forest area, inhabited by people involved in administration, exploitation, or availing the surrounding forest areas."@en ,
+                                                        "Osada leśna jest to niewielka osada położona w obrębie lub na skraju obszaru leśnego, zamieszkała przez ludność związaną z administrowaniem, eksploatacją lub wykorzystywaniem otaczających obszarów leśnych."@pl .
 
 
 ontohgis:settlement_type_37 rdfs:comment "Osada miejska to miejscowość."@pl ,
                                          "Termin był stosowany dla oznaczenia ośrodków, które utraciły prawa miejskie po powstaniu styczniowym. Osada miejska mogła być stosowana także sensie szerszym, obejmującym wszystkie jednostki osadnicze o charakterze miejskim, np. duże miasto, przedmieścia itp."@pl ,
                                          "This notion was used to mark localites that lost their city rights after the \"January Uprising\". The urban settlement could also be used in a broader sense, encompassing all settlement units of urban character, e.g. a big city, suburbs, etc."@en ,
                                          "Urban settlement is a locality."@en ;
-                            ontohgis:isDefinedByLiteral "Osada miejska to miejscowość posiadająca wcześniej prawa miejskie i aktualnie ich pozbawiona."@pl ,
-                                             "Urban settlement is a locality which used to have city rights, but currently without them."@en ;
                             rdfs:label "osada miejska"@pl ,
                                        "urban settlement"@en ;
                             rdfs:seeAlso <http://dbpedia.org/page/Urban-type_settlement> ,
@@ -18679,9 +18799,8 @@ ontohgis:settlement_type_37 rdfs:comment "Osada miejska to miejscowość."@pl ,
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "osada miejska"@pl ,
                                                                             "urban settlement"@en ;
                             ontohgis:hasExternalIdentifier "37" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Osada miejska to miejscowość posiadająca wcześniej prawa miejskie i aktualnie ich pozbawiona."@pl ,
+                                                        "Urban settlement is a locality which used to have city rights, but currently without them."@en .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_37 ;
@@ -18693,8 +18812,6 @@ ontohgis:settlement_type_37 rdfs:comment "Osada miejska to miejscowość."@pl ,
 
 ontohgis:settlement_type_38 rdfs:comment "Mill settlement often emereged as a separete locality, which might later be combined with another locality or become a part of it."@en ,
                                          "Osada młyńska powstawała często jako odrębna miejscowość, później łączyła się niekiedy z inną osadą  lub była włączana do innej miejscowości."@pl ;
-                            ontohgis:isDefinedByLiteral "Mill settlement is a settlement in which a main role is played by a mill, most often a watermill, but it also might be a windmill or wind turbine."@en ,
-                                             "Osada młyńska jest to osada, w której główną rolę pełni młyn, najczęściej młyn wodny, ale może to być też również wiatrak lub turbina wiatrowa."@pl ;
                             rdfs:label "mill settlement"@en ,
                                        "osada młyńska"@pl ;
                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "conlocationen"@la ,
@@ -18712,15 +18829,12 @@ ontohgis:settlement_type_38 rdfs:comment "Mill settlement often emereged as a se
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "mill settlement"@en ,
                                                                             "osada młyńska"@pl ;
                             ontohgis:hasExternalIdentifier "38" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Mill settlement is a settlement in which a main role is played by a mill, most often a watermill, but it also might be a windmill or wind turbine."@en ,
+                                                        "Osada młyńska jest to osada, w której główną rolę pełni młyn, najczęściej młyn wodny, ale może to być też również wiatrak lub turbina wiatrowa."@pl .
 
 
 ontohgis:settlement_type_41 rdfs:comment "In each analysed case, a rectory being a separate settlement, lays in a vicinity of a village, or a town/city with the same name. In cartographical sources, one can find it presented separately, with its proper name, an abbreviation of a category (i.e. pol “pleb.”, which is “rect.”), and distinguished by its morphology. A rectory differs slightly from the house of a provost, but we leave this difference aside."@en ,
                                          "We wszystkich analizowanych przypadkach jeżeli plebania jest odrębną miejscowością, to znajduje się w pobliżu wsi, miasta lub osady o tej samej nazwie. W ujęciu kartograficznym wyodrębniona przez nazwę własną, skrót kategorii (np. pleb.) oraz morfologicznie. Plebania różni się nieco od probostwa, gdyż pleban nie jest tożsamy z proboszczem, ale różnicę tę pomijamy."@pl ;
-                            ontohgis:isDefinedByLiteral "Plebania jest to miejscowość, w której główną rolę pełni plebania jako obiekt sakralny."@pl ,
-                                             "Rectory is a locality, where the main role is played by a rectory, a home of a provost, as a sacral object."@en ;
                             rdfs:label "plebania"@pl ,
                                        "rectory"@en ;
                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "curionatus"@la ,
@@ -18739,9 +18853,8 @@ ontohgis:settlement_type_41 rdfs:comment "In each analysed case, a rectory being
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "plebania"@pl ,
                                                                             "rectory"@en ;
                             ontohgis:hasExternalIdentifier "41" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                            ontohgis:isDefinedByLiteral "Plebania jest to miejscowość, w której główną rolę pełni plebania jako obiekt sakralny."@pl ,
+                                                        "Rectory is a locality, where the main role is played by a rectory, a home of a provost, as a sacral object."@en .
 
 
 ontohgis:settlement_type_43 rdfs:comment """Przedmieście z zasady jest częścią miejscowości: miasta. 
@@ -18752,8 +18865,6 @@ Należy odróżnić od przedmieścia osady przedmiejskie, które były w znaczny
 In the fortified cities, the area of the core city was limted by the fortifications, especially by the walls.
 The suburb could have a different degree of legal separation from the city. It is an entity typical rather for the pre-industrial era. Most of the suburbs, especially from the end of the 18th c., were incorporated legally and then functionally as well as morphologically into the city. The particular name of the suburb usually disappeared or obtained a different meaning.
 It is necessary to distinguish  suburbs from the suburban settlements which were largely independent of the neighboring city or even held central functions to it, e.g. due to the location of the seats of the authorities. Such a situation was common during the first stages of cities establishment, especially for larger centers (prince's stronghold and the cathedral outside the main municipality)."""@en ;
-                            ontohgis:isDefinedByLiteral "Przedmieście to peryferyjna część miasta, tj. położona poza obrębem miasta właściwego (lokacyjnego), wyodrębniona przestrzennie lub morfologicznie i z własną nazwą, wobec której miasto pełni funkcje centralne."@pl ,
-                                             "Suburb is a peripheral part of the city, towards which the city performs central functions. A suburb is located outside its initial location city; distinguished spatially or morphologically and with its own (proper) name."@en ;
                             rdfs:label "Vorstadt"@de ,
                                        "przedmieście"@pl ,
                                        "suburb"@en ,
@@ -18766,9 +18877,8 @@ It is necessary to distinguish  suburbs from the suburban settlements which were
                                                                               "osada przedmiejska"@pl ,
                                                                               "wieś podmiejska"@pl ;
                             ontohgis:hasExternalIdentifier "43" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Przedmieście to peryferyjna część miasta, tj. położona poza obrębem miasta właściwego (lokacyjnego), wyodrębniona przestrzennie lub morfologicznie i z własną nazwą, wobec której miasto pełni funkcje centralne."@pl ,
+                                                        "Suburb is a peripheral part of the city, towards which the city performs central functions. A suburb is located outside its initial location city; distinguished spatially or morphologically and with its own (proper) name."@en .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_43 ;
@@ -18792,9 +18902,7 @@ It is necessary to distinguish  suburbs from the suburban settlements which were
  ] .
 
 
-ontohgis:settlement_type_44 ontohgis:isDefinedByLiteral "Hamlet (pol \"przysiółek\") is a small group of buildings belonging to another locality, located on its land, in a remote part, and legally associated with it."@en ,
-                                             "Przysiółek to mała grupa zabudowań, należących do innej miejscowości, położona na jej gruntach, w oddaleniu od niej i prawnie z nią związana."@pl ;
-                            rdfs:label "hamlet"@en ,
+ontohgis:settlement_type_44 rdfs:label "hamlet"@en ,
                                        "przysiółek"@pl ;
                             rdfs:seeAlso <http://linkedgeodata.org/ontology/Hamlet> ;
                             <http://www.w3.org/2004/02/skos/core#altLabel> "mała wioska (pl), niesamodzielna osada (pl), skupisko gospodarstw (pl)" ;
@@ -18813,16 +18921,13 @@ ontohgis:settlement_type_44 ontohgis:isDefinedByLiteral "Hamlet (pol \"przysió�
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "hamlet"@en ,
                                                                             "przysiółek"@pl ;
                             ontohgis:hasExternalIdentifier "44" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Hamlet (pol \"przysiółek\") is a small group of buildings belonging to another locality, located on its land, in a remote part, and legally associated with it."@en ,
+                                                        "Przysiółek to mała grupa zabudowań, należących do innej miejscowości, położona na jej gruntach, w oddaleniu od niej i prawnie z nią związana."@pl .
 
 
 ontohgis:settlement_type_45 rdfs:comment "Included as locality type in Bystrzycki's register in the abbreviation list (pol \"kol.\"; \"prz. k.\");included on topographic maps marked with the explanatory abbreviation (pol \"p.\"; ger \"hp.\");included in DBTO10k in the \"objects related to communication\" feature class (OIKM)."@en ,
                                          "Występuje jako rodzaj miejscowości u Bystrzyckiego w spisie (prz. kol.; prz.. k.); na mapach jako „p.” – przystanek lub „hp.” (ger Haltepunkt). W BDOT10k w klasie obiekt związany z komunikacją."@pl ,
                                          "dworzec kolejowy"@pl ;
-                            ontohgis:isDefinedByLiteral "Przystanek kolejowy (miejscowość) jest to osada, w której główną rolę odgrywa przystanek kolejowy (obiekt)."@pl ,
-                                             "Train stop (locality) is a settlement where the main role is played by a train stop (object)."@en ;
                             rdfs:label "przystanek kolejowy"@pl ,
                                        "train stop"@en ;
                             <http://www.w3.org/2004/02/skos/core#altLabel> "Haltepunkt (de)" ;
@@ -18830,15 +18935,12 @@ ontohgis:settlement_type_45 rdfs:comment "Included as locality type in Bystrzyck
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "przystanek kolejowy"@pl ,
                                                                             "train stop"@en ;
                             ontohgis:hasExternalIdentifier "45" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Przystanek kolejowy (miejscowość) jest to osada, w której główną rolę odgrywa przystanek kolejowy (obiekt)."@pl ,
+                                                        "Train stop (locality) is a settlement where the main role is played by a train stop (object)."@en .
 
 
 ontohgis:settlement_type_47 rdfs:comment "If residential buildings were erected around the tar pitch, it could be a kind of a separate forest settlement. The boundary between a tar pitch as an economic facility and a kind of forest settlement was blurry. It dependended on the seasonality and permanence of habitation."@en ,
                                          "Jeżeli wokół smolarni utrwaliła się zabudowa mieszkalna to smolarnia mogła stanowić rodzaj odrębnej osady leśnej. Granica między smolarnią jako obiektem gospodarczym a smolarnią jako rodzajem osady leśnej była płynna. Była uzależniona od sezonowości i stałości zamieszkiwania."@pl ;
-                            ontohgis:isDefinedByLiteral "Smolarnia (miejscowość) jest to osada, w której główną rolę pełni smolarnia jako obiekt gospodarczy."@pl ,
-                                             "Tar pitch (locality) is a settlement where the main role is played by a tar pitch (industrial facility)."@en ;
                             rdfs:label "smolarnia"@pl ,
                                        "tar pitch"@en ;
                             <http://www.w3.org/2004/02/skos/core#altLabel> "der Teerofen (de), smolanoi zawod (ru)" ;
@@ -18849,15 +18951,12 @@ ontohgis:settlement_type_47 rdfs:comment "If residential buildings were erected 
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "smolarnia"@pl ,
                                                                             "tar pitch"@en ;
                             ontohgis:hasExternalIdentifier "47" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Smolarnia (miejscowość) jest to osada, w której główną rolę pełni smolarnia jako obiekt gospodarczy."@pl ,
+                                                        "Tar pitch (locality) is a settlement where the main role is played by a tar pitch (industrial facility)."@en .
 
 
 ontohgis:settlement_type_48 rdfs:comment "Included as locality type in Bystrzycki's register in the abbreviation list (pl. \"st. kol.\"; \"st. k.\");included on topographic maps marked with the explanatory abbreviation (pl. \"St.\" or \"St. tow.\" [freight station], ger \"H.st.\" [Haltestation]);included in DBTO10k in the \"communication complex\" feature class (KUKO)."@en ,
                                          "Stacja kolejowa występuje jako rodzaj miejscowości u Bystrzyckiego w spisie (st. kol.; st. k.); na mapach oznaczana skrótem objaśniającym „St.” lub „St. tow.” (stacja towarowa), „H.st.” (ger Haltestation);w BDOT10k w klasie kompleks komunikacyjny."@pl ;
-                            ontohgis:isDefinedByLiteral "Railway station (locality) is a settlement where the main role is played by a railway station (object)."@en ,
-                                             "Stacja kolejowa (miejscowość) jest to osada, w której główną rolę odgrywa stacja kolejowa (obiekt)."@pl ;
                             rdfs:label "railway station"@en ,
                                        "stacja kolejowa"@pl ;
                             rdfs:seeAlso <http://dbpedia.org/ontology/RailwayStation> ,
@@ -18870,16 +18969,13 @@ ontohgis:settlement_type_48 rdfs:comment "Included as locality type in Bystrzyck
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "railway station"@en ,
                                                                             "stacja kolejowa"@pl ;
                             ontohgis:hasExternalIdentifier "48" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Railway station (locality) is a settlement where the main role is played by a railway station (object)."@en ,
+                                                        "Stacja kolejowa (miejscowość) jest to osada, w której główną rolę odgrywa stacja kolejowa (obiekt)."@pl .
 
 
 ontohgis:settlement_type_50 rdfs:comment "If residential buildings emerged around a sawmill, then it could be a kind of a separate forest settlement or a mill settlement. The distinction between the sawmill as an industrial facility and the sawmill as a kind of locality was blurry. It depended on the seasonality or permanence of habitation."@en ,
                                          "Jeżeli wokół tartaku utrwaliła się zabudowa mieszkalna to tartak mógł stanowić rodzaj odrębnej osady leśnej lub osady młyńskiej. Granica między tartakiem jako obiektem gospodarczym a tartakiem jako rodzajem osady była płynna. Była uzależniona od sezonowości i stałości zamieszkiwania."@pl ,
                                          "piła"@pl ;
-                            ontohgis:isDefinedByLiteral "Sawmill (locality) is a locality where the main role is played by a sawmill (facility)."@en ,
-                                             "Tartak (miejscowość) to miejscowość, w której główną rolę odgrywa tartak (obiekt)."@pl ;
                             rdfs:label "sawmill"@en ,
                                        "tartak"@pl ;
                             <http://www.w3.org/2004/02/skos/core#altLabel> "das Sägewerk (de), lesopilnyi zawod (ru)" ;
@@ -18890,30 +18986,24 @@ ontohgis:settlement_type_50 rdfs:comment "If residential buildings emerged aroun
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "sawmill"@en ,
                                                                             "tartak"@pl ;
                             ontohgis:hasExternalIdentifier "50" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Sawmill (locality) is a locality where the main role is played by a sawmill (facility)."@en ,
+                                                        "Tartak (miejscowość) to miejscowość, w której główną rolę odgrywa tartak (obiekt)."@pl .
 
 
 ontohgis:settlement_type_51 rdfs:comment "If residential buildings emerged around a peat mine, then it could be a kind of a separate mine settlement or an industrial settlement. The distinction between the peat mine as an industrial facility and the peat mine as a kind of locality was blurry. It depended on the seasonality or permanence of habitation."@en ,
                                          "Jeżeli wokół torfiarni utrwaliła się zabudowa mieszkalna to torfiarnia mogła stanowić rodzaj odrębnej osady górniczej lub osady fabrycznej. Granica między torfiarnią jako obiektem gospodarczym a torfiarnią jako rodzajem osady była płynna. Była uzależniona od sezonowości i stałości zamieszkiwania."@pl ;
-                            ontohgis:isDefinedByLiteral "Peat mine (locality) is a locality where the main role is played by a peat mine (facility)."@en ,
-                                             "Torfiarnia (miejscowość) jest to miejscowość, w której główną rolę odgrywa torfiarnia (obiekt)."@pl ;
                             rdfs:label "peat mine"@en ,
                                        "torfiarnia"@pl ;
                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "torfowisko"@pl ;
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "peat mine"@en ,
                                                                             "torfiarnia"@pl ;
                             ontohgis:hasExternalIdentifier "51" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Peat mine (locality) is a locality where the main role is played by a peat mine (facility)."@en ,
+                                                        "Torfiarnia (miejscowość) jest to miejscowość, w której główną rolę odgrywa torfiarnia (obiekt)."@pl .
 
 
 ontohgis:settlement_type_52 rdfs:comment "A fortress might be a separate settlement unit or a building inside a superior unit."@en ,
                                          "Twierdza mogła być samodzielną jednostką osadniczą lub obiektem w obrębie większej jednostki."@pl ;
-                            ontohgis:isDefinedByLiteral "Fortress is a locality for which a defensive function is dominant."@en ,
-                                             "Miejscowość, dla której dominująca jest funkcja obronna."@pl ;
                             rdfs:label "fortress"@en ,
                                        "twierdza"@pl ;
                             rdfs:seeAlso <http://linkedgeodata.org/ontology/Fortress> ;
@@ -18925,9 +19015,8 @@ ontohgis:settlement_type_52 rdfs:comment "A fortress might be a separate settlem
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "fortress"@en ,
                                                                             "twierdza"@pl ;
                             ontohgis:hasExternalIdentifier "52" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                            ontohgis:isDefinedByLiteral "Fortress is a locality for which a defensive function is dominant."@en ,
+                                                        "Miejscowość, dla której dominująca jest funkcja obronna."@pl .
 
 
 ontohgis:settlement_type_53 rdfs:comment """Functional distinctivness - clearly defined function, a locality connected with the service of bathers/visitors; it seems this is not the most important criterion of defining a type of locality (e.g. Ciechocinek in Bystrzycki's register is a city, not a spa).
@@ -18938,8 +19027,6 @@ Spatial distinctiveness - clear, as far as Czarniecka Góra and Miłowody (spas 
 Odrębność morfologiczna – luźna zabudowa (uzdrowiskowa), najczęściej pośród lasu (Czarniecka Góra, Miłowody); Nałęczów u Bystrzyckiego również jest określany jako uzdrowisko, a cechuje się zabudową zwartą (patrz: mapy WIG).
 Odrębność przestrzenna – wyraźna w przy Czarnieckiej Górze i Miłowodach (uzdrowiska położone pośród lasu)."""@pl ,
                                          "Występuje jako rodzaj miejscowości u Bystrzyckiego w spisie (uzdrow.).Na mapach WIG oznaczane krojem pisma charakterystycznym dla miejscowości (Czarniecka Góra, Nałęczów) lub budynków/obiektów terenowych (Miłowody); brak odrębnej sygnatury/skrótu objaśniające w legendach."@pl ;
-                            ontohgis:isDefinedByLiteral "A spa is a locality, where climate enhances treatment, and a main function of which is to serve bathers and visitors."@en ,
-                                             "Uzdrowisko jest miejscowością, w której warunki klimatyczne sprzyjają leczeniu chorób i której główną funkcją jest obsługa kuracjuszy"@pl ;
                             rdfs:label "spa"@en ,
                                        "uzdrowisko"@pl ;
                             rdfs:seeAlso <http://dbpedia.org/page/Spa_town> ,
@@ -18952,10 +19039,8 @@ Odrębność przestrzenna – wyraźna w przy Czarnieckiej Górze i Miłowodach 
                                                                               "letnisko"@pl ,
                                                                               "sanatorium"@pl ;
                             ontohgis:hasExternalIdentifier "53" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 ,
-                                                   ontohgis:person_9 .
+                            ontohgis:isDefinedByLiteral "A spa is a locality, where climate enhances treatment, and a main function of which is to serve bathers and visitors."@en ,
+                                                        "Uzdrowisko jest miejscowością, w której warunki klimatyczne sprzyjają leczeniu chorób i której główną funkcją jest obsługa kuracjuszy"@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_53 ;
@@ -18976,8 +19061,6 @@ ontohgis:settlement_type_54 rdfs:comment """Forest distrct as it had a separate 
 The basic criterion of distinguishing forest district from other localities or settlement units from the perspective of its functionality is its relation to the organization of forestry or agricultural production. Individual parts of forest or agricultural areas for a better understanding of space received their own names. It also did not exclude the forest settlement form the process of settling and thus the transformation to the kind of locality. The morphological distinctiveness of forest districts due to the nature of natural boundaries (swamps, glades, etc.) is fuzzy. From the legal point of view, the status of the forest district is rather unclear because this term was also used in relation to various types of forest settlements or parts of forests such as \"bór\" or \"ostęp\"."""@en ,
                                          """Uroczysko, ponieważ posiadało odrębną nazwę i było wydzielone przestrzennie, mogło być miejscowością (uroczysko zamieszkane) lub jednostką osadniczą (uroczysko niezamieszkane, uroczysko opuszczone). Ta druga kategoria była dominująca. Jako kategoria miejscowości (obok wsi, miasta, folwarku etc.) wymieniane jest w rejestrach dotyczących wschodnich województw dawnej Rzeczypospolitej. Liczba mieszkańców nie przekraczała zazwyczaj kilkunastu osób. Obecnie uroczysko jest rodzajem obiektu fizjograficznego w klasie obiektów \"Inny obiekt fizjograficzny\" w Państwowym Rejestrze Nazw Geograficznych.
 Podstawowym kryterium wyodrębniającym uroczysko od innych miejscowości lub jednostek osadniczych w aspekcie funkcjonalnym jest jego związek z organizacją produkcji leśnej lub rolniczej. Poszczególne części obszarów leśnych lub rolnych dla lepszej orientacji w przestrzeni otrzymywały swoje nazwy własne. Nie wykluczało to też procesu osiedlania się a tym samym przekształcania uroczyska w rodzaj miejscowości. Odrębność morfologiczna uroczysk ze względu na charakter granic naturalnych (bagna, polany etc.) jest rozmyta. Od strony prawnej status uroczyska jest dość niejasny, gdyż termin ten był używany także w odniesieniu do różnego typu osad leśnych lub części lasów takich jak bory czy ostępy."""@pl ;
-                            ontohgis:isDefinedByLiteral "Forest distrct is a part of a forest, meadow or swampy area separated by natural borders and an own (proper) name for better organization of social and economic life. Built-up and inhabited forest district used to be a locality."@en ,
-                                             "Uroczysko to obszar leśny, łąkowy lub bagnisty wyodrębniony naturalnymi granicami oraz nazwą własną w celu lepszej organizacji życia społecznego i gospodarczego. Uroczysko zabudowane i zamieszkane było miejscowością."@pl ;
                             rdfs:label "forest district"@en ,
                                        "uroczysko"@pl ;
                             rdfs:seeAlso <http://vocab.getty.edu/aat/300379281> ,
@@ -19001,16 +19084,15 @@ Podstawowym kryterium wyodrębniającym uroczysko od innych miejscowości lub je
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "forest district"@en ,
                                                                             "uroczysko"@pl ;
                             ontohgis:hasExternalIdentifier "54" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Forest distrct is a part of a forest, meadow or swampy area separated by natural borders and an own (proper) name for better organization of social and economic life. Built-up and inhabited forest district used to be a locality."@en ,
+                                                        "Uroczysko to obszar leśny, łąkowy lub bagnisty wyodrębniony naturalnymi granicami oraz nazwą własną w celu lepszej organizacji życia społecznego i gospodarczego. Uroczysko zabudowane i zamieszkane było miejscowością."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_54 ;
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "1. teren trudno dostępny, najczęściej bagnisty, leśny; też: miejsce odludne, 2. część terenu otoczona naturalnymi granicami, wyodrębniona za pomocą nazwy topograficznej, 3. u dawnych Słowian: miejsce w głębi puszczy związane z kultem bóstwa, odbywaniem narad lub uważane za siedzibę złych duchów"@pl ;
    ontohgis:isDefinedByIRI <http://sjp.pwn.pl/sjp/uroczysko;2533316.html> ,
-                    ontohgis:document_3
+                           ontohgis:document_3
  ] .
 
 [ rdf:type owl:Axiom ;
@@ -19053,14 +19135,12 @@ Podstawowym kryterium wyodrębniającym uroczysko od innych miejscowości lub je
    owl:annotatedProperty rdfs:seeAlso ;
    owl:annotatedTarget "u dawnych Słowian: miejsce przed świątynią lub w głębi puszczy, związane z kultem jakiegoś bóstwa, z odbywaniem narad, sądów; ogólnie: miejsce odludne, tajemnicze; pustkowie -- 2. część terenu (zwykle lasu wyodrębniona za pomocą nazwy o charakterze topograficznym."@pl ;
    ontohgis:isDefinedByIRI <http://sjp.pwn.pl/doroszewski/uroczysko;5512266.html> ,
-                    ontohgis:document_4
+                           ontohgis:document_4
  ] .
 
 
 ontohgis:settlement_type_56 rdfs:comment "\"Zaścianek\" is typical mostly for Mazovia, Podlachia and areas of the former Grand Duchy of Lithuania."@en ,
                                          "Zaścianki są najbardziej charakterystyczne dla Mazowsza, Podlasia i obszarów dawnego Wielkiego Księstwa Litewskiego."@pl ;
-                            ontohgis:isDefinedByLiteral "\"Zaścianek\" is an agricultural locality inhabited by the poor nobility who cultivate their land on their own."@en ,
-                                             "Zaścianek to miejscowość o charakterze rolniczym zamieszkała przez drobną szlachtę samodzielnie uprawiającą posiadaną ziemię."@pl ;
                             rdfs:label "\"zaścianek\""@en ,
                                        "zaścianek"@pl ;
                             <http://www.w3.org/2004/02/skos/core#altLabel> "okolica"@pl ,
@@ -19072,29 +19152,23 @@ ontohgis:settlement_type_56 rdfs:comment "\"Zaścianek\" is typical mostly for M
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "\"zaścianek\""@en ,
                                                                             "zaścianek"@pl ;
                             ontohgis:hasExternalIdentifier "56" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "\"Zaścianek\" is an agricultural locality inhabited by the poor nobility who cultivate their land on their own."@en ,
+                                                        "Zaścianek to miejscowość o charakterze rolniczym zamieszkała przez drobną szlachtę samodzielnie uprawiającą posiadaną ziemię."@pl .
 
 
 ontohgis:settlement_type_60 rdfs:comment "Część kolonii jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Części kolonii występują najczęściej w woj. lubelskim, łódzkim i pomorskim. W sumie jest ich w Polsce 281."@pl ,
                                          "Part of a colony is a separate settlement unit, a kind of locality, always has a particular name. Parts of colonies occur most often in Lubelskie, Łódzkie, and Pomorskie voivodships. In total, there are 281 parts of colonies in Poland."@en ;
-                            ontohgis:isDefinedByLiteral "Część kolonii to miejscowość stanowiąca integralną część miejscowości podstawowej kolonii, jest wydzielona administracyjnie, ale należy do jednostki nadrzędnej."@pl ,
-                                             "Part of a colony is an integral part of the main locality a colony; it is administratively separated, but belongs to the superior unit."@en ;
                             rdfs:label "część kolonii"@pl ,
                                        "part of a colony"@en ;
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "część kolonii"@pl ,
                                                                             "part of a colony"@en ;
                             ontohgis:hasExternalIdentifier "60" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Część kolonii to miejscowość stanowiąca integralną część miejscowości podstawowej kolonii, jest wydzielona administracyjnie, ale należy do jednostki nadrzędnej."@pl ,
+                                                        "Part of a colony is an integral part of the main locality a colony; it is administratively separated, but belongs to the superior unit."@en .
 
 
 ontohgis:settlement_type_61 rdfs:comment "Część miasta jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. W sumie jest ich w Polsce 10425. Są to części miejscowości skupiające się często wokół większych miejscowości w całej Polsce, większe skupiska części miejscowości są m. in. w woj. śląskim, mazowieckim, małopolskim, wielkopolskim, pomorskim."@pl ,
                                          "Part of a city is a separate settlement unit, a kind of locality, it always has a particular name. There are 10425 of these units in Poland at the moment. These are mostly parts of localities converging upon bigger localities around Poland. Large clusters of these units are located i.e. in Śląskie, Mazowieckie, Małopolskie, Wielkopolskie, and Pomorskie voivodeships."@en ;
-                            ontohgis:isDefinedByLiteral "Część miasta to miejscowość stanowiąca integralną część miejscowości podstawowej miasta, jest wydzielona administracyjnie, ale należy do jednostki nadrzędnej."@pl ,
-                                             "Part of a city is an integral part of the main locality a city (or a town); it is administratively separated, but belongs to the superior unit."@en ;
                             rdfs:label "część miasta"@pl ,
                                        "part of a city"@en ;
                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "Stadt"@de ,
@@ -19110,15 +19184,12 @@ ontohgis:settlement_type_61 rdfs:comment "Część miasta jest odrębną jednost
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "część miasta"@pl ,
                                                                             "part of a city"@en ;
                             ontohgis:hasExternalIdentifier "61" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                            ontohgis:isDefinedByLiteral "Część miasta to miejscowość stanowiąca integralną część miejscowości podstawowej miasta, jest wydzielona administracyjnie, ale należy do jednostki nadrzędnej."@pl ,
+                                                        "Part of a city is an integral part of the main locality a city (or a town); it is administratively separated, but belongs to the superior unit."@en .
 
 
 ontohgis:settlement_type_62 rdfs:comment "Część osady jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Części osady występują w większości na Pomorzu. W sumie jest ich w Polsce 76."@pl ,
                                          "Part of a settlement is a separate settlement unit, a kind of locality, it always has a particular name. Parts of settlements occur mostly in Pomorze. In total, there are 76 parts of settlements in Poland."@en ;
-                            ontohgis:isDefinedByLiteral "Część osady to miejscowość stanowiąca integralną część miejscowości podstawowej osady, jest wydzielona administracyjnie, ale należy do jednostki nadrzędnej."@pl ,
-                                             "Part of a settlement is an integral part of the main locality a settlement, it is administratively separated, but belongs to the superior unit."@en ;
                             rdfs:label "część osady"@pl ,
                                        "part of a settlement"@en ;
                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "conlocationen"@la ,
@@ -19136,15 +19207,12 @@ ontohgis:settlement_type_62 rdfs:comment "Część osady jest odrębną jednostk
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "część osady"@pl ,
                                                                             "part of a settlement"@en ;
                             ontohgis:hasExternalIdentifier "62" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Część osady to miejscowość stanowiąca integralną część miejscowości podstawowej osady, jest wydzielona administracyjnie, ale należy do jednostki nadrzędnej."@pl ,
+                                                        "Part of a settlement is an integral part of the main locality a settlement, it is administratively separated, but belongs to the superior unit."@en .
 
 
 ontohgis:settlement_type_63 rdfs:comment "A part of a village is a separate settlement unit, a kind of locality, and always has its own (individual) name. There are 41942 parts of villages around the whole Poland at the moment."@en ,
                                          "Część wsi jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Części wsi występują w całej Polsce. W sumie jest ich w Polsce 41942."@pl ;
-                            ontohgis:isDefinedByLiteral "A part of a village is a locality being an integral part of the main locality a village; it is administratively separated, but belongs to the superior unit."@en ,
-                                             "Część wsi to miejscowość stanowiąca integralną część miejscowości podstawowej wsi, jest wydzielona administracyjnie, ale przynależy do jednostki nadrzędnej."@pl ;
                             rdfs:label "część wsi"@pl ,
                                        "part of a village"@en ;
                             rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/czescWsi> ,
@@ -19159,15 +19227,12 @@ ontohgis:settlement_type_63 rdfs:comment "A part of a village is a separate sett
                                                                               "village"@en ,
                                                                               "wioska"@pl ;
                             ontohgis:hasExternalIdentifier "63" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_9 .
+                            ontohgis:isDefinedByLiteral "A part of a village is a locality being an integral part of the main locality a village; it is administratively separated, but belongs to the superior unit."@en ,
+                                                        "Część wsi to miejscowość stanowiąca integralną część miejscowości podstawowej wsi, jest wydzielona administracyjnie, ale przynależy do jednostki nadrzędnej."@pl .
 
 
 ontohgis:settlement_type_64 rdfs:comment "Colony of a colony is a separate settlement unit, a kind of locality, and always has its particular name. They occur most often in the Lubelskie and Podlaskie voivodships. In total, there are 31 colonies of colony at the moment."@en ,
                                          "Kolonia kolonii jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Kolonia kolonii występują w większości w woj. lubelskim i woj. podlaskim. W sumie jest ich obecnie w Polsce 31."@pl ;
-                            ontohgis:isDefinedByLiteral "Colony of a colony is a colony which is related to a colony."@en ,
-                                             "Kolonia osady to kolonia zależna od kolonii."@pl ;
                             rdfs:label "colony of a colony"@en ,
                                        "kolonia kolonii"@pl ;
                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "chutor"@pl ,
@@ -19186,15 +19251,12 @@ ontohgis:settlement_type_64 rdfs:comment "Colony of a colony is a separate settl
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "colony of a colony"@en ,
                                                                             "kolonia kolonii"@pl ;
                             ontohgis:hasExternalIdentifier "64" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Colony of a colony is a colony which is related to a colony."@en ,
+                                                        "Kolonia osady to kolonia zależna od kolonii."@pl .
 
 
 ontohgis:settlement_type_65 rdfs:comment "A built-up area located away from previously existing buildings (locality) to which it is related. Colony of a settlement is a separate settlement unit, a kind of locality, always with its particular name. Colonies of settlements occur mainly in Zachodniopomorskie, Warmińsko-mazurskie and Podlaskie voivodships. In total, there are 17 colonies of settlements in Poland."@en ,
                                          "Obszar zabudowany oddalony od wczesniejszej zabudowy, od której jest zależny. Kolonia osady jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Kolonie osady występują w większości w woj. zachodniopomorskim, warmińsko-mazurskim i woj. podlaskim. W sumie jest ich w Polsce 17."@pl ;
-                            ontohgis:isDefinedByLiteral "Colony of a settlement is a colony related to a settlement."@en ,
-                                             "Kolonia osady to kolonia zależna od osady."@pl ;
                             rdfs:label "colony of a settlement"@en ,
                                        "kolonia osady"@pl ;
                             rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/koloniaOsady> ,
@@ -19202,15 +19264,12 @@ ontohgis:settlement_type_65 rdfs:comment "A built-up area located away from prev
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "colony of a settlement"@en ,
                                                                             "kolonia osady"@pl ;
                             ontohgis:hasExternalIdentifier "65" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Colony of a settlement is a colony related to a settlement."@en ,
+                                                        "Kolonia osady to kolonia zależna od osady."@pl .
 
 
 ontohgis:settlement_type_66 rdfs:comment "Colony of a village is a separate settlement unit, a kind of locality, and always has its particular name. They are spread all over modern Poland and there are 4043 collonies of villages at the moment."@en ,
                                          "Kolonia wsi jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Kolonie wsi występują w całej Polsce. W sumie jest ich obecnie w Polsce 4043."@pl ;
-                            ontohgis:isDefinedByLiteral "Colony of a village is a colony related to a village."@en ,
-                                             "Kolonia wsi to kolonia zależna od wsi."@pl ;
                             rdfs:label "colony of a village"@en ,
                                        "kolonia wsi"@pl ;
                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "chutor"@pl ,
@@ -19229,33 +19288,27 @@ ontohgis:settlement_type_66 rdfs:comment "Colony of a village is a separate sett
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "colony of a village"@en ,
                                                                             "kolonia wsi"@pl ;
                             ontohgis:hasExternalIdentifier "66" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Colony of a village is a colony related to a village."@en ,
+                                                        "Kolonia wsi to kolonia zależna od wsi."@pl .
 
 
 ontohgis:settlement_type_68 rdfs:comment "Brak oficjalnej definicji w \"Ustawie o nazwach urzędowych miejscowości i jednostek fizjograficznych\"."@pl ,
                                          "No official definition in the \"Act on official names of localities and physiographic units\"."@en ,
                                          "Są cztery takie obiekty w Polsce, wszystkie w woj. lubelskim."@pl ,
                                          "There are 4 such a settlements is contemporary Poland: all in Lubelskie voivodship."@en ;
-                            ontohgis:isDefinedByLiteral "Osada kolonii jest to osada stanowiąca integralną część kolonii."@pl ,
-                                             "Settlement of a colony is a settlement which is an integral part of a colony."@en ;
                             rdfs:label "osada kolonii"@pl ,
                                        "settlement of a colony"@en ;
                             rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/osadaKolonii> ,
                                          <https://www.wikidata.org/wiki/Q41970180> ;
                             ontohgis:hasExternalIdentifier "68" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Osada kolonii jest to osada stanowiąca integralną część kolonii."@pl ,
+                                                        "Settlement of a colony is a settlement which is an integral part of a colony."@en .
 
 
 ontohgis:settlement_type_69 rdfs:comment "Brak oficjalnej definicji w \"Ustawie o nazwach urzędowych miejscowości i jednostek fizjograficznych\"."@pl ,
                                          "No official definition in the \"Act on official names of localities and physiographic units\"."@en ,
                                          "Są 233 takie obiekty w Polsce, świętokrzyskie, północnym lubelskim, północnym lubuskim, Borach Tucholskich."@pl ,
                                          "There are 233 forest settlements of a village in Poland, mainly in Świętokrzyskie northern part of Lubelskie, northern part of Lubuskie voivodships as well as in \"Bory Tuchulskie\" (Pomorskie voivodship)."@en ;
-                            ontohgis:isDefinedByLiteral "Forest settlement of a village is a forest settlement which is an integral part of  a village."@en ,
-                                             "Osada leśna wsi to osada leśna stanowiąca integralną część wsi."@pl ;
                             rdfs:label "forest settlement of a village"@en ,
                                        "osada leśna wsi"@pl ;
                             rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/osadaLesnaWsi> ,
@@ -19275,9 +19328,8 @@ ontohgis:settlement_type_69 rdfs:comment "Brak oficjalnej definicji w \"Ustawie 
                                                                               "settlement"@en ,
                                                                               "zagroda włościańska"@pl ;
                             ontohgis:hasExternalIdentifier "69" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Forest settlement of a village is a forest settlement which is an integral part of  a village."@en ,
+                                                        "Osada leśna wsi to osada leśna stanowiąca integralną część wsi."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_69 ;
@@ -19289,8 +19341,6 @@ ontohgis:settlement_type_69 rdfs:comment "Brak oficjalnej definicji w \"Ustawie 
 
 ontohgis:settlement_type_7 rdfs:comment "Usually, a manor house was located away from the main group of houses in a village, on the outskirts, or in a vicinity. A manor house is recognised in historiography as identical with a manor (folwark, demesne), however a manor house appears in texts on culture, customs, legal issues, whereas a manor (folwark, demesne) usually corresponds with economic matters."@en ,
                                         "Zazwyczaj dwór położony był poza głównym zbudową wsi, na jej obrzeżach lub w nieznacznym oddaleniu. Pojęcie często tożsame w literaturze z folwarkiem. Z czasem dwór pojawia się w kontekście pisania o życiu, kulturze, obyczajowości, a folwark dotyczy kwestii gospodarczych."@pl ;
-                           ontohgis:isDefinedByLiteral "A manor (a notion with a multiple meaning) is a home or a temporary house of a land lord and the managment of different clusters of estates, including a house and a farmstead ( a manor). In High and Late Middle Ages it could be a defensive tower (conical gord or a manor built on a mound) or a castle. Most of these, however, were one-floor homes (i.e. nobleman manor), which later (in 16th-20th century) evolved into palaces."@en ,
-                                            "Dwór (pojęcie wieloznaczne) jest to siedziba lub miejsce okresowego pobytu pana gruntowego oraz zarządu poszczególnych kluczy dóbr, składająca się z domu oraz zabudowań gospodarczych ( folwark). W pełnym i późnym średniowieczu mógł przyjmować charakter rezydencjonalno-obronnej wieży (tzw. grodzisko stożkowate, lub dworu na kopcu) ew. zamku. W większości były to jednak jednokondygnacyjne siedziby (tzw. dwór szlachecki) mogące później (XVI-XX w.) przybierać formę pałacową."@pl ;
                            rdfs:label "dwór - obiekt"@pl ,
                                       "manor house"@en ;
                            rdfs:seeAlso <http://gov.genealogy.net/types.owl#24> ,
@@ -19318,9 +19368,8 @@ ontohgis:settlement_type_7 rdfs:comment "Usually, a manor house was located away
                            <http://www.w3.org/2004/02/skos/core#prefLabel> "dwór"@pl ,
                                                                            "manor house"@en ;
                            ontohgis:hasExternalIdentifier "7" ;
-                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                           ontohgis:hasTranslator ontohgis:person_9 .
+                           ontohgis:isDefinedByLiteral "A manor (a notion with a multiple meaning) is a home or a temporary house of a land lord and the managment of different clusters of estates, including a house and a farmstead ( a manor). In High and Late Middle Ages it could be a defensive tower (conical gord or a manor built on a mound) or a castle. Most of these, however, were one-floor homes (i.e. nobleman manor), which later (in 16th-20th century) evolved into palaces."@en ,
+                                                       "Dwór (pojęcie wieloznaczne) jest to siedziba lub miejsce okresowego pobytu pana gruntowego oraz zarządu poszczególnych kluczy dóbr, składająca się z domu oraz zabudowań gospodarczych ( folwark). W pełnym i późnym średniowieczu mógł przyjmować charakter rezydencjonalno-obronnej wieży (tzw. grodzisko stożkowate, lub dworu na kopcu) ew. zamku. W większości były to jednak jednokondygnacyjne siedziby (tzw. dwór szlachecki) mogące później (XVI-XX w.) przybierać formę pałacową."@pl .
 
 [ rdf:type owl:Axiom ;
    owl:annotatedSource ontohgis:settlement_type_7 ;
@@ -19360,8 +19409,6 @@ ontohgis:settlement_type_7 rdfs:comment "Usually, a manor house was located away
 
 ontohgis:settlement_type_70 rdfs:comment "Jest 17 takich obiektów w Polsce, zachodniopomorskie, północne wielkopolskie."@pl ,
                                          "Therea are 17 such localities in Poland: in Zachodniopomorskie and in the northern part of Wielkopolskie voivodships."@en ;
-                            ontohgis:isDefinedByLiteral "Osada osady jest to osada stanowiąca integralną część innej osady."@pl ,
-                                             "Settlement of a settlement is a settlement which is an integral part of a settlement."@en ;
                             rdfs:label "osada osady"@pl ,
                                        "settlement of a settlement"@en ;
                             rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/osadaOsady> ,
@@ -19380,15 +19427,12 @@ ontohgis:settlement_type_70 rdfs:comment "Jest 17 takich obiektów w Polsce, zac
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "osada osady"@pl ,
                                                                             "settlement of a settlement"@en ;
                             ontohgis:hasExternalIdentifier "70" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Osada osady jest to osada stanowiąca integralną część innej osady."@pl ,
+                                                        "Settlement of a settlement is a settlement which is an integral part of a settlement."@en .
 
 
 ontohgis:settlement_type_71 rdfs:comment "Jest 778 takich obiektów w Polsce, są one równomiernie rozmieszczone w całej Polsce."@pl ,
                                          "There are 778 such localities in Poland and they are evenly spread across Poland."@en ;
-                            ontohgis:isDefinedByLiteral "Osada wsi jest to osada przynależna administracyjnie do wsi."@pl ,
-                                             "Settlement of a village is a settlement which is related to a village."@en ;
                             rdfs:label "osada wsi"@pl ,
                                        "settlement of a village"@en ;
                             <http://www.w3.org/2004/02/skos/core#hiddenLabel> "conlocationen"@la ,
@@ -19406,17 +19450,14 @@ ontohgis:settlement_type_71 rdfs:comment "Jest 778 takich obiektów w Polsce, s�
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "osada wsi"@pl ,
                                                                             "settlement of a village"@en ;
                             ontohgis:hasExternalIdentifier "71" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Osada wsi jest to osada przynależna administracyjnie do wsi."@pl ,
+                                                        "Settlement of a village is a settlement which is related to a village."@en .
 
 
 ontohgis:settlement_type_72 rdfs:comment "In urban studies, this notion is derived from a \"neighbouring unit\" idea, which denotes a group of residential buildings with service facilities and green areas."@en ,
                                          "Jest 11 takich obiektów w Polsce, są one rozmieszczone w północno-zachodniej Polsce."@pl ,
                                          "There are 11 housing estates of a village which are located in NW Poland."@en ,
                                          "W urbanistyce (planowaniu przestrzennym) pojęcie osiedla wywodzi się z koncepcji „jednostki sąsiedzkiej”, na którą składa się zespół budynków mieszkalnych wraz z zapleczem obiektów usługowych oraz terenów zielonych."@pl ;
-                            ontohgis:isDefinedByLiteral "Housing estate of a village is a housing estate which is an integral part of a village."@en ,
-                                             "Osiedle wsi jest to osiedle stanowiące integralną część wsi."@pl ;
                             rdfs:label "housing estate of a village"@en ,
                                        "osiedle wsi"@pl ;
                             rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/osiedleWsi> ,
@@ -19436,30 +19477,23 @@ ontohgis:settlement_type_72 rdfs:comment "In urban studies, this notion is deriv
                                                                               "residential quarter"@en ,
                                                                               "settlement"@en ;
                             ontohgis:hasExternalIdentifier "72" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 ,
-                                                   ontohgis:person_9 .
+                            ontohgis:isDefinedByLiteral "Housing estate of a village is a housing estate which is an integral part of a village."@en ,
+                                                        "Osiedle wsi jest to osiedle stanowiące integralną część wsi."@pl .
 
 
 ontohgis:settlement_type_73 rdfs:comment "Hamlet of a colony is a separate settlement unit, a kind of locality, it always has a particular name. Hamlets of colonies occur most often in Lubelskie voivodship. In total, there are 72 hamlets of colonies in Poland."@en ,
                                          "Przysiółek kolonii jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Przysiółki kolonii występują głównie w lubelskim. W sumie są to 72 obiekty."@pl ;
-                            ontohgis:isDefinedByLiteral "Hamlet of a colony is a hamlet, for which a colony is a superior unit."@en ,
-                                             "Przysiółek kolonii jest to przysiółek, dla którego jednostką nadrzędną jest kolonia."@pl ;
                             rdfs:label "hamlet of a colony"@en ,
                                        "przysiółek kolonii"@pl ;
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "hamlet of a colony"@en ,
                                                                             "przysiółek kolonii"@pl ;
                             ontohgis:hasExternalIdentifier "73" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Hamlet of a colony is a hamlet, for which a colony is a superior unit."@en ,
+                                                        "Przysiółek kolonii jest to przysiółek, dla którego jednostką nadrzędną jest kolonia."@pl .
 
 
 ontohgis:settlement_type_74 rdfs:comment "Przysiółek osady jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Przysiółki osady występują główniezachodnio-pomorskim, pomorskim, warmińsko-mazurskim. W sumie jest 80 takich obiektów."@pl ,
                                          "The hamlet of a settlement is a separate settlement unit, a kind of locality, always has its particular name. Hamlets of settlements occur mainly in the Zachodniopomorskie, Pomorskie, and Warmińsko-Mazurskie voivodships. In total, there are 80 hamlets of settlements in Poland. "@en ;
-                            ontohgis:isDefinedByLiteral "Hamlet of a settlement is a hamlet, for which a superior unit is a settlement."@en ,
-                                             "Przysiółek osady jest to przysiółek, dla którego jednostką nadrzędną jest osada."@pl ;
                             rdfs:label "hamlet of a settlement"@en ,
                                        "przysiółek osady"@pl ;
                             <http://www.w3.org/2004/02/skos/core#altLabel> "osada przemysłowa (pl)" ;
@@ -19478,31 +19512,25 @@ ontohgis:settlement_type_74 rdfs:comment "Przysiółek osady jest odrębną jedn
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "hamlet of a settlement"@en ,
                                                                             "przysiółek osady"@pl ;
                             ontohgis:hasExternalIdentifier "74" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Hamlet of a settlement is a hamlet, for which a superior unit is a settlement."@en ,
+                                                        "Przysiółek osady jest to przysiółek, dla którego jednostką nadrzędną jest osada."@pl .
 
 
 ontohgis:settlement_type_75 rdfs:comment "Brak oficjalnej definicji w \"Ustawie o nazwach urzędowych miejscowości i jednostek fizjograficznych\"."@pl ,
                                          "No official definition in the \"Act on official names of localities and physiographic units\"."@en ,
                                          "Przysiółek wsi jest odrębną jednostką osadniczą, rodzajem miejscowości, zawsze ma swoją nazwę własną. Przysiółki wsi występują głównie w woj. podkarpackim, małopolskim oraz w świętokrzyskim. W sumie jest ich 11580."@pl ,
                                          "The hamlet of a village is a separate settlement unit, a kind of locality, always has its particular name. Hamlets of villages occur mainly in Podkarpackie, Małopolskie, and Świętokrzyskie voivodships. In total, there are 11 580 hamlets of villages in Poland. "@en ;
-                            ontohgis:isDefinedByLiteral "Hamlet of a village is a hamlet, for which a superior unit is a village."@en ,
-                                             "Przysiółek wsi jest to przysiółek, dla którego jednostką nadrzędną jest wieś."@pl ;
                             rdfs:label "hamlet of a village"@en ,
                                        "przysiółek wsi"@pl ;
                             rdfs:seeAlso <https://pzgik.geoportal.gov.pl/ontologies/prng/przysiolekWsi> ,
                                          <https://www.wikidata.org/wiki/Q41970180> ;
                             ontohgis:hasExternalIdentifier "75" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Hamlet of a village is a hamlet, for which a superior unit is a village."@en ,
+                                                        "Przysiółek wsi jest to przysiółek, dla którego jednostką nadrzędną jest wieś."@pl .
 
 
 ontohgis:settlement_type_76 rdfs:comment "In BDTO10k a tourist shelter is distinguished as a [1] building, [2] hotel services' complex, and [3] locality; in PRNG as a \"tourist shelter\". On MGI maps - a shelter [developed or undeveloped were depicted using different symbols] (\"schr.\"), on German maps - Jugenherberge (youth hostel, \"Jg. Hb.\"), Winterhutte (winter shelter, \"Wint. H.\"), Schutzhutte (hostel). Tourist shelters are not included in Bystrzycki's register."@en ,
                                          "W BDOT10k schronisko turystyczne wyróżnione jest jako budynek, kompleks usług hotelarskich oraz miejscowość; w PRNG jako „schronisko turystyczne”.Na mapach WIG – schronisko [zagospodarowane lub niezagospodarowane odmiennym znakiem] („schr.”), niemieckich – Jugenherberge (schronisko młodzieżowe, „Jg. Hb.”), Winterhutte (schron zimowy, „Wint. H.”), Schutzhutte (schronisko). Brak u Bystrzyckiego."@pl ;
-                            ontohgis:isDefinedByLiteral "Schronisko turystyczne (miejscowość) to miejscowość, w której główną rolę pełni schronisko turystyczne (obiekt)."@pl ,
-                                             "Tourist shelter (locality) is a settlement where the main role is played by a tourist shelter (object)."@en ;
                             rdfs:label "schronisko turystyczne"@pl ,
                                        "tourist shelter"@en ,
                                        "schronisko turystyczne" ;
@@ -19515,9 +19543,8 @@ ontohgis:settlement_type_76 rdfs:comment "In BDTO10k a tourist shelter is distin
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "schronisko turystyczne"@pl ,
                                                                             "tourist shelter"@en ;
                             ontohgis:hasExternalIdentifier "76" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Schronisko turystyczne (miejscowość) to miejscowość, w której główną rolę pełni schronisko turystyczne (obiekt)."@pl ,
+                                                        "Tourist shelter (locality) is a settlement where the main role is played by a tourist shelter (object)."@en .
 
 
 ontohgis:settlement_type_8 rdfs:comment "A demesne (manor) may be considered as an independent locality as long as it is distinguished by an individual name. Usually, a demesne was located away from the main group of houses in a village, on the outskirts, or in its vicinity."@en ,
@@ -19549,9 +19576,6 @@ ontohgis:settlement_type_8 rdfs:comment "A demesne (manor) may be considered as 
                            <http://www.w3.org/2004/02/skos/core#prefLabel> "demesne"@en ,
                                                                            "folwark"@pl ;
                            ontohgis:hasExternalIdentifier "8" ;
-                           ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                           ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                           ontohgis:hasTranslator ontohgis:person_9 ;
                            ontohgis:isDefinedByLiteral "A demesne (en: manor, pl: folwark, de: Volwerk) is a locality with an industrial function, often located near the manor (a building) or separate."^^rdfs:Literal ,
                                                        "Folwark (niem: Volwerk) to miejscowość o charakterze gospodarczym, często funkcjonująca obok dworu lub osobno."^^rdfs:Literal .
 
@@ -19599,16 +19623,12 @@ ontohgis:settlement_type_80 rdfs:comment "Characteristic for the Commonwealth of
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "\"holendry\""@en ,
                                                                             "holendry"@pl ;
                             ontohgis:hasExternalIdentifier "80" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
                             ontohgis:isDefinedByLiteral "\"Holendry\" (a Dutch type locality) is a colony established on an empty territory, in areas not very useful for agriculture. It was a type of locality characteristic for a \"Dutch colonisation\", which was a specific form of a settlement movement - widespread in the Commonwealth of Poland and Lithuania from 16th to 18th century. Granting uncongenial land difficult to cultivate or for animal husbandry to local people or (more often) immigrants inflowing from Flanders, German countries and Silesia was the core element of this process."^^rdfs:Literal ,
                                                         "Holendry to kolonia zakładana na obszarach nieobjętych osadnictwem z powodu nikłej przydatności rolniczej, właściwa dla tzw. kolonizacji olęderskiej, czyli specyficznej formy ruchu osadniczego – charakterystycznego dla Rzeczypospolitej XVII–XVIII wieku – polegającego na nadaniu ludności rodzimej – lub częściej – imigrantom pochodzącym z Flandrii, państw niemieckich lub Śląska, trudnej (w uprawie lub hodowli) ziemi."^^rdfs:Literal .
 
 
 ontohgis:settlement_type_82 rdfs:comment "Port morski na austriackiej mapie 1:75 000 wyróżniony explicite i opisany krojem pisma takim jak miasta większe niż 100 000 mieszkańców i twierdze.W BDOT10k „port wodny lub przystań” w klasie kompleks komunikacyjny.Jest u Bystrzyckiego (nie w skrótach) – port, miasto portowe."@pl ,
                                          "Sea harbour on the Austrian map 1:75,000 (Spezialkarte...) is explicitly distinguished as a placename using the same annotation style as \"cities larger than 100,000 inhabitants and fortresses\".Sea harbour is included in DBTO10k as \"sea harbour port or marina\" in the communication complex feature class (KUKO).Sea harbour is included in Bystrzycki's register (however, not in abbreviations list) as \"harbour\" (pol \"port\"), \"harbour city\" (pol \"miasto portowe\")."@en ;
-                            ontohgis:isDefinedByLiteral "Port morski (miejscowość) jest to miejscowość w której główną rolę pełni port morski jako obiekt"@pl ,
-                                             "Sea harbour (locality) is a locality where the main role is played by a sea harbour (area)."@en ;
                             rdfs:label "port morski"@pl ,
                                        "sea harbour"@en ;
                             rdfs:seeAlso <http://dbpedia.org/ontology/Port> ,
@@ -19616,14 +19636,11 @@ ontohgis:settlement_type_82 rdfs:comment "Port morski na austriackiej mapie 1:75
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "port morski"@pl ,
                                                                             "sea harbour"@en ;
                             ontohgis:hasExternalIdentifier "82" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Port morski (miejscowość) jest to miejscowość w której główną rolę pełni port morski jako obiekt"@pl ,
+                                                        "Sea harbour (locality) is a locality where the main role is played by a sea harbour (area)."@en .
 
 
-ontohgis:settlement_type_99 ontohgis:isDefinedByLiteral "Inn (locality) is a settlement in which the main role is played by an inn (builing)."@en ,
-                                             "Osada karczemna to osada, w której główną rolę pełni karczma (obiekt)."@pl ;
-                            rdfs:label "inn"@en ,
+ontohgis:settlement_type_99 rdfs:label "inn"@en ,
                                        "osada karczemna"@pl ;
                             rdfs:seeAlso <http://dbpedia.org/page/Hamlet_(place)> ,
                                          <http://gov.genealogy.net/types.owl#120> ,
@@ -19643,9 +19660,8 @@ ontohgis:settlement_type_99 ontohgis:isDefinedByLiteral "Inn (locality) is a set
                             <http://www.w3.org/2004/02/skos/core#prefLabel> "inn"@en ,
                                                                             "osada karczemna"@pl ;
                             ontohgis:hasExternalIdentifier "99" ;
-                            ontohgis:hasLanguageVerificator ontohgis:person_1 ;
-                            ontohgis:hasOntologicalVerificator ontohgis:person_10 ;
-                            ontohgis:hasTranslator ontohgis:person_5 .
+                            ontohgis:isDefinedByLiteral "Inn (locality) is a settlement in which the main role is played by an inn (builing)."@en ,
+                                                        "Osada karczemna to osada, w której główną rolę pełni karczma (obiekt)."@pl .
 
 
 ###  Generated by the OWL API (version 4.5.24.2023-01-14T21:28:32Z) https://github.com/owlcs/owlapi


### PR DESCRIPTION
We want to separate the usages of rdfs:seeAlso when it is used to denote an IRI from those that denote a literal.